### PR TITLE
Standardize I/O interfaces around file objects

### DIFF
--- a/sarkit/standards/sicd/__init__.py
+++ b/sarkit/standards/sicd/__init__.py
@@ -23,7 +23,6 @@ Reading and Writing
 .. autosummary::
    :toctree: generated/
 
-   read_sicd_xml
    SicdNitfReader
    SicdNitfWriter
 
@@ -145,7 +144,6 @@ from .io import (
     SicdNitfReader,
     SicdNitfSecurityFields,
     SicdNitfWriter,
-    read_sicd_xml,
 )
 from .projection.derived import (
     image_to_constant_hae_surface,
@@ -162,7 +160,6 @@ __all__ = [
     "SicdNitfReader",
     "SicdNitfSecurityFields",
     "SicdNitfWriter",
-    "read_sicd_xml",
 ]
 
 # Projections

--- a/sarkit/standards/sidd/io.py
+++ b/sarkit/standards/sidd/io.py
@@ -436,15 +436,14 @@ class SiddNitfReader:
 
     Parameters
     ----------
-    file : file-like
+    file : `file object`
         SIDD NITF file to read
 
     Examples
     --------
-    >>> with sidd_filename.open('rb') as file:
-    ...     with SiddNitfReader(file) as reader:
-    ...         sidd_xmltree = reader.images[0].sidd_xmltree
-    ...         pixels = reader.read_image(0)
+    >>> with sidd_path.open('rb') as file, SiddNitfReader(file) as reader:
+    ...     sidd_xmltree = reader.images[0].sidd_xmltree
+    ...     pixels = reader.read_image(0)
 
     Attributes
     ----------
@@ -593,7 +592,7 @@ class SiddNitfWriter:
 
     Parameters
     ----------
-    file : file-like
+    file : `file object`
         SIDD NITF file to write
     nitf_plan : :py:class:`SiddNitfPlan`
         NITF plan object
@@ -608,9 +607,8 @@ class SiddNitfWriter:
     ...                                                        security=SiddNitfSecurityFields(clas='U')))
     >>> image_index = plan.add_image(is_fields=SiddNitfImageSegmentFields(security=SiddNitfSecurityFields(clas='U')),
     ...                              des_fields=SiddNitfDESegmentFields(security=SiddNitfSecurityFields(clas='U')))
-    >>> with output_filename.open('wb') as file:
-    ...     with SiddNitfWriter(file, plan) as writer:
-    ...         writer.write_image(image_index, pixel_array)
+    >>> with output_path.open('wb') as file, SiddNitfWriter(file, plan) as writer:
+    ...     writer.write_image(image_index, pixel_array)
 
     See Also
     --------


### PR DESCRIPTION
# Description
This PR standardizes the io interfaces around file objects, which was first proposed when SIDD I/O was introduced as a way to simplify the code/API as a lesson learned from some SARPy issues:

- https://github.com/ngageoint/sarpy/pull/524
- https://github.com/ngageoint/sarpy/pull/526

This change impacted `sarkit.standards.sicd.read_sicd_xml`. I was going to update the function but it seems like an outlier (CPHD/SIDD do not have them) that went against the spirit of these standardized interfaces so I propose removing it.

## Notes
- add some missing type hints
- add types to properties in class docstrings to make them render similarly to non-properties