### PR TITLE
Improve consistency error messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
 
 [project.optional-dependencies]
 verification = [
-    "pytest>=8.0.0",
     "shapely>=2.0.2",
 ]
 processing = [
@@ -89,7 +88,6 @@ module = [
     "lxml.*",
     "numba.*",
     "shapely.*",
-    "_pytest.*",
 ]
 ignore_missing_imports = true
 

--- a/sarkit/verification/cphd_consistency.py
+++ b/sarkit/verification/cphd_consistency.py
@@ -1976,25 +1976,7 @@ def main(args=None):
     if config.schema is not None and config.version is None:
         raise RuntimeError("--version must be specified if using --schema")
 
-    # Some questionable abuse of the pytest internals
-    import ast
-
-    import _pytest.assertion.rewrite
-
-    base, _ = os.path.splitext(__file__)  # python2 can return the '*.pyc' file
-    with open(base + ".py", "r") as fd:
-        source = fd.read()
-    tree = ast.parse(source)
-    try:
-        _pytest.assertion.rewrite.rewrite_asserts(tree)
-    except TypeError:
-        _pytest.assertion.rewrite.rewrite_asserts(tree, source)
-
-    co = compile(tree, __file__, "exec", dont_inherit=True)
-    ns = {}
-    exec(co, ns)
-
-    cphd_con = ns["CphdConsistency"].from_file(
+    cphd_con = CphdConsistency.from_file(
         filename=config.file_name,
         schema=config.schema,
         version=config.version,

--- a/sarkit/verification/sicd_consistency.py
+++ b/sarkit/verification/sicd_consistency.py
@@ -25,7 +25,6 @@ import copy
 import datetime
 import functools
 import logging
-import os
 import pathlib
 from typing import Optional
 
@@ -1938,25 +1937,7 @@ def main(args=None):
     if config.schema is not None and config.version is None:
         raise RuntimeError("--version must be specified if using --schema")
 
-    # More questionable abuse of the pytest internals
-    import ast
-
-    import _pytest.assertion.rewrite
-
-    base, _ = os.path.splitext(__file__)  # python2 can return the '*.pyc' file
-    with open(base + ".py", "r") as fd:
-        source = fd.read()
-    tree = ast.parse(source)
-    try:
-        _pytest.assertion.rewrite.rewrite_asserts(tree)
-    except TypeError:
-        _pytest.assertion.rewrite.rewrite_asserts(tree, source)
-
-    co = compile(tree, __file__, "exec", dont_inherit=True)
-    ns = {}
-    exec(co, ns)
-
-    sicd_con = ns["SicdConsistency"].from_file(
+    sicd_con = SicdConsistency.from_file(
         filename=config.file_name, schema=config.schema, version=config.version
     )
     sicd_con.check(ignore_patterns=config.ignore)

--- a/tests/verification/test_consistency.py
+++ b/tests/verification/test_consistency.py
@@ -73,25 +73,7 @@ def dummycon():
     ------
     DummyConsistency object
     """
-    import ast
-    import os
-
-    import _pytest.assertion.rewrite
-
-    base, _ = os.path.splitext(__file__)  # python2 can return the '*.pyc' file
-    with open(base + ".py", "r") as fd:
-        source = fd.read()
-    tree = ast.parse(source)
-    try:
-        _pytest.assertion.rewrite.rewrite_asserts(tree)
-    except TypeError:
-        _pytest.assertion.rewrite.rewrite_asserts(tree, source)
-
-    co = compile(tree, __file__, "exec", dont_inherit=True)
-    ns = {}
-    exec(co, ns)
-    cover_con = ns["DummyConsistency"]()
-    yield cover_con
+    yield DummyConsistency()
 
 
 def test_all(dummycon, capsys):

--- a/tests/verification/test_sicd_consistency.py
+++ b/tests/verification/test_sicd_consistency.py
@@ -74,7 +74,7 @@ def test_from_file_xml():
     + list(DATAPATH.glob("example-sicd*.xml")),
 )
 def test_main(file):
-    assert not main([str(file)])
+    assert not main([str(file), "-vv"])
 
 
 @pytest.mark.parametrize("xml_file", (DATAPATH / "syntax_only/sicd").glob("*.xml"))


### PR DESCRIPTION
# Description
Credit to @mtrachy

This PR improves the consistency error messages and removes the `pytest` dependency for the `verification` extra.

## Before MR

```shell
$ python -m sarkit.verification.sicd_consistency data/example-sicd-1.4.0.xml -v
check_image_formation_timeline: Checks that the slow time span for data processed to form the image is within collect.
    [Error] Need: 0 <= TStartProc < TEndProc <= CollectDuration
        line#1519: assert 0 <= t_start_proc < t_end_proc <= collect_duration
        assert 3.005681678814601 < 2.544960558148007
```

## After MR

```shell
$ python -m sarkit.verification.sicd_consistency data/example-sicd-1.4.0.xml -v
check_image_formation_timeline: Checks that the slow time span for data processed to form the image is within collect.
    [Error] Need: 0 <= TStartProc < TEndProc <= CollectDuration
        line#1518: assert 0 <= t_start_proc < t_end_proc <= collect_duration

         where:
         0 <= t_start_proc < t_end_proc <= collect_duration = False

         where:
         t_start_proc = 3.005681678814601

         where:
         t_end_proc = 2.544960558148007

         where:
         collect_duration = 2.5506314363333673

```