### PR TITLE
Bugfix - node name mismatch

### DIFF
--- a/sarkit/verification/sicd_consistency.py
+++ b/sarkit/verification/sicd_consistency.py
@@ -691,6 +691,8 @@ class SicdConsistency(con.ConsistencyChecker):
                 algo := self.sicdroot.findtext("./{*}ImageFormation/{*}ImageFormAlgo")
             ) != "OTHER"
             with self.need("ImageFormationAlgo paired with appropriate block"):
+                if algo == "RGAZCOMP":
+                    algo = "RgAzComp"
                 assert self.sicdroot.find("./{*}" + algo) is not None
 
     def check_pfa_grid_type(self) -> None:
@@ -1255,7 +1257,6 @@ class SicdConsistency(con.ConsistencyChecker):
                     np.round(npp.polyval(iset["t_end"], iset["ipp_poly"]) - 1),
                 )
             isets.append(iset)
-
         isets.sort(key=lambda x: x["index"])
 
         t_starts = np.asarray([iset["t_start"] for iset in isets])

--- a/tests/verification/test_sicd_consistency.py
+++ b/tests/verification/test_sicd_consistency.py
@@ -556,6 +556,19 @@ def test_rgazcomp_polys(sicd_con, em):
     assert sicd_con.failures()
 
 
+def test_rgazcomp_ifa(sicd_con, em):
+    sicd_con.sicdroot.append(
+        em.RgAzComp(
+            em.AzSF("0.0"),
+            sarkit.standards.xml.PolyType(1).make_elem("KazPoly", np.zeros(4)),
+        )
+    )
+
+    sicd_con.sicdroot.find("./{*}ImageFormation/{*}ImageFormAlgo").text = "RGAZCOMP"
+    sicd_con.check("check_valid_ifa")
+    assert not sicd_con.failures()
+
+
 @pytest.mark.parametrize(
     "poly_to_invalidate",
     ("{*}PolarAngPoly", "{*}SpatialFreqSFPoly", "{*}STDeskew/{*}STDSPhasePoly"),


### PR DESCRIPTION
While testing with `RGAZCOMP` xml, I discovered that the IFA test was failing.  This is due to a mismatch in the `ImageFormation/ImageFormAlgo` and the node name from the spec and schema, which is CamelCase.  `RGAZCOMP` vs `RgAzComp`.

Here's a simple fix...

<details>
<summary>Failed testing from main</summary>

```

$ pdm run nox
nox > Running session lint
nox > Creating virtual environment (virtualenv) using python in .nox/lint
nox > pdm install --frozen-lockfile -G dev-lint
INFO: Inside an active virtualenv /home/vscuser/repos/ext_sarkit/.nox/lint, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 45 to add, 0 to update, 0 to remove

  ✔ Install alabaster 1.0.0 successful
  ✔ Install colorlog 6.9.0 successful
  ✔ Install argcomplete 3.5.2 successful
  ✔ Install charset-normalizer 3.4.1 successful
  ✔ Install idna 3.10 successful
  ✔ Install filelock 3.16.1 successful
  ✔ Install distlib 0.3.9 successful
  ✔ Install docutils 0.21.2 successful
  ✔ Install certifi 2024.12.14 successful
  ✔ Install iniconfig 2.0.0 successful
  ✔ Install imagesize 1.4.1 successful
  ✔ Install jinja2 3.1.5 successful
  ✔ Install markupsafe 3.0.2 successful
  ✔ Install mypy-extensions 1.0.0 successful
  ✔ Install nox 2024.10.9 successful
  ✔ Install numpydoc 1.8.0 successful
  ✔ Install packaging 24.2 successful
  ✔ Install platformdirs 4.3.6 successful
  ✔ Install pluggy 1.5.0 successful
  ✔ Install pytest 8.3.4 successful
  ✔ Install requests 2.32.3 successful
  ✔ Install pygments 2.18.0 successful
  ✔ Install babel 2.16.0 successful
  ✔ Install snowballstemmer 2.2.0 successful
  ✔ Install shapely 2.0.6 successful
  ✔ Install numba 0.60.0 successful
  ✔ Install mypy 1.14.0 successful
  ✔ Install sphinxcontrib-autoprogram 0.1.9 successful
  ✔ Install sphinxcontrib-applehelp 2.0.0 successful
  ✔ Install sphinx 8.1.3 successful
  ✔ Install sphinxcontrib-devhelp 2.0.0 successful
  ✔ Install sphinxcontrib-jquery 4.1 successful
  ✔ Install sphinxcontrib-htmlhelp 2.1.0 successful
  ✔ Install sphinxcontrib-jsmath 1.0.1 successful
  ✔ Install tabulate 0.9.0 successful
  ✔ Install sphinxcontrib-qthelp 2.0.0 successful
  ✔ Install typing-extensions 4.12.2 successful
  ✔ Install sphinx-rtd-theme 3.0.2 successful
  ✔ Install sphinxcontrib-serializinghtml 2.0.0 successful
  ✔ Install urllib3 2.3.0 successful
  ✔ Install lxml 5.3.0 successful
  ✔ Install llvmlite 0.43.0 successful
  ✔ Install virtualenv 20.28.0 successful
  ✔ Install ruff 0.8.4 successful
  ✔ Install numpy 2.0.2 successful
  ✔ Install sarkit 0.1.dev9+gff9d7ae.d20241230 successful

  0:00:13 🎉 All complete! 45/45
INFO: PDM 2.22.0 is installed, while 2.22.1 is available.
Please run `pdm self update` to upgrade.
Run `pdm config check_update false` to disable the check.
nox > ruff check
All checks passed!
nox > ruff format --diff
warning: The following rule may cause conflicts when used with the formatter: `ISC001`. To avoid unexpected behavior, we recommend disabling this rule, either by removing it from the `select` or `extend-select` configuration, or adding it to the `ignore` configuration.
73 files already formatted
nox > mypy /home/vscuser/repos/ext_sarkit/sarkit
Success: no issues found in 43 source files
nox > Session lint was successful.
nox > Running session data
nox > Creating virtual environment (virtualenv) using python in .nox/data
nox > pdm install --frozen-lockfile
INFO: Inside an active virtualenv /home/vscuser/repos/ext_sarkit/.nox/data, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 45 to add, 0 to update, 0 to remove

  ✔ Install certifi 2024.12.14 successful
  ✔ Install distlib 0.3.9 successful
  ✔ Install filelock 3.16.1 successful
  ✔ Install alabaster 1.0.0 successful
  ✔ Install argcomplete 3.5.2 successful
  ✔ Install idna 3.10 successful
  ✔ Install charset-normalizer 3.4.1 successful
  ✔ Install colorlog 6.9.0 successful
  ✔ Install iniconfig 2.0.0 successful
  ✔ Install docutils 0.21.2 successful
  ✔ Install imagesize 1.4.1 successful
  ✔ Install jinja2 3.1.5 successful
  ✔ Install mypy-extensions 1.0.0 successful
  ✔ Install nox 2024.10.9 successful
  ✔ Install numpydoc 1.8.0 successful
  ✔ Install packaging 24.2 successful
  ✔ Install platformdirs 4.3.6 successful
  ✔ Install pluggy 1.5.0 successful
  ✔ Install lxml 5.3.0 successful
  ✔ Install pytest 8.3.4 successful
  ✔ Install requests 2.32.3 successful
  ✔ Install pygments 2.18.0 successful
  ✔ Install markupsafe 3.0.2 successful
  ✔ Install snowballstemmer 2.2.0 successful
  ✔ Install babel 2.16.0 successful
  ✔ Install sphinx-rtd-theme 3.0.2 successful
  ✔ Install sphinxcontrib-applehelp 2.0.0 successful
  ✔ Install sphinx 8.1.3 successful
  ✔ Install sphinxcontrib-autoprogram 0.1.9 successful
  ✔ Install sphinxcontrib-devhelp 2.0.0 successful
  ✔ Install sphinxcontrib-htmlhelp 2.1.0 successful
  ✔ Install shapely 2.0.6 successful
  ✔ Install sphinxcontrib-jquery 4.1 successful
  ✔ Install numba 0.60.0 successful
  ✔ Install sphinxcontrib-jsmath 1.0.1 successful
  ✔ Install typing-extensions 4.12.2 successful
  ✔ Install tabulate 0.9.0 successful
  ✔ Install sphinxcontrib-serializinghtml 2.0.0 successful
  ✔ Install sphinxcontrib-qthelp 2.0.0 successful
  ✔ Install urllib3 2.3.0 successful
  ✔ Install virtualenv 20.28.0 successful
  ✔ Install ruff 0.8.4 successful
  ✔ Install mypy 1.14.0 successful
  ✔ Install llvmlite 0.43.0 successful
  ✔ Install numpy 2.0.2 successful
  ✔ Install sarkit 0.1.dev9+gff9d7ae.d20241230 successful

  0:00:13 🎉 All complete! 45/45
INFO: PDM 2.22.0 is installed, while 2.22.1 is available.
Please run `pdm self update` to upgrade.
Run `pdm config check_update false` to disable the check.
nox > python data/syntax_only/sicd/make_syntax_only_sicd_xmls.py --check
nox > python data/syntax_only/cphd/make_syntax_only_cphd_xmls.py --check
nox > Session data was successful.
nox > Running session test
nox > Creating virtual environment (virtualenv) using python in .nox/test
nox > Session test was successful.
nox > Running session test_standards
nox > Creating virtual environment (virtualenv) using python in .nox/test_standards
nox > pdm install --frozen-lockfile -G dev-test
INFO: Inside an active virtualenv /home/vscuser/repos/ext_sarkit/.nox/test_standards, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 41 to add, 0 to update, 0 to remove

  ✔ Install argcomplete 3.5.2 successful
  ✔ Install alabaster 1.0.0 successful
  ✔ Install idna 3.10 successful
  ✔ Install distlib 0.3.9 successful
  ✔ Install filelock 3.16.1 successful
  ✔ Install colorlog 6.9.0 successful
  ✔ Install iniconfig 2.0.0 successful
  ✔ Install certifi 2024.12.14 successful
  ✔ Install imagesize 1.4.1 successful
  ✔ Install jinja2 3.1.5 successful
  ✔ Install docutils 0.21.2 successful
  ✔ Install nox 2024.10.9 successful
  ✔ Install numpydoc 1.8.0 successful
  ✔ Install packaging 24.2 successful
  ✔ Install pluggy 1.5.0 successful
  ✔ Install platformdirs 4.3.6 successful
  ✔ Install pytest 8.3.4 successful
  ✔ Install requests 2.32.3 successful
  ✔ Install lxml 5.3.0 successful
  ✔ Install snowballstemmer 2.2.0 successful
  ✔ Install markupsafe 3.0.2 successful
  ✔ Install pygments 2.18.0 successful
  ✔ Install sphinxcontrib-applehelp 2.0.0 successful
  ✔ Install sphinxcontrib-autoprogram 0.1.9 successful
  ✔ Install sphinxcontrib-devhelp 2.0.0 successful
  ✔ Install sphinx-rtd-theme 3.0.2 successful
  ✔ Install sphinxcontrib-jquery 4.1 successful
  ✔ Install sphinxcontrib-jsmath 1.0.1 successful
  ✔ Install sphinxcontrib-htmlhelp 2.1.0 successful
  ✔ Install babel 2.16.0 successful
  ✔ Install tabulate 0.9.0 successful
  ✔ Install shapely 2.0.6 successful
  ✔ Install sphinxcontrib-serializinghtml 2.0.0 successful
  ✔ Install sphinxcontrib-qthelp 2.0.0 successful
  ✔ Install numba 0.60.0 successful
  ✔ Install urllib3 2.3.0 successful
  ✔ Install sphinx 8.1.3 successful
  ✔ Install virtualenv 20.28.0 successful
  ✔ Install numpy 2.0.2 successful
  ✔ Install llvmlite 0.43.0 successful
  ✔ Install sarkit 0.1.dev9+gff9d7ae.d20241230 successful

  0:00:10 🎉 All complete! 41/41
INFO: PDM 2.22.0 is installed, while 2.22.1 is available.
Please run `pdm self update` to upgrade.
Run `pdm config check_update false` to disable the check.
nox > pytest tests/standards
======================================================= test session starts ========================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/vscuser/repos/ext_sarkit
configfile: pyproject.toml
collected 110 items                                                                                                                

tests/standards/cphd/test_io.py ....                                                                                         [  3%]
tests/standards/cphd/test_xml.py ...                                                                                         [  6%]
tests/standards/general/test_base.py ...                                                                                     [  9%]
tests/standards/general/test_data_segment.py ..........                                                                      [ 18%]
tests/standards/general/test_format_function.py ........                                                                     [ 25%]
tests/standards/general/test_nitf.py ..                                                                                      [ 27%]
tests/standards/general/test_nitf_image.py ....                                                                              [ 30%]
tests/standards/sicd/test_io.py ........                                                                                     [ 38%]
tests/standards/sicd/test_projection.py ................                                                                     [ 52%]
tests/standards/sicd/test_xml.py ........                                                                                    [ 60%]
tests/standards/sidd/test_io.py ......                                                                                       [ 65%]
tests/standards/sidd/test_xml.py ........                                                                                    [ 72%]
tests/standards/test_geocoords.py ......                                                                                     [ 78%]
tests/standards/test_sicd_projections.py .......                                                                             [ 84%]
tests/standards/test_xml.py .................                                                                                [100%]

======================================================= 110 passed in 5.48s ========================================================
nox > Session test_standards was successful.
nox > Running session test_processing
nox > Creating virtual environment (virtualenv) using python in .nox/test_processing
nox > pdm install --frozen-lockfile -G dev-test -G processing
INFO: Inside an active virtualenv /home/vscuser/repos/ext_sarkit/.nox/test_processing, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 41 to add, 0 to update, 0 to remove

  ✔ Install alabaster 1.0.0 successful
  ✔ Install argcomplete 3.5.2 successful
  ✔ Install colorlog 6.9.0 successful
  ✔ Install certifi 2024.12.14 successful
  ✔ Install distlib 0.3.9 successful
  ✔ Install charset-normalizer 3.4.1 successful
  ✔ Install imagesize 1.4.1 successful
  ✔ Install filelock 3.16.1 successful
  ✔ Install idna 3.10 successful
  ✔ Install jinja2 3.1.5 successful
  ✔ Install iniconfig 2.0.0 successful
  ✔ Install docutils 0.21.2 successful
  ✔ Install nox 2024.10.9 successful
  ✔ Install numpydoc 1.8.0 successful
  ✔ Install packaging 24.2 successful
  ✔ Install platformdirs 4.3.6 successful
  ✔ Install pluggy 1.5.0 successful
  ✔ Install pytest 8.3.4 successful
  ✔ Install requests 2.32.3 successful
  ✔ Install markupsafe 3.0.2 successful
  ✔ Install pygments 2.18.0 successful
  ✔ Install snowballstemmer 2.2.0 successful
  ✔ Install lxml 5.3.0 successful
  ✔ Install sphinxcontrib-applehelp 2.0.0 successful
  ✔ Install babel 2.16.0 successful
  ✔ Install sphinxcontrib-autoprogram 0.1.9 successful
  ✔ Install sphinx-rtd-theme 3.0.2 successful
  ✔ Install sphinxcontrib-devhelp 2.0.0 successful
  ✔ Install sphinxcontrib-htmlhelp 2.1.0 successful
  ✔ Install sphinxcontrib-jsmath 1.0.1 successful
  ✔ Install sphinxcontrib-jquery 4.1 successful
  ✔ Install tabulate 0.9.0 successful
  ✔ Install sphinxcontrib-qthelp 2.0.0 successful
  ✔ Install sphinxcontrib-serializinghtml 2.0.0 successful
  ✔ Install urllib3 2.3.0 successful
  ✔ Install shapely 2.0.6 successful
  ✔ Install sphinx 8.1.3 successful
  ✔ Install virtualenv 20.28.0 successful
  ✔ Install numba 0.60.0 successful
  ✔ Install llvmlite 0.43.0 successful
  ✔ Install numpy 2.0.2 successful
  ✔ Install sarkit 0.1.dev9+gff9d7ae.d20241230 successful

  0:00:09 🎉 All complete! 41/41
INFO: PDM 2.22.0 is installed, while 2.22.1 is available.
Please run `pdm self update` to upgrade.
Run `pdm config check_update false` to disable the check.
nox > pytest tests/processing
======================================================= test session starts ========================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/vscuser/repos/ext_sarkit
configfile: pyproject.toml
collected 6 items                                                                                                                  

tests/processing/test_deskew.py ...                                                                                          [ 50%]
tests/processing/test_pixel_type.py ..                                                                                       [ 83%]
tests/processing/test_subimage.py .                                                                                          [100%]

======================================================== 6 passed in 4.00s =========================================================
nox > Session test_processing was successful.
nox > Running session test_verification
nox > Creating virtual environment (virtualenv) using python in .nox/test_verification
nox > pdm install --frozen-lockfile -G dev-test -G verification
INFO: Inside an active virtualenv /home/vscuser/repos/ext_sarkit/.nox/test_verification, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 41 to add, 0 to update, 0 to remove

  ✔ Install certifi 2024.12.14 successful
  ✔ Install argcomplete 3.5.2 successful
  ✔ Install distlib 0.3.9 successful
  ✔ Install idna 3.10 successful
  ✔ Install colorlog 6.9.0 successful
  ✔ Install alabaster 1.0.0 successful
  ✔ Install charset-normalizer 3.4.1 successful
  ✔ Install filelock 3.16.1 successful
  ✔ Install docutils 0.21.2 successful
  ✔ Install imagesize 1.4.1 successful
  ✔ Install iniconfig 2.0.0 successful
  ✔ Install nox 2024.10.9 successful
  ✔ Install jinja2 3.1.5 successful
  ✔ Install markupsafe 3.0.2 successful
  ✔ Install packaging 24.2 successful
  ✔ Install numpydoc 1.8.0 successful
  ✔ Install platformdirs 4.3.6 successful
  ✔ Install pluggy 1.5.0 successful
  ✔ Install requests 2.32.3 successful
  ✔ Install pytest 8.3.4 successful
  ✔ Install snowballstemmer 2.2.0 successful
  ✔ Install pygments 2.18.0 successful
  ✔ Install lxml 5.3.0 successful
  ✔ Install sphinxcontrib-applehelp 2.0.0 successful
  ✔ Install sphinxcontrib-autoprogram 0.1.9 successful
  ✔ Install numba 0.60.0 successful
  ✔ Install sphinxcontrib-devhelp 2.0.0 successful
  ✔ Install sphinx-rtd-theme 3.0.2 successful
  ✔ Install shapely 2.0.6 successful
  ✔ Install sphinxcontrib-jquery 4.1 successful
  ✔ Install sphinxcontrib-htmlhelp 2.1.0 successful
  ✔ Install tabulate 0.9.0 successful
  ✔ Install sphinx 8.1.3 successful
  ✔ Install sphinxcontrib-jsmath 1.0.1 successful
  ✔ Install sphinxcontrib-qthelp 2.0.0 successful
  ✔ Install sphinxcontrib-serializinghtml 2.0.0 successful
  ✔ Install urllib3 2.3.0 successful
  ✔ Install babel 2.16.0 successful
  ✔ Install virtualenv 20.28.0 successful
  ✔ Install numpy 2.0.2 successful
  ✔ Install llvmlite 0.43.0 successful
  ✔ Install sarkit 0.1.dev9+gff9d7ae.d20241230 successful

  0:00:09 🎉 All complete! 41/41
INFO: PDM 2.22.0 is installed, while 2.22.1 is available.
Please run `pdm self update` to upgrade.
Run `pdm config check_update false` to disable the check.
nox > pytest tests/verification
======================================================= test session starts ========================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/vscuser/repos/ext_sarkit
configfile: pyproject.toml
collected 183 items                                                                                                                

tests/verification/test_consistency.py ........                                                                              [  4%]
tests/verification/test_cphd_consistency.py ................................................................................ [ 48%]
............                                                                                                                 [ 54%]
tests/verification/test_sicd_consistency.py ..........................................................................F..... [ 98%]
...                                                                                                                          [100%]

============================================================= FAILURES =============================================================
________________________________________________________ test_rgazcomp_ifa _________________________________________________________

sicd_con = <sarkit.verification.sicd_consistency.SicdConsistency object at 0x7f01123c6a50>
em = <lxml.builder.ElementMaker object at 0x7f0110712280>

    def test_rgazcomp_ifa(sicd_con, em):
        sicd_con.sicdroot.append(
            em.RgAzComp(
                em.AzSF("0.0"),
                sarkit.standards.xml.PolyType(1).make_elem("KazPoly", np.zeros(4)),
            )
        )
    
        sicd_con.sicdroot.find("./{*}ImageFormation/{*}ImageFormAlgo").text = "RGAZCOMP"
        sicd_con.check("check_valid_ifa")
>       assert not sicd_con.failures()
E       AssertionError: assert not {'check_valid_ifa': {'details': [{'details': 'ImageFormationAlgo paired with appropriate block', 'message': 'line#694:...d': False, 'severity': 'Error'}], 'doc': 'ImageFormationAlgo must be paired with appropriate block.', 'passed': False}}
E        +  where {'check_valid_ifa': {'details': [{'details': 'ImageFormationAlgo paired with appropriate block', 'message': 'line#694:...d': False, 'severity': 'Error'}], 'doc': 'ImageFormationAlgo must be paired with appropriate block.', 'passed': False}} = failures()
E        +    where failures = <sarkit.verification.sicd_consistency.SicdConsistency object at 0x7f01123c6a50>.failures

tests/verification/test_sicd_consistency.py:569: AssertionError
========================================================= warnings summary =========================================================
tests/verification/test_sicd_consistency.py::test_smoketest[xml_file4]
  /home/vscuser/repos/ext_sarkit/sarkit/verification/sicd_consistency.py:53: RuntimeWarning: invalid value encountered in divide
    return vec / np.linalg.norm(vec, axis=axis, keepdims=True)

tests/verification/test_sicd_consistency.py::test_smoketest[xml_file6]
  /home/vscuser/repos/ext_sarkit/sarkit/standards/sicd/xml.py:706: RuntimeWarning: invalid value encountered in arccos
    dca_xmt = np.arccos(-rdot_xmt_scp / vxmt_m)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================== short test summary info ======================================================
FAILED tests/verification/test_sicd_consistency.py::test_rgazcomp_ifa - AssertionError: assert not {'check_valid_ifa': {'details': [{'details': 'ImageFormationAlgo paired with appropriate block', 'me...
============================================ 1 failed, 182 passed, 2 warnings in 7.44s =============================================
nox > Command pytest tests/verification failed with exit code 1
nox > Session test_verification failed.
nox > Ran multiple sessions:
nox > * lint: success
nox > * data: success
nox > * test: success
nox > * test_standards: success
nox > * test_processing: success
nox > * test_verification: failed

```

</details>


<details>
<summary>Successful testing from this branch</summary>

```

$ pdm run nox
nox > Running session lint
nox > Creating virtual environment (virtualenv) using python in .nox/lint
nox > pdm install --frozen-lockfile -G dev-lint
INFO: Inside an active virtualenv /home/vscuser/repos/ext_sarkit/.nox/lint, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 45 to add, 0 to update, 0 to remove

  ✔ Install certifi 2024.12.14 successful
  ✔ Install argcomplete 3.5.2 successful
  ✔ Install colorlog 6.9.0 successful
  ✔ Install charset-normalizer 3.4.1 successful
  ✔ Install idna 3.10 successful
  ✔ Install alabaster 1.0.0 successful
  ✔ Install filelock 3.16.1 successful
  ✔ Install iniconfig 2.0.0 successful
  ✔ Install imagesize 1.4.1 successful
  ✔ Install docutils 0.21.2 successful
  ✔ Install jinja2 3.1.5 successful
  ✔ Install distlib 0.3.9 successful
  ✔ Install mypy-extensions 1.0.0 successful
  ✔ Install nox 2024.10.9 successful
  ✔ Install numpydoc 1.8.0 successful
  ✔ Install packaging 24.2 successful
  ✔ Install platformdirs 4.3.6 successful
  ✔ Install pluggy 1.5.0 successful
  ✔ Install markupsafe 3.0.2 successful
  ✔ Install pygments 2.18.0 successful
  ✔ Install pytest 8.3.4 successful
  ✔ Install requests 2.32.3 successful
  ✔ Install babel 2.16.0 successful
  ✔ Install snowballstemmer 2.2.0 successful
  ✔ Install sphinx 8.1.3 successful
  ✔ Install numba 0.60.0 successful
  ✔ Install lxml 5.3.0 successful
  ✔ Install shapely 2.0.6 successful
  ✔ Install sphinxcontrib-autoprogram 0.1.9 successful
  ✔ Install sphinxcontrib-applehelp 2.0.0 successful
  ✔ Install sphinxcontrib-jquery 4.1 successful
  ✔ Install sphinxcontrib-devhelp 2.0.0 successful
  ✔ Install sphinxcontrib-htmlhelp 2.1.0 successful
  ✔ Install sphinxcontrib-jsmath 1.0.1 successful
  ✔ Install sphinx-rtd-theme 3.0.2 successful
  ✔ Install tabulate 0.9.0 successful
  ✔ Install sphinxcontrib-qthelp 2.0.0 successful
  ✔ Install typing-extensions 4.12.2 successful
  ✔ Install sphinxcontrib-serializinghtml 2.0.0 successful
  ✔ Install urllib3 2.3.0 successful
  ✔ Install llvmlite 0.43.0 successful
  ✔ Install virtualenv 20.28.0 successful
  ✔ Install mypy 1.14.0 successful
  ✔ Install ruff 0.8.4 successful
  ✔ Install numpy 2.0.2 successful
  ✔ Install sarkit 0.1.dev8+g4c0ced9 successful

  0:00:14 🎉 All complete! 45/45
INFO: PDM 2.22.0 is installed, while 2.22.1 is available.
Please run `pdm self update` to upgrade.
Run `pdm config check_update false` to disable the check.
nox > ruff check
All checks passed!
nox > ruff format --diff
warning: The following rule may cause conflicts when used with the formatter: `ISC001`. To avoid unexpected behavior, we recommend disabling this rule, either by removing it from the `select` or `extend-select` configuration, or adding it to the `ignore` configuration.
73 files already formatted
nox > mypy /home/vscuser/repos/ext_sarkit/sarkit
Success: no issues found in 43 source files
nox > Session lint was successful.
nox > Running session data
nox > Creating virtual environment (virtualenv) using python in .nox/data
nox > pdm install --frozen-lockfile
INFO: Inside an active virtualenv /home/vscuser/repos/ext_sarkit/.nox/data, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 45 to add, 0 to update, 0 to remove

  ✔ Install argcomplete 3.5.2 successful
  ✔ Install distlib 0.3.9 successful
  ✔ Install charset-normalizer 3.4.1 successful
  ✔ Install certifi 2024.12.14 successful
  ✔ Install alabaster 1.0.0 successful
  ✔ Install colorlog 6.9.0 successful
  ✔ Install idna 3.10 successful
  ✔ Install iniconfig 2.0.0 successful
  ✔ Install imagesize 1.4.1 successful
  ✔ Install jinja2 3.1.5 successful
  ✔ Install filelock 3.16.1 successful
  ✔ Install mypy-extensions 1.0.0 successful
  ✔ Install nox 2024.10.9 successful
  ✔ Install docutils 0.21.2 successful
  ✔ Install numpydoc 1.8.0 successful
  ✔ Install packaging 24.2 successful
  ✔ Install platformdirs 4.3.6 successful
  ✔ Install pluggy 1.5.0 successful
  ✔ Install markupsafe 3.0.2 successful
  ✔ Install pygments 2.18.0 successful
  ✔ Install pytest 8.3.4 successful
  ✔ Install requests 2.32.3 successful
  ✔ Install babel 2.16.0 successful
  ✔ Install snowballstemmer 2.2.0 successful
  ✔ Install sphinx 8.1.3 successful
  ✔ Install numba 0.60.0 successful
  ✔ Install shapely 2.0.6 successful
  ✔ Install sphinxcontrib-autoprogram 0.1.9 successful
  ✔ Install sphinxcontrib-applehelp 2.0.0 successful
  ✔ Install sphinxcontrib-devhelp 2.0.0 successful
  ✔ Install sphinxcontrib-jquery 4.1 successful
  ✔ Install sphinxcontrib-jsmath 1.0.1 successful
  ✔ Install sphinxcontrib-htmlhelp 2.1.0 successful
  ✔ Install mypy 1.14.0 successful
  ✔ Install sphinx-rtd-theme 3.0.2 successful
  ✔ Install tabulate 0.9.0 successful
  ✔ Install sphinxcontrib-qthelp 2.0.0 successful
  ✔ Install typing-extensions 4.12.2 successful
  ✔ Install sphinxcontrib-serializinghtml 2.0.0 successful
  ✔ Install lxml 5.3.0 successful
  ✔ Install urllib3 2.3.0 successful
  ✔ Install llvmlite 0.43.0 successful
  ✔ Install virtualenv 20.28.0 successful
  ✔ Install ruff 0.8.4 successful
  ✔ Install numpy 2.0.2 successful
  ✔ Install sarkit 0.1.dev8+g4c0ced9 successful

  0:00:15 🎉 All complete! 45/45
INFO: PDM 2.22.0 is installed, while 2.22.1 is available.
Please run `pdm self update` to upgrade.
Run `pdm config check_update false` to disable the check.
nox > python data/syntax_only/sicd/make_syntax_only_sicd_xmls.py --check
nox > python data/syntax_only/cphd/make_syntax_only_cphd_xmls.py --check
nox > Session data was successful.
nox > Running session test
nox > Creating virtual environment (virtualenv) using python in .nox/test
nox > Session test was successful.
nox > Running session test_standards
nox > Creating virtual environment (virtualenv) using python in .nox/test_standards
nox > pdm install --frozen-lockfile -G dev-test
INFO: Inside an active virtualenv /home/vscuser/repos/ext_sarkit/.nox/test_standards, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 41 to add, 0 to update, 0 to remove

  ✔ Install charset-normalizer 3.4.1 successful
  ✔ Install colorlog 6.9.0 successful
  ✔ Install distlib 0.3.9 successful
  ✔ Install alabaster 1.0.0 successful
  ✔ Install certifi 2024.12.14 successful
  ✔ Install filelock 3.16.1 successful
  ✔ Install argcomplete 3.5.2 successful
  ✔ Install imagesize 1.4.1 successful
  ✔ Install iniconfig 2.0.0 successful
  ✔ Install jinja2 3.1.5 successful
  ✔ Install idna 3.10 successful
    Installing babel 2.16.0...     Downloading... 100%
  ✔ Install nox 2024.10.9 successful
  ✔ Install numpydoc 1.8.0 successful
  ✔ Install docutils 0.21.2 successful
  ✔ Install platformdirs 4.3.6 successful
    Installing babel 2.16.0...       Downloading... 100%
  ✔ Install packaging 24.2 successful
  ✔ Install pluggy 1.5.0 successful
  ✔ Install pytest 8.3.4 successful
  ✔ Install requests 2.32.3 successful
  ✔ Install pygments 2.18.0 successful
  ✔ Install snowballstemmer 2.2.0 successful
  ✔ Install markupsafe 3.0.2 successful
  ✔ Install babel 2.16.0 successful
  ✔ Install lxml 5.3.0 successful
  ✔ Install sphinxcontrib-applehelp 2.0.0 successful
  ✔ Install sphinxcontrib-autoprogram 0.1.9 successful
  ⠙ Installing llvmlite 0.43.0...                 Downloading...  35%
  ✔ Install sphinx-rtd-theme 3.0.2 successful
  ✔ Install sphinxcontrib-jquery 4.1 successful
  ✔ Install sphinxcontrib-devhelp 2.0.0 successful
  ✔ Install sphinxcontrib-jsmath 1.0.1 successful
  ✔ Install sphinxcontrib-htmlhelp 2.1.0 successful
  ✔ Install tabulate 0.9.0 successful
  ✔ Install urllib3 2.3.0 successful
  ✔ Install sphinxcontrib-qthelp 2.0.0 successful
  ✔ Install sphinxcontrib-serializinghtml 2.0.0 successful
  ✔ Install sphinx 8.1.3 successful
  ✔ Install shapely 2.0.6 successful
  ✔ Install virtualenv 20.28.0 successful
  ✔ Install numba 0.60.0 successful
  ✔ Install numpy 2.0.2 successful
  ✔ Install llvmlite 0.43.0 successful
  ✔ Install sarkit 0.1.dev8+g4c0ced9 successful

  0:00:11 🎉 All complete! 41/41
INFO: PDM 2.22.0 is installed, while 2.22.1 is available.
Please run `pdm self update` to upgrade.
Run `pdm config check_update false` to disable the check.
nox > pytest tests/standards
======================================================= test session starts ========================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/vscuser/repos/ext_sarkit
configfile: pyproject.toml
collected 112 items                                                                                                                

tests/standards/cphd/test_io.py ....                                                                                         [  3%]
tests/standards/cphd/test_xml.py ...                                                                                         [  6%]
tests/standards/general/test_base.py ...                                                                                     [  8%]
tests/standards/general/test_data_segment.py ..........                                                                      [ 17%]
tests/standards/general/test_format_function.py ........                                                                     [ 25%]
tests/standards/general/test_nitf.py ..                                                                                      [ 26%]
tests/standards/general/test_nitf_image.py ....                                                                              [ 30%]
tests/standards/sicd/test_io.py ..........                                                                                   [ 39%]
tests/standards/sicd/test_projection.py ................                                                                     [ 53%]
tests/standards/sicd/test_xml.py ........                                                                                    [ 60%]
tests/standards/sidd/test_io.py ......                                                                                       [ 66%]
tests/standards/sidd/test_xml.py ........                                                                                    [ 73%]
tests/standards/test_geocoords.py ......                                                                                     [ 78%]
tests/standards/test_sicd_projections.py .......                                                                             [ 84%]
tests/standards/test_xml.py .................                                                                                [100%]

======================================================= 112 passed in 6.93s ========================================================
nox > Session test_standards was successful.
nox > Running session test_processing
nox > Creating virtual environment (virtualenv) using python in .nox/test_processing
nox > pdm install --frozen-lockfile -G dev-test -G processing
INFO: Inside an active virtualenv /home/vscuser/repos/ext_sarkit/.nox/test_processing, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 41 to add, 0 to update, 0 to remove

  ✔ Install colorlog 6.9.0 successful
  ✔ Install alabaster 1.0.0 successful
  ✔ Install argcomplete 3.5.2 successful
  ✔ Install filelock 3.16.1 successful
  ✔ Install docutils 0.21.2 successful
  ✔ Install charset-normalizer 3.4.1 successful
  ✔ Install distlib 0.3.9 successful
  ✔ Install idna 3.10 successful
  ✔ Install jinja2 3.1.5 successful
  ✔ Install certifi 2024.12.14 successful
  ✔ Install iniconfig 2.0.0 successful
    Installing babel 2.16.0...     Downloading... 100%
  ✔ Install markupsafe 3.0.2 successful
  ✔ Install imagesize 1.4.1 successful
  ✔ Install nox 2024.10.9 successful
  ✔ Install numpydoc 1.8.0 successful
  ✔ Install packaging 24.2 successful
  ✔ Install platformdirs 4.3.6 successful
  ✔ Install pluggy 1.5.0 successful
  ✔ Install requests 2.32.3 successful
  ✔ Install pytest 8.3.4 successful
  ✔ Install snowballstemmer 2.2.0 successful
  ✔ Install lxml 5.3.0 successful
  ✔ Install pygments 2.18.0 successful
  ✔ Install shapely 2.0.6 successful
  ✔ Install sphinxcontrib-autoprogram 0.1.9 successful
  ✔ Install sphinxcontrib-applehelp 2.0.0 successful
  ✔ Install sphinxcontrib-devhelp 2.0.0 successful
  ✔ Install sphinxcontrib-jquery 4.1 successful
  ✔ Install sphinxcontrib-htmlhelp 2.1.0 successful
  ✔ Install sphinxcontrib-jsmath 1.0.1 successful
  ✔ Install sphinx-rtd-theme 3.0.2 successful
  ✔ Install tabulate 0.9.0 successful
  ✔ Install numba 0.60.0 successful
  ✔ Install sphinxcontrib-qthelp 2.0.0 successful
  ✔ Install babel 2.16.0 successful
  ✔ Install sphinxcontrib-serializinghtml 2.0.0 successful
  ✔ Install urllib3 2.3.0 successful
  ✔ Install sphinx 8.1.3 successful
  ✔ Install virtualenv 20.28.0 successful
  ✔ Install numpy 2.0.2 successful
  ✔ Install llvmlite 0.43.0 successful
  ✔ Install sarkit 0.1.dev8+g4c0ced9 successful

  0:00:10 🎉 All complete! 41/41
INFO: PDM 2.22.0 is installed, while 2.22.1 is available.
Please run `pdm self update` to upgrade.
Run `pdm config check_update false` to disable the check.
nox > pytest tests/processing
======================================================= test session starts ========================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/vscuser/repos/ext_sarkit
configfile: pyproject.toml
collected 6 items                                                                                                                  

tests/processing/test_deskew.py ...                                                                                          [ 50%]
tests/processing/test_pixel_type.py ..                                                                                       [ 83%]
tests/processing/test_subimage.py .                                                                                          [100%]

======================================================== 6 passed in 5.30s =========================================================
nox > Session test_processing was successful.
nox > Running session test_verification
nox > Creating virtual environment (virtualenv) using python in .nox/test_verification
nox > pdm install --frozen-lockfile -G dev-test -G verification
INFO: Inside an active virtualenv /home/vscuser/repos/ext_sarkit/.nox/test_verification, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 41 to add, 0 to update, 0 to remove

  ✔ Install distlib 0.3.9 successful
  ✔ Install colorlog 6.9.0 successful
  ✔ Install argcomplete 3.5.2 successful
  ✔ Install charset-normalizer 3.4.1 successful
  ✔ Install idna 3.10 successful
  ✔ Install docutils 0.21.2 successful
  ✔ Install alabaster 1.0.0 successful
  ✔ Install certifi 2024.12.14 successful
  ✔ Install iniconfig 2.0.0 successful
  ✔ Install filelock 3.16.1 successful
  ✔ Install imagesize 1.4.1 successful
  ✔ Install nox 2024.10.9 successful
  ✔ Install jinja2 3.1.5 successful
  ✔ Install numpydoc 1.8.0 successful
  ✔ Install markupsafe 3.0.2 successful
  ✔ Install packaging 24.2 successful
  ✔ Install platformdirs 4.3.6 successful
  ✔ Install pluggy 1.5.0 successful
  ✔ Install requests 2.32.3 successful
  ✔ Install pytest 8.3.4 successful
  ✔ Install snowballstemmer 2.2.0 successful
  ✔ Install pygments 2.18.0 successful
  ✔ Install sphinx-rtd-theme 3.0.2 successful
  ✔ Install babel 2.16.0 successful
  ✔ Install sphinxcontrib-autoprogram 0.1.9 successful
  ✔ Install sphinx 8.1.3 successful
  ✔ Install sphinxcontrib-jquery 4.1 successful
  ✔ Install sphinxcontrib-devhelp 2.0.0 successful
  ✔ Install sphinxcontrib-htmlhelp 2.1.0 successful
  ✔ Install sphinxcontrib-jsmath 1.0.1 successful
  ✔ Install tabulate 0.9.0 successful
  ✔ Install sphinxcontrib-qthelp 2.0.0 successful
  ✔ Install sphinxcontrib-serializinghtml 2.0.0 successful
  ✔ Install urllib3 2.3.0 successful
  ✔ Install shapely 2.0.6 successful
  ✔ Install virtualenv 20.28.0 successful
  ✔ Install numba 0.60.0 successful
  ✔ Install lxml 5.3.0 successful
  ✔ Install numpy 2.0.2 successful
  ✔ Install llvmlite 0.43.0 successful
  ✔ Install sarkit 0.1.dev8+g4c0ced9 successful

  0:00:11 🎉 All complete! 41/41
INFO: PDM 2.22.0 is installed, while 2.22.1 is available.
Please run `pdm self update` to upgrade.
Run `pdm config check_update false` to disable the check.
nox > pytest tests/verification
======================================================= test session starts ========================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/vscuser/repos/ext_sarkit
configfile: pyproject.toml
collected 183 items                                                                                                                

tests/verification/test_consistency.py ........                                                                              [  4%]
tests/verification/test_cphd_consistency.py ................................................................................ [ 48%]
............                                                                                                                 [ 54%]
tests/verification/test_sicd_consistency.py ................................................................................ [ 98%]
...                                                                                                                          [100%]

========================================================= warnings summary =========================================================
tests/verification/test_sicd_consistency.py::test_smoketest[xml_file4]
  /home/vscuser/repos/ext_sarkit/sarkit/verification/sicd_consistency.py:53: RuntimeWarning: invalid value encountered in divide
    return vec / np.linalg.norm(vec, axis=axis, keepdims=True)

tests/verification/test_sicd_consistency.py::test_smoketest[xml_file6]
  /home/vscuser/repos/ext_sarkit/sarkit/standards/sicd/xml.py:706: RuntimeWarning: invalid value encountered in arccos
    dca_xmt = np.arccos(-rdot_xmt_scp / vxmt_m)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================= 183 passed, 2 warnings in 7.39s ==================================================
nox > Session test_verification was successful.
nox > Ran multiple sessions:
nox > * lint: success
nox > * data: success
nox > * test: success
nox > * test_standards: success
nox > * test_processing: success
nox > * test_verification: success

```

</details>