### PR TITLE
CPHD IO: Support writing masked support arrays

### DIFF
--- a/sarkit/standards/cphd/io.py
+++ b/sarkit/standards/cphd/io.py
@@ -693,6 +693,7 @@ class CphdWriter:
             2D array of complex samples
 
         """
+        # TODO Add support for partial CPHD writing
         assert (
             signal_array.nbytes
             == self._channel_size_offsets[channel_identifier]["signal_size"]
@@ -705,9 +706,6 @@ class CphdWriter:
         )
         output_dtype = signal_array.dtype.newbyteorder(">")
         signal_array.astype(output_dtype, copy=False).tofile(self._file_object)
-
-        # TODO Add support for partial CPHD writing
-        return
 
     def write_pvp(self, channel_identifier: str, pvp_array: npt.NDArray):
         """Write pvp data to a CPHD file
@@ -732,7 +730,6 @@ class CphdWriter:
         )
         output_dtype = pvp_array.dtype.newbyteorder(">")
         pvp_array.astype(output_dtype, copy=False).tofile(self._file_object)
-        return
 
     def write_support_array(
         self, support_array_identifier: str, support_array: npt.NDArray
@@ -745,20 +742,50 @@ class CphdWriter:
             Unique support array identifier
         support_array : ndarray
             Array of support data
-
         """
-        assert (
-            support_array.nbytes
-            == self._sa_size_offsets[support_array_identifier]["size"]
+        data_sa_elem = self._plan.cphd_xmltree.find(
+            f"{{*}}Data/{{*}}SupportArray[{{*}}Identifier='{support_array_identifier}']"
         )
+        expected_shape = (
+            int(data_sa_elem.findtext("{*}NumRows")),
+            int(data_sa_elem.findtext("{*}NumCols")),
+        )
+        sa_elem = self._plan.cphd_xmltree.find(
+            f"{{*}}SupportArray/*[{{*}}Identifier='{support_array_identifier}']"
+        )
+        element_format = sa_elem.findtext("{*}ElementFormat")
+        expected_dtype = binary_format_string_to_dtype(element_format)
+        expected_nodata = sa_elem.findtext("{*}NODATA")
 
-        self._support_arrays_written.add(support_array_identifier)
+        if expected_dtype != support_array.dtype.newbyteorder("="):
+            raise ValueError(
+                f"{support_array.dtype=} is not compatible with {expected_dtype=}"
+            )
+        if expected_shape != support_array.shape:
+            raise ValueError(f"{support_array.shape=} does not match {expected_shape=}")
+        if isinstance(support_array, np.ma.MaskedArray):
+            actual_nodata = (
+                support_array.fill_value.astype(expected_dtype.newbyteorder(">"))
+                .tobytes()
+                .hex()
+            )
+
+            def _is_masked(array):
+                # structured arrays don't play nice with np.ma
+                if array.dtype.names is None:
+                    return np.ma.is_masked(array)
+                return any(_is_masked(array[n]) for n in array.dtype.names)
+
+            if _is_masked(support_array) and expected_nodata != actual_nodata:
+                raise ValueError(f"{actual_nodata=} does not match {expected_nodata=}")
+
         self._file_object.seek(self._file_header_kvp["SUPPORT_BLOCK_BYTE_OFFSET"])
         self._file_object.seek(
             self._sa_size_offsets[support_array_identifier]["offset"], os.SEEK_CUR
         )
         output_dtype = support_array.dtype.newbyteorder(">")
-        support_array.astype(output_dtype, copy=False).tofile(self._file_object)
+        self._file_object.write(support_array.astype(output_dtype, copy=False).data)
+        self._support_arrays_written.add(support_array_identifier)
 
     def done(self):
         """Warn about unwritten arrays declared in the XML"""

--- a/sarkit/standards/sicd/projection/calc.py
+++ b/sarkit/standards/sicd/projection/calc.py
@@ -158,6 +158,7 @@ def compute_coa_pos_vel(
     grp_coa = _xyzpolyval(t_coa, proj_metadata.GRP_Poly)
 
     # Compute transmit time
+    assert proj_metadata.Xmt_Poly is not None
     x0 = _xyzpolyval(t_coa, proj_metadata.Xmt_Poly)
     r_x0 = np.linalg.norm(x0 - grp_coa)
     tx_coa = t_coa - r_x0 / sarkit.constants.speed_of_light
@@ -172,6 +173,7 @@ def compute_coa_pos_vel(
     tr_coa = t_coa + r_r0 / sarkit.constants.speed_of_light
 
     # Compute receive APC position and velocity
+    assert proj_metadata.Rcv_Poly is not None
     rcv_coa = _xyzpolyval(tr_coa, proj_metadata.Rcv_Poly)
     vrcv_coa = _xyzpolyval(tr_coa, npp.polyder(proj_metadata.Rcv_Poly))
 
@@ -333,6 +335,7 @@ def r_rdot_from_rgazim_pfa(
     tgts = np.asarray(image_grid_locations)
     rg_tgts = tgts[..., 0]
     az_tgts = tgts[..., 1]
+    t_coa = np.asarray(t_coa)
 
     if proj_metadata.is_monostatic():
         r_scp_vector = coa_pos_vels.ARP_COA - proj_metadata.SCP
@@ -346,10 +349,12 @@ def r_rdot_from_rgazim_pfa(
         rdot_scp = pt_r_rdot_params.Rdot_Avg_PT
 
     # Compute polar angle and its derivative with respect to time
+    assert proj_metadata.cPA is not None
     theta = npp.polyval(t_coa, proj_metadata.cPA)
     dtheta_dt = npp.polyval(t_coa, npp.polyder(proj_metadata.cPA))
 
     # Compute polar aperture scale factor and its derivative with respect to polar angle
+    assert proj_metadata.cKSF is not None
     ksf = npp.polyval(theta, proj_metadata.cKSF)
     dksf_dtheta = npp.polyval(theta, npp.polyder(proj_metadata.cKSF))
 
@@ -416,6 +421,7 @@ def r_rdot_from_rgzero(
     az_tgts = tgts[..., 1]
 
     # Compute the range at closest approach and the time of closest approach for the image grid location
+    assert proj_metadata.cT_CA is not None
     r_ca = proj_metadata.R_CA_SCP + rg_tgts
     t_ca = npp.polyval(az_tgts, proj_metadata.cT_CA)
 
@@ -424,6 +430,7 @@ def r_rdot_from_rgzero(
     varp_ca_mag = np.linalg.norm(varp_ca, axis=-1, keepdims=True)
 
     # Compute the Doppler Rate Scale Factor for image grid (rg_tgts, az_tgts)
+    assert proj_metadata.cDRSF is not None
     drsf = npp.polyval2d(rg_tgts, az_tgts, proj_metadata.cDRSF)
 
     # Compute the time difference between the COA time and the CA time

--- a/sarkit/standards/sicd/xml.py
+++ b/sarkit/standards/sicd/xml.py
@@ -653,6 +653,8 @@ def compute_scp_coa(sicd_xmltree: lxml.etree.ElementTree) -> lxml.etree.ElementT
     # Additional COA Parameters for Bistatic Images
     params = ss_proj.MetadataParams.from_xml(sicd_xmltree)
     if not pre_1_4 and not params.is_monostatic():
+        assert params.Xmt_Poly is not None
+        assert params.Rcv_Poly is not None
         tx_coa = t_coa - (1 / sarkit.constants.speed_of_light) * np.linalg.norm(
             npp.polyval(t_coa, params.Xmt_Poly) - scp
         )

--- a/tests/standards/cphd/test_io.py
+++ b/tests/standards/cphd/test_io.py
@@ -177,10 +177,8 @@ def test_write_support_array(is_masked, nodata_in_xml, tmp_path):
                     (
                         int(x.findtext("{*}ArrayByteOffset"))
                         + int(x.findtext("{*}NumRows"))
-                        * int(
-                            x.findtext("{*}NumCols")
-                            * int(x.findtext("{*}BytesPerElement"))
-                        )
+                        * int(x.findtext("{*}NumCols"))
+                        * int(x.findtext("{*}BytesPerElement"))
                         for x in basis_etree.findall("{*}Data/{*}SupportArray")
                     ),
                     default=0,


### PR DESCRIPTION
# Description
As a follow-on to #12, this PR updates `CphdWriter.write_support_array` to:
- accommodate writing masked arrays
- add dtype/shape/value checks (ala `SicdNitfWriter.write_signal`)
  - raises `ValueError` if masked array's fill value does not match the XML AND the array uses the fill value
- changed from `ndarray.tofile` to `_file_object.write`
  - masked arrays don't implement `tofile` yet and in an effort to create a more flexible API, we want to move to `seek`, `write`, and `read` anyways
- minor cleanup