### PR TITLE
Bugfix: Projecting Multiple Grid Locations

### DIFF
--- a/sarkit/standards/sicd/projection/calc.py
+++ b/sarkit/standards/sicd/projection/calc.py
@@ -401,7 +401,7 @@ def r_rdot_from_rgazim_rgazcomp(
     )
 
     # Compute the range and range rate to the target at COA
-    r_tgt_coa = r_scp + rg_tgts
+    r_tgt_coa = (r_scp + rg_tgts)[..., np.newaxis]
     rdot_tgt_coa = rdot_scp + delta_rdot[..., np.newaxis]
     return r_tgt_coa, rdot_tgt_coa
 
@@ -437,8 +437,16 @@ def r_rdot_from_rgzero(
     delta_t_coa = t_coa - t_ca
 
     # Compute the range and range rate relative to the ARP at COA
-    r_tgt_coa = np.sqrt(r_ca**2 + drsf * varp_ca_mag**2 * delta_t_coa**2)
-    rdot_tgt_coa = drsf / r_tgt_coa * varp_ca_mag**2 * delta_t_coa
+    r_tgt_coa = np.sqrt(
+        r_ca[..., np.newaxis] ** 2
+        + drsf[..., np.newaxis] * varp_ca_mag**2 * delta_t_coa[..., np.newaxis] ** 2
+    )
+    rdot_tgt_coa = (
+        drsf[..., np.newaxis]
+        / r_tgt_coa
+        * varp_ca_mag**2
+        * delta_t_coa[..., np.newaxis]
+    )
     return r_tgt_coa, rdot_tgt_coa
 
 
@@ -482,7 +490,9 @@ def r_rdot_from_plane(
 
     # Compute the image plane point for image grid location (xrowTGT, ycolTGT), IP_TGT
     ip_tgt = (
-        proj_metadata.SCP + (x_tgt * proj_metadata.uRow) + (y_tgt * proj_metadata.uCol)
+        proj_metadata.SCP
+        + (x_tgt[..., np.newaxis] * proj_metadata.uRow)
+        + (y_tgt[..., np.newaxis] * proj_metadata.uCol)
     )
 
     # Compute the range and range rate to the image plane point IP_TGT relative to the COA positions and velocities

--- a/tests/standards/sicd/test_projection.py
+++ b/tests/standards/sicd/test_projection.py
@@ -33,6 +33,11 @@ def mono_and_bi_proj_metadata(request):
     return ss_proj.MetadataParams.from_xml(etree)
 
 
+@pytest.fixture
+def image_grid_locations():
+    return np.random.default_rng(12345).uniform(size=(3, 4, 5, 2))
+
+
 def test_metadata_params():
     all_attrs = set()
     set_attrs = set()
@@ -251,7 +256,7 @@ def test_r_rdot_to_hae_surface(mdata_name, scalar_hae, request):
     assert np.array_equal(bad_index, mismatched_index)
 
 
-def test_r_rdot_from_rgazim_rgazcomp(example_proj_metadata):
+def test_r_rdot_from_rgazim_rgazcomp(example_proj_metadata, image_grid_locations):
     example_proj_metadata.IFA = "RGAZCOMP"
     example_proj_metadata.Grid_Type = "RGAZIM"
     example_proj_metadata.AzSF = 2.0
@@ -260,15 +265,17 @@ def test_r_rdot_from_rgazim_rgazcomp(example_proj_metadata):
     )
     r_tgt_coa, rdot_tgt_coa = ss_proj.compute_coa_r_rdot(
         example_proj_metadata,
-        [0, 0],
+        image_grid_locations,
         example_proj_metadata.t_SCP_COA,
         computed_pos_vel,
     )
 
-    assert all([r_tgt_coa, rdot_tgt_coa])
+    assert r_tgt_coa.shape[-1] == 1
+    assert rdot_tgt_coa.shape[-1] == 1
+    assert np.all([r_tgt_coa, rdot_tgt_coa])
 
 
-def test_r_rdot_from_rgzero(example_proj_metadata):
+def test_r_rdot_from_rgzero(example_proj_metadata, image_grid_locations):
     example_proj_metadata.IFA = "RMA"
     example_proj_metadata.Grid_Type = "RGZERO"
     example_proj_metadata.cT_CA = np.array([1.0, 0.0001])
@@ -280,45 +287,51 @@ def test_r_rdot_from_rgzero(example_proj_metadata):
     )
     r_tgt_coa, rdot_tgt_coa = ss_proj.compute_coa_r_rdot(
         example_proj_metadata,
-        [0, 0],
+        image_grid_locations,
         example_proj_metadata.t_SCP_COA,
         computed_pos_vel,
     )
 
-    assert all([r_tgt_coa, rdot_tgt_coa])
+    assert r_tgt_coa.shape[-1] == 1
+    assert rdot_tgt_coa.shape[-1] == 1
+    assert np.all([r_tgt_coa, rdot_tgt_coa])
 
 
-def test_r_rdot_from_xrgycr(mono_and_bi_proj_metadata):
+def test_r_rdot_from_xrgycr(mono_and_bi_proj_metadata, image_grid_locations):
     mono_and_bi_proj_metadata.Grid_Type = "XRGYCR"
     computed_pos_vel = ss_proj.compute_coa_pos_vel(
         mono_and_bi_proj_metadata, mono_and_bi_proj_metadata.t_SCP_COA
     )
     r_tgt_coa, rdot_tgt_coa = ss_proj.compute_coa_r_rdot(
         mono_and_bi_proj_metadata,
-        [0, 0],
+        image_grid_locations,
         mono_and_bi_proj_metadata.t_SCP_COA,
         computed_pos_vel,
     )
 
-    assert all([r_tgt_coa, rdot_tgt_coa])
+    assert r_tgt_coa.shape[-1] == 1
+    assert rdot_tgt_coa.shape[-1] == 1
+    assert np.all([r_tgt_coa, rdot_tgt_coa])
 
 
-def test_r_rdot_from_xctyat(mono_and_bi_proj_metadata):
+def test_r_rdot_from_xctyat(mono_and_bi_proj_metadata, image_grid_locations):
     mono_and_bi_proj_metadata.Grid_Type = "XCTYAT"
     computed_pos_vel = ss_proj.compute_coa_pos_vel(
         mono_and_bi_proj_metadata, mono_and_bi_proj_metadata.t_SCP_COA
     )
     r_tgt_coa, rdot_tgt_coa = ss_proj.compute_coa_r_rdot(
         mono_and_bi_proj_metadata,
-        [0, 0],
+        image_grid_locations,
         mono_and_bi_proj_metadata.t_SCP_COA,
         computed_pos_vel,
     )
 
-    assert all([r_tgt_coa, rdot_tgt_coa])
+    assert r_tgt_coa.shape[-1] == 1
+    assert rdot_tgt_coa.shape[-1] == 1
+    assert np.all([r_tgt_coa, rdot_tgt_coa])
 
 
-def test_r_rdot_from_plane(mono_and_bi_proj_metadata):
+def test_r_rdot_from_plane(mono_and_bi_proj_metadata, image_grid_locations):
     mono_and_bi_proj_metadata.IFA = "RMA"
     mono_and_bi_proj_metadata.Grid_Type = "PLANE"
     mono_and_bi_proj_metadata.cT_CA = np.array([1.0, 0.0001])
@@ -329,9 +342,11 @@ def test_r_rdot_from_plane(mono_and_bi_proj_metadata):
     )
     r_tgt_coa, rdot_tgt_coa = ss_proj.compute_coa_r_rdot(
         mono_and_bi_proj_metadata,
-        [0, 0],
+        image_grid_locations,
         mono_and_bi_proj_metadata.t_SCP_COA,
         computed_pos_vel,
     )
 
-    assert all([r_tgt_coa, rdot_tgt_coa])
+    assert r_tgt_coa.shape[-1] == 1
+    assert rdot_tgt_coa.shape[-1] == 1
+    assert np.all([r_tgt_coa, rdot_tgt_coa])

--- a/tests/standards/sicd/test_projection.py
+++ b/tests/standards/sicd/test_projection.py
@@ -349,7 +349,9 @@ def test_r_rdot_from_plane(mono_and_bi_proj_metadata, image_grid_locations):
         computed_pos_vel,
     )
 
-    assert all([r_tgt_coa, rdot_tgt_coa])
+    assert r_tgt_coa.shape[-1] == 1
+    assert rdot_tgt_coa.shape[-1] == 1
+    assert np.all([r_tgt_coa, rdot_tgt_coa])
 
 
 @pytest.fixture(
@@ -444,6 +446,3 @@ def test_apo(proj_metadata_with_error):
         )
         assert adjust_proj_set.R_Avg_COA != proj_set.R_Avg_COA
         assert adjust_proj_set.Rdot_Avg_COA != proj_set.Rdot_Avg_COA
-    assert r_tgt_coa.shape[-1] == 1
-    assert rdot_tgt_coa.shape[-1] == 1
-    assert np.all([r_tgt_coa, rdot_tgt_coa])


### PR DESCRIPTION
This is meant to address the issues @mstewart-vsc found while trying to use the projection code.  I  duplicated the problem by simply changing the test code to project multiple points.  Here's a snip from error that is produced.

![Error2](https://github.com/user-attachments/assets/696bc8b9-8c18-4230-8316-381acdb0c6c9)

I used `np.newaxis` to orient the various components to produce the correct output and improved the unit tests to use multi-dimensional input.

<details>
<summary>New Tests Pass</summary>

```

$ pdm run nox
nox > Running session lint
nox > Creating virtual environment (virtualenv) using python in .nox/lint
nox > pdm sync --prod -G dev-lint
INFO: Inside an active virtualenv /home/vscuser/repos/ext_sarkit/.nox/lint, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 6 to add, 0 to update, 0 to remove

  ✔ Install typing-extensions 4.12.2 successful
  ✔ Install mypy-extensions 1.0.0 successful
  ✔ Install lxml 5.3.0 successful
  ✔ Install mypy 1.14.1 successful
  ✔ Install ruff 0.8.5 successful
  ✔ Install numpy 2.0.2 successful
  ✔ Install sarkit 0.1.1.dev1+g786c86e successful

  0:00:30 🎉 All complete! 6/6
nox > ruff check
All checks passed!
nox > ruff format --diff
warning: The following rule may cause conflicts when used with the formatter: `ISC001`. To avoid unexpected behavior, we recommend disabling this rule, either by removing it from the `select` or `extend-select` configuration, or adding it to the `ignore` configuration.
83 files already formatted
nox > mypy /home/vscuser/repos/ext_sarkit/sarkit
Success: no issues found in 48 source files
nox > Session lint was successful.
nox > Running session data
nox > Creating virtual environment (virtualenv) using python in .nox/data
nox > pdm sync --prod
INFO: Inside an active virtualenv /home/vscuser/repos/ext_sarkit/.nox/data, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 2 to add, 0 to update, 0 to remove

  ✔ Install lxml 5.3.0 successful
  ✔ Install numpy 2.0.2 successful
  ✔ Install sarkit 0.1.1.dev1+g786c86e successful

  0:00:02 🎉 All complete! 2/2
nox > python data/syntax_only/sicd/make_syntax_only_sicd_xmls.py --check
nox > python data/syntax_only/cphd/make_syntax_only_cphd_xmls.py --check
nox > Session data was successful.
nox > Running session test
nox > Creating virtual environment (virtualenv) using python in .nox/test
nox > Session test was successful.
nox > Running session test_standards
nox > Creating virtual environment (virtualenv) using python in .nox/test_standards
nox > pdm sync --prod -G dev-test
INFO: Inside an active virtualenv /home/vscuser/repos/ext_sarkit/.nox/test_standards, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 6 to add, 0 to update, 0 to remove

  ✔ Install packaging 24.2 successful
  ✔ Install iniconfig 2.0.0 successful
  ✔ Install pluggy 1.5.0 successful
  ✔ Install pytest 8.3.4 successful
  ✔ Install lxml 5.3.0 successful
  ✔ Install numpy 2.0.2 successful
  ✔ Install sarkit 0.1.1.dev1+g786c86e successful

  0:00:02 🎉 All complete! 6/6
nox > pytest tests/standards
==================================================== test session starts =====================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/vscuser/repos/ext_sarkit
configfile: pyproject.toml
collected 116 items                                                                                                          

tests/standards/cphd/test_io.py ..........................                                                             [ 22%]
tests/standards/cphd/test_xml.py ...                                                                                   [ 25%]
tests/standards/crsd/test_io.py .                                                                                      [ 25%]
tests/standards/crsd/test_xml.py .                                                                                     [ 26%]
tests/standards/sicd/test_io.py ........                                                                               [ 33%]
tests/standards/sicd/test_projection.py .........................                                                      [ 55%]
tests/standards/sicd/test_xml.py ........                                                                              [ 62%]
tests/standards/sidd/test_io.py ......                                                                                 [ 67%]
tests/standards/sidd/test_xml.py ........                                                                              [ 74%]
tests/standards/test_geocoords.py ......                                                                               [ 79%]
tests/standards/test_sicd_projections.py .......                                                                       [ 85%]
tests/standards/test_xml.py .................                                                                          [100%]

==================================================== 116 passed in 7.11s =====================================================
nox > Session test_standards was successful.
nox > Running session test_processing
nox > Creating virtual environment (virtualenv) using python in .nox/test_processing
nox > pdm sync --prod -G dev-test -G processing
INFO: Inside an active virtualenv /home/vscuser/repos/ext_sarkit/.nox/test_processing, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 8 to add, 0 to update, 0 to remove

  ✔ Install iniconfig 2.0.0 successful
  ✔ Install pluggy 1.5.0 successful
  ✔ Install packaging 24.2 successful
  ✔ Install pytest 8.3.4 successful
  ✔ Install lxml 5.3.0 successful
  ✔ Install numpy 2.0.2 successful
  ✔ Install numba 0.60.0 successful
  ✔ Install llvmlite 0.43.0 successful
  ✔ Install sarkit 0.1.1.dev1+g786c86e successful

  0:00:41 🎉 All complete! 8/8
nox > pytest tests/processing
==================================================== test session starts =====================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/vscuser/repos/ext_sarkit
configfile: pyproject.toml
collected 6 items                                                                                                            

tests/processing/test_deskew.py ...                                                                                    [ 50%]
tests/processing/test_pixel_type.py ..                                                                                 [ 83%]
tests/processing/test_subimage.py .                                                                                    [100%]

===================================================== 6 passed in 3.70s ======================================================
nox > Session test_processing was successful.
nox > Running session test_verification
nox > Creating virtual environment (virtualenv) using python in .nox/test_verification
nox > pdm sync --prod -G dev-test -G verification
INFO: Inside an active virtualenv /home/vscuser/repos/ext_sarkit/.nox/test_verification, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 7 to add, 0 to update, 0 to remove

  ✔ Install packaging 24.2 successful
  ✔ Install pluggy 1.5.0 successful
  ✔ Install iniconfig 2.0.0 successful
  ✔ Install pytest 8.3.4 successful
  ✔ Install lxml 5.3.0 successful
  ✔ Install shapely 2.0.6 successful
  ✔ Install numpy 2.0.2 successful
  ✔ Install sarkit 0.1.1.dev1+g786c86e successful

  0:00:03 🎉 All complete! 7/7
nox > pytest tests/verification
==================================================== test session starts =====================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/vscuser/repos/ext_sarkit
configfile: pyproject.toml
collected 815 items                                                                                                          

tests/verification/test_consistency.py ........                                                                        [  0%]
tests/verification/test_cphd_consistency.py .......................................................................... [ 10%]
..................                                                                                                     [ 12%]
tests/verification/test_crsd_consistency.py .......................................................................... [ 21%]
...................................................................................................................... [ 35%]
.........ssss...........................................sss........................sssssssssssssssssssssssssssssss.... [ 50%]
.......sssss......ss.ss.ss............sssssss....................ss..........ssss....sssssssssssssssssssssssssssssssss [ 64%]
ssssssssss.................................................................ssss...........ss.ss.ss.....sssssss........ [ 79%]
ss................s.................................................................                                   [ 89%]
tests/verification/test_sicd_consistency.py .......................................................................... [ 98%]
...........                                                                                                            [100%]

====================================================== warnings summary ======================================================
tests/verification/test_sicd_consistency.py::test_smoketest[xml_file4]
  /home/vscuser/repos/ext_sarkit/sarkit/verification/sicd_consistency.py:52: RuntimeWarning: invalid value encountered in divide
    return vec / np.linalg.norm(vec, axis=axis, keepdims=True)

tests/verification/test_sicd_consistency.py::test_smoketest[xml_file6]
  /home/vscuser/repos/ext_sarkit/sarkit/standards/sicd/xml.py:708: RuntimeWarning: invalid value encountered in arccos
    dca_xmt = np.arccos(-rdot_xmt_scp / vxmt_m)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================== 690 passed, 125 skipped, 2 warnings in 9.19s ========================================
nox > Session test_verification was successful.
nox > Ran multiple sessions:
nox > * lint: success
nox > * data: success
nox > * test: success
nox > * test_standards: success
nox > * test_processing: success
nox > * test_verification: success

```

</details>