### PR TITLE
Add apo adjustments to projections

### DIFF
--- a/sarkit/standards/sicd/projection/__init__.py
+++ b/sarkit/standards/sicd/projection/__init__.py
@@ -17,6 +17,7 @@ relevant subset, e.g. for when Collect_Type = MONOSTATIC vs BISTATIC.
 .. autosummary::
    :toctree: generated/
 
+   AdjustableParameterOffsets
    MetadataParams
    CoaPosVels
    ProjectionSets
@@ -78,6 +79,14 @@ Scene To Image Grid Projection
 
    scene_to_image
 
+Adjustable Parameters
+=====================
+
+.. autosummary::
+   :toctree: generated/
+
+   compute_and_apply_offsets
+
 Precise R/Rdot to Constant HAE Surface Projection
 =================================================
 
@@ -88,6 +97,7 @@ Precise R/Rdot to Constant HAE Surface Projection
 """
 
 from .calc import (
+    compute_and_apply_offsets,
     compute_coa_pos_vel,
     compute_coa_r_rdot,
     compute_coa_time,
@@ -104,6 +114,7 @@ from .calc import (
     scene_to_image,
 )
 from .params import (
+    AdjustableParameterOffsets,
     CoaPosVels,
     MetadataParams,
     ProjectionSets,
@@ -112,6 +123,7 @@ from .params import (
 )
 
 __all__ = [
+    "compute_and_apply_offsets",
     "compute_coa_pos_vel",
     "compute_coa_r_rdot",
     "compute_coa_time",
@@ -129,6 +141,7 @@ __all__ = [
 ]
 
 __all__ += [
+    "AdjustableParameterOffsets",
     "CoaPosVels",
     "MetadataParams",
     "ProjectionSets",

--- a/sarkit/standards/sicd/projection/derived.py
+++ b/sarkit/standards/sicd/projection/derived.py
@@ -52,6 +52,12 @@ def image_to_ground_plane(
     """
     proj_metadata = params.MetadataParams.from_xml(sicd_xmltree)
     projection_sets = calc.compute_projection_sets(proj_metadata, image_grid_locations)
+
+    if params.AdjustableParameterOffsets.exists(sicd_xmltree):
+        adjust_param_offsets = params.AdjustableParameterOffsets.from_xml(sicd_xmltree)
+        projection_sets = calc.compute_and_apply_offsets(
+            proj_metadata, projection_sets, adjust_param_offsets
+        )
     method = (
         {True: "monostatic", False: "bistatic"}[proj_metadata.is_monostatic()]
         if method is None
@@ -133,9 +139,15 @@ def scene_to_image(
         intermediate ground plane points.
     """
     proj_metadata = params.MetadataParams.from_xml(sicd_xmltree)
+
+    adjust_param_offsets = None
+    if params.AdjustableParameterOffsets.exists(sicd_xmltree):
+        adjust_param_offsets = params.AdjustableParameterOffsets.from_xml(sicd_xmltree)
+
     return calc.scene_to_image(
         proj_metadata,
         scene_points,
+        adjust_param_offsets=adjust_param_offsets,
         delta_gp_s2i=delta_gp_s2i,
         maxiter=maxiter,
         bistat_delta_gp_gpp=bistat_delta_gp_gpp,
@@ -187,6 +199,13 @@ def image_to_constant_hae_surface(
     """
     proj_metadata = params.MetadataParams.from_xml(sicd_xmltree)
     projection_sets = calc.compute_projection_sets(proj_metadata, image_grid_locations)
+
+    if params.AdjustableParameterOffsets.exists(sicd_xmltree):
+        adjust_param_offsets = params.AdjustableParameterOffsets.from_xml(sicd_xmltree)
+        projection_sets = calc.compute_and_apply_offsets(
+            proj_metadata, projection_sets, adjust_param_offsets
+        )
+
     return calc.r_rdot_to_constant_hae_surface(
         proj_metadata,
         projection_sets,

--- a/tests/standards/sicd/test_projection.py
+++ b/tests/standards/sicd/test_projection.py
@@ -1,12 +1,14 @@
 import dataclasses
 import pathlib
 
+import lxml.builder
 import lxml.etree
 import numpy as np
 import pytest
 
 import sarkit.standards.geocoords
 import sarkit.standards.sicd.projection as ss_proj
+import sarkit.standards.xml
 
 DATAPATH = pathlib.Path(__file__).parents[3] / "data"
 
@@ -335,3 +337,97 @@ def test_r_rdot_from_plane(mono_and_bi_proj_metadata):
     )
 
     assert all([r_tgt_coa, rdot_tgt_coa])
+
+
+@pytest.fixture(
+    params=[
+        DATAPATH / "example-sicd-1.3.0.xml",
+        DATAPATH / "example-sicd-1.4.0.xml",
+    ]
+)
+def proj_metadata_with_error(request):
+    etree = lxml.etree.parse(request.param)
+    root = etree.getroot()
+
+    elem_ns = lxml.etree.QName(root).namespace
+    em = lxml.builder.ElementMaker(namespace=elem_ns, nsmap={None: elem_ns})
+
+    if etree.findtext("{*}CollectionInfo/{*}CollectType") == "MONOSTATIC":
+        root.append(
+            em.ErrorStatistics(
+                em.AdjustableParameterOffsets(
+                    sarkit.standards.xml.XyzType().make_elem(
+                        "ARPPosSCPCOA", [10000, 11000, 12000]
+                    ),
+                    sarkit.standards.xml.XyzType().make_elem(
+                        "ARPVel", [1500, 1600, 1700]
+                    ),
+                    em.TxTimeSCPCOA("10.0"),
+                    em.RcvTimeSCPCOA("11.0"),
+                )
+            )
+        )
+    else:
+        root.append(
+            em.ErrorStatistics(
+                em.BistaticAdjustableParameterOffsets(
+                    em.TxPlatform(
+                        sarkit.standards.xml.XyzType().make_elem(
+                            "APCPosSCPCOA", [10000, 11000, 12000]
+                        ),
+                        sarkit.standards.xml.XyzType().make_elem(
+                            "APCVel", [1500, 1600, 1700]
+                        ),
+                        em.ClockFreqSF("10.0"),
+                        em.TimeSCPCOA("11.0"),
+                    ),
+                    em.RcvPlatform(
+                        sarkit.standards.xml.XyzType().make_elem(
+                            "APCPosSCPCOA", [20000, 21000, 22000]
+                        ),
+                        sarkit.standards.xml.XyzType().make_elem(
+                            "APCVel", [2500, 2600, 2700]
+                        ),
+                        em.ClockFreqSF("20.0"),
+                        em.TimeSCPCOA("21.0"),
+                    ),
+                )
+            )
+        )
+
+    meta = ss_proj.MetadataParams.from_xml(etree)
+    apos = ss_proj.AdjustableParameterOffsets.from_xml(etree)
+
+    return meta, apos
+
+
+def test_apo(proj_metadata_with_error):
+    meta, apos = proj_metadata_with_error
+    proj_set = ss_proj.compute_projection_sets(meta, [0, 0])
+    adjust_proj_set = ss_proj.compute_and_apply_offsets(meta, proj_set, apos)
+
+    # Make sure things that were supposed to change did
+    if meta.is_monostatic():
+        assert adjust_proj_set.t_COA == proj_set.t_COA
+        assert np.all(
+            adjust_proj_set.ARP_COA - proj_set.ARP_COA == [10000, 11000, 12000]
+        )
+        assert np.all(
+            adjust_proj_set.VARP_COA - proj_set.VARP_COA == [1500, 1600, 1700]
+        )
+        assert adjust_proj_set.R_COA != proj_set.R_COA
+        assert adjust_proj_set.Rdot_COA == proj_set.Rdot_COA
+    else:
+        assert adjust_proj_set.t_COA == proj_set.t_COA
+        assert adjust_proj_set.tx_COA - proj_set.tx_COA == pytest.approx(11, abs=0.1)
+        assert adjust_proj_set.tr_COA - proj_set.tr_COA == pytest.approx(21, abs=0.1)
+        assert np.all(adjust_proj_set.Xmt_COA != proj_set.Xmt_COA)
+        assert np.all(
+            adjust_proj_set.VXmt_COA - proj_set.VXmt_COA == [1500, 1600, 1700]
+        )
+        assert np.all(adjust_proj_set.Rcv_COA != proj_set.Rcv_COA)
+        assert np.all(
+            adjust_proj_set.VRcv_COA - proj_set.VRcv_COA == [2500, 2600, 2700]
+        )
+        assert adjust_proj_set.R_Avg_COA != proj_set.R_Avg_COA
+        assert adjust_proj_set.Rdot_Avg_COA != proj_set.Rdot_Avg_COA


### PR DESCRIPTION
Implement the equations from section `8 Adjustable Parameters` from NGA.STND.0024-3_1.4.0_SICD_IPDD_2024_05_01

The names were chosen to closely match the document for traceability.  Included a smoke test for monostatic and bistatic cases.

<details>
<summary>Tests pass</summary>

```

$ pdm run nox
nox > Running session lint
nox > Creating virtual environment (virtualenv) using python in .nox/lint
nox > pdm sync --prod -G dev-lint
INFO: Inside an active virtualenv /home/vscuser/repos/sarkit/.nox/lint, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 6 to add, 0 to update, 0 to remove

  ✔ Install mypy-extensions 1.0.0 successful
  ✔ Install typing-extensions 4.12.2 successful
  ✔ Install lxml 5.3.0 successful
  ✔ Install mypy 1.14.1 successful
  ✔ Install ruff 0.9.2 successful
  ✔ Install numpy 2.1.3 successful
  ✔ Install sarkit 0.1.1.dev1+g2b6af5a successful

  0:00:06 🎉 All complete! 6/6
nox > ruff check
All checks passed!
nox > ruff format --diff
83 files already formatted
nox > mypy /home/vscuser/repos/sarkit/sarkit
Success: no issues found in 48 source files
nox > Session lint was successful.
nox > Running session data
nox > Creating virtual environment (virtualenv) using python in .nox/data
nox > pdm sync --prod
INFO: Inside an active virtualenv /home/vscuser/repos/sarkit/.nox/data, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 2 to add, 0 to update, 0 to remove

  ✔ Install lxml 5.3.0 successful
  ✔ Install numpy 2.1.3 successful
  ✔ Install sarkit 0.1.1.dev1+g2b6af5a successful

  0:00:02 🎉 All complete! 2/2
nox > python data/syntax_only/sicd/make_syntax_only_sicd_xmls.py --check
nox > python data/syntax_only/cphd/make_syntax_only_cphd_xmls.py --check
nox > Session data was successful.
nox > Running session test
nox > Creating virtual environment (virtualenv) using python in .nox/test
nox > Session test was successful.
nox > Running session test_standards
nox > Creating virtual environment (virtualenv) using python in .nox/test_standards
nox > pdm sync --prod -G dev-test
INFO: Inside an active virtualenv /home/vscuser/repos/sarkit/.nox/test_standards, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 6 to add, 0 to update, 0 to remove

  ✔ Install iniconfig 2.0.0 successful
  ✔ Install pluggy 1.5.0 successful
  ✔ Install packaging 24.2 successful
  ✔ Install pytest 8.3.4 successful
  ✔ Install lxml 5.3.0 successful
  ✔ Install numpy 2.1.3 successful
  ✔ Install sarkit 0.1.1.dev1+g2b6af5a successful

  0:00:02 🎉 All complete! 6/6
nox > pytest tests/standards
==================================================== test session starts =====================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/vscuser/repos/sarkit
configfile: pyproject.toml
collected 118 items                                                                                                          

tests/standards/cphd/test_io.py ..........................                                                             [ 22%]
tests/standards/cphd/test_xml.py ...                                                                                   [ 24%]
tests/standards/crsd/test_io.py .                                                                                      [ 25%]
tests/standards/crsd/test_xml.py .                                                                                     [ 26%]
tests/standards/sicd/test_io.py ........                                                                               [ 33%]
tests/standards/sicd/test_projection.py ...........................                                                    [ 55%]
tests/standards/sicd/test_xml.py ........                                                                              [ 62%]
tests/standards/sidd/test_io.py ......                                                                                 [ 67%]
tests/standards/sidd/test_xml.py ........                                                                              [ 74%]
tests/standards/test_geocoords.py ......                                                                               [ 79%]
tests/standards/test_sicd_projections.py .......                                                                       [ 85%]
tests/standards/test_xml.py .................                                                                          [100%]

==================================================== 118 passed in 6.22s =====================================================
nox > Session test_standards was successful.
nox > Running session test_processing
nox > Creating virtual environment (virtualenv) using python in .nox/test_processing
nox > pdm sync --prod -G dev-test -G processing
INFO: Inside an active virtualenv /home/vscuser/repos/sarkit/.nox/test_processing, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 8 to add, 0 to update, 0 to remove

  ✔ Install pluggy 1.5.0 successful
  ✔ Install iniconfig 2.0.0 successful
  ✔ Install pytest 8.3.4 successful
  ✔ Install packaging 24.2 successful
  ✔ Install lxml 5.3.0 successful
  ✔ Install numba 0.61.0 successful
  ✔ Install numpy 2.1.3 successful
  ✔ Install llvmlite 0.44.0 successful
  ✔ Install sarkit 0.1.1.dev1+g2b6af5a successful

  0:00:04 🎉 All complete! 8/8
nox > pytest tests/processing
==================================================== test session starts =====================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/vscuser/repos/sarkit
configfile: pyproject.toml
collected 6 items                                                                                                            

tests/processing/test_deskew.py ...                                                                                    [ 50%]
tests/processing/test_pixel_type.py ..                                                                                 [ 83%]
tests/processing/test_subimage.py .                                                                                    [100%]

===================================================== 6 passed in 3.90s ======================================================
nox > Session test_processing was successful.
nox > Running session test_verification
nox > Creating virtual environment (virtualenv) using python in .nox/test_verification
nox > pdm sync --prod -G dev-test -G verification
INFO: Inside an active virtualenv /home/vscuser/repos/sarkit/.nox/test_verification, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 7 to add, 0 to update, 0 to remove

  ✔ Install pluggy 1.5.0 successful
  ✔ Install packaging 24.2 successful
  ✔ Install iniconfig 2.0.0 successful
  ✔ Install pytest 8.3.4 successful
  ✔ Install shapely 2.0.6 successful
  ✔ Install lxml 5.3.0 successful
  ✔ Install numpy 2.1.3 successful
  ✔ Install sarkit 0.1.1.dev1+g2b6af5a successful

  0:00:03 🎉 All complete! 7/7
nox > pytest tests/verification
==================================================== test session starts =====================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/vscuser/repos/sarkit
configfile: pyproject.toml
collected 815 items                                                                                                          

tests/verification/test_consistency.py ........                                                                        [  0%]
tests/verification/test_cphd_consistency.py .......................................................................... [ 10%]
..................                                                                                                     [ 12%]
tests/verification/test_crsd_consistency.py .......................................................................... [ 21%]
...................................................................................................................... [ 35%]
.........ssss...........................................sss........................sssssssssssssssssssssssssssssss.... [ 50%]
.......sssss......ss.ss.ss............sssssss....................ss..........ssss....sssssssssssssssssssssssssssssssss [ 64%]
ssssssssss.................................................................ssss...........ss.ss.ss.....sssssss........ [ 79%]
ss................s.................................................................                                   [ 89%]
tests/verification/test_sicd_consistency.py .......................................................................... [ 98%]
...........                                                                                                            [100%]

====================================================== warnings summary ======================================================
tests/verification/test_sicd_consistency.py::test_smoketest[xml_file4]
  /home/vscuser/repos/sarkit/sarkit/verification/sicd_consistency.py:52: RuntimeWarning: invalid value encountered in divide
    return vec / np.linalg.norm(vec, axis=axis, keepdims=True)

tests/verification/test_sicd_consistency.py::test_smoketest[xml_file6]
  /home/vscuser/repos/sarkit/sarkit/standards/sicd/xml.py:708: RuntimeWarning: invalid value encountered in arccos
    dca_xmt = np.arccos(-rdot_xmt_scp / vxmt_m)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================= 690 passed, 125 skipped, 2 warnings in 11.31s ========================================
nox > Session test_verification was successful.
nox > Ran multiple sessions:
nox > * lint: success
nox > * data: success
nox > * test: success
nox > * test_standards: success
nox > * test_processing: success
nox > * test_verification: success

```

>/details>