### PR TITLE
SICD IO: support other pixel types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <div align="center">
 
-<!-- TODO: Replace link with github asset when available in main -->
-<img src="https://sarkit.readthedocs.io/en/user-guide/_static/sarkit_logo.png" width=200>
+<img src="https://raw.githubusercontent.com/ValkyrieSystems/sarkit/main/docs/source/_static/sarkit_logo.png" width=200>
 
 [![Python package](https://github.com/ValkyrieSystems/sarkit/actions/workflows/python-package.yml/badge.svg)](https://github.com/ValkyrieSystems/sarkit/actions/workflows/python-package.yml)
 [![Documentation Status](https://readthedocs.org/projects/sarkit/badge/?version=latest)](https://sarkit.readthedocs.io/en/latest/?badge=latest)

--- a/sarkit/processing/pixel_type.py
+++ b/sarkit/processing/pixel_type.py
@@ -66,7 +66,7 @@ def as_re32f_im32f(
     """
     input_type = sicd_xmltree.findtext("./{*}ImageData/{*}PixelType")
 
-    if ss_io.PIXEL_TYPES[input_type]["dtype"] != array.dtype:
+    if ss_io.PIXEL_TYPES[input_type]["dtype"] != array.dtype.newbyteorder("="):
         raise TypeError(
             f"{array.dtype=} does not match ImageData/PixelType={input_type}"
         )
@@ -106,7 +106,7 @@ def as_re16i_im16i(
     """
     input_type = sicd_xmltree.findtext("./{*}ImageData/{*}PixelType")
 
-    if ss_io.PIXEL_TYPES[input_type]["dtype"] != array.dtype:
+    if ss_io.PIXEL_TYPES[input_type]["dtype"] != array.dtype.newbyteorder("="):
         raise TypeError(
             f"{array.dtype=} does not match ImageData/PixelType={input_type}"
         )
@@ -118,7 +118,7 @@ def as_re16i_im16i(
     xml_helper = ss_xml.XmlHelper(sicd_xmltree_out)
     if xml_helper.load("./{*}ImageData/{*}PixelType") == "AMP8I_PHS8I":
         array = _amp8i_phs8i_to_re32f_im32f(array, xml_helper)
-    array_f32 = array.reshape(array.shape + (1,)).view(np.float32)
+    array_f32 = array.reshape(array.shape + (1,)).view(array.real.dtype)
     mabs = _max_abs(array_f32)
     scale = (2**15 - 1) / mabs
     scale_sq = scale * scale
@@ -169,7 +169,7 @@ def as_amp8i_phs8i(
     """
     input_type = sicd_xmltree.findtext("./{*}ImageData/{*}PixelType")
 
-    if ss_io.PIXEL_TYPES[input_type]["dtype"] != array.dtype:
+    if ss_io.PIXEL_TYPES[input_type]["dtype"] != array.dtype.newbyteorder("="):
         raise TypeError(
             f"{array.dtype=} does not match ImageData/PixelType={input_type}"
         )


### PR DESCRIPTION
# Description
This PR applies the I/O conventions of the CPHD reader/writer to SICD:
- `read_image` returns an array whose dtype is appropriate for the PixelType
- `write_image` requires an array whose dtype is appropriate for the PixelType; will byteswap if necessary

In addition, since #8 has been merged and the asset is available in github on main, the image src in the README has been swapped out.

# Demo
After running the new unittest (`pytest tests/standards/sicd/test_io.py::test_roundtrip`):

```python
import pathlib

import sarkit.standards.sicd as ss

for sicd in pathlib.Path("/data/tmp/pytest-of-vscuser/pytest-current/").rglob("out.sicd"):
    with open(sicd, "rb") as f, ss.SicdNitfReader(f) as r:
        print(sicd.parent)
        print(r.sicd_xmltree.findtext(".//{*}PixelType"))
        print(r.read_image().dtype)
        print()

```

Output:
```
/data/tmp/pytest-of-vscuser/pytest-current/test_roundtrip_sicd_xml0_RE32F0
RE32F_IM32F
>c8

/data/tmp/pytest-of-vscuser/pytest-current/test_roundtrip_sicd_xml1_RE16I0
RE16I_IM16I
[('real', '>i2'), ('imag', '>i2')]

/data/tmp/pytest-of-vscuser/pytest-current/test_roundtrip_sicd_xml2_AMP8I0
AMP8I_PHS8I
[('amp', 'u1'), ('phase', 'u1')]

/data/tmp/pytest-of-vscuser/pytest-current/test_roundtrip_sicd_xml3_RE32F0
RE32F_IM32F
>c8
```