### PR TITLE
add Read the Docs config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+  jobs:
+    post_create_environment:
+      - pip install --upgrade pdm
+    post_install:
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH pdm install -dG doc
+
+sphinx:
+   configuration: docs/source/conf.py


### PR DESCRIPTION
# Description
This PR adds a [Read the Docs configuration file](https://docs.readthedocs.io/en/stable/config-file/index.html).
The proposed config file is an amalgam of:

- [a Read the Docs example from the documentation](https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-poetry)
- [pdm's .readthedocs.yaml](https://github.com/pdm-project/pdm/blob/main/.readthedocs.yaml)

In order to test it out, I already leaned forward and created a SARkit project in Read the Docs and currently have it configured to a this branch:
See the docs here: https://sarkit.readthedocs.io/en/latest/

![image](https://github.com/user-attachments/assets/c2ae60af-a8a8-4cc1-8275-32b259ce518b)
