### PR TITLE
verification: move common CLI args/calls to base class; add NO_COLOR args

### DIFF
--- a/sarkit/verification/cphd_consistency.py
+++ b/sarkit/verification/cphd_consistency.py
@@ -11,13 +11,6 @@ CLI
 .. autoprogram:: sarkit.verification.cphd_consistency:_parser()
    :prog: cphd_consistency.py
 
-Consistency Object
-==================
-
-.. autosummary::
-
-    CphdConsistency
-
 """
 
 import argparse
@@ -1934,13 +1927,6 @@ def _parser():
     )
     parser.add_argument("file_name")
     parser.add_argument(
-        "-v",
-        "--verbose",
-        default=0,
-        action="count",
-        help="Increase verbosity (can be specified more than once >4 doesn't help)",
-    )
-    parser.add_argument(
         "--schema",
         type=pathlib.Path,
         help="Use a supplied schema file (attempts version-specific schema if omitted)",
@@ -1958,15 +1944,7 @@ def _parser():
         action="store_true",
         help="Check the signal data for NaN and +/- Inf",
     )
-    parser.add_argument(
-        "--ignore",
-        action="append",
-        metavar="PATTERN",
-        help=(
-            "Skip any check matching PATTERN at the beginning of its name. Can be specified more than"
-            " once."
-        ),
-    )
+    CphdConsistency.add_cli_args(parser)
     return parser
 
 
@@ -1982,16 +1960,7 @@ def main(args=None):
         version=config.version,
         check_signal_data=config.signal_data,
     )
-    cphd_con.check(ignore_patterns=config.ignore)
-    failures = cphd_con.failures()
-    cphd_con.print_result(
-        fail_detail=config.verbose >= 1,
-        include_passed_asserts=config.verbose >= 2,
-        include_passed_checks=config.verbose >= 3,
-        skip_detail=config.verbose >= 4,
-    )
-
-    return bool(failures)
+    return cphd_con.run_cli(config)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/sarkit/verification/sicd_consistency.py
+++ b/sarkit/verification/sicd_consistency.py
@@ -11,13 +11,6 @@ CLI
 .. autoprogram:: sarkit.verification.sicd_consistency:_parser()
    :prog: sicd_consistency.py
 
-Consistency Object
-==================
-
-.. autosummary::
-
-    SicdConsistency
-
 """
 
 import argparse
@@ -1899,13 +1892,6 @@ def _parser():
     )
     parser.add_argument("file_name")
     parser.add_argument(
-        "-v",
-        "--verbose",
-        default=0,
-        action="count",
-        help="Increase verbosity (can be specified more than once; >4 doesn't help)",
-    )
-    parser.add_argument(
         "--schema",
         type=pathlib.Path,
         help="Use a supplied schema file (attempts version-specific schema if omitted)",
@@ -1918,16 +1904,7 @@ def _parser():
             "Attempts auto-detection if omitted. Required if using --schema"
         ),
     )
-    parser.add_argument(
-        "--ignore",
-        action="extend",
-        nargs="+",
-        metavar="PATTERN",
-        help=(
-            "Skip any check matching PATTERN at the beginning of its name. "
-            "Can be specified more than once."
-        ),
-    )
+    SicdConsistency.add_cli_args(parser)
     return parser
 
 
@@ -1940,16 +1917,7 @@ def main(args=None):
     sicd_con = SicdConsistency.from_file(
         filename=config.file_name, schema=config.schema, version=config.version
     )
-    sicd_con.check(ignore_patterns=config.ignore)
-    failures = sicd_con.failures()
-    sicd_con.print_result(
-        fail_detail=config.verbose >= 1,
-        include_passed_asserts=config.verbose >= 2,
-        include_passed_checks=config.verbose >= 3,
-        skip_detail=config.verbose >= 4,
-    )
-
-    return bool(failures)
+    return sicd_con.run_cli(config)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/verification/test_crsd_consistency.py
+++ b/tests/verification/test_crsd_consistency.py
@@ -179,7 +179,7 @@ def example_crsdsar_file(tmp_path_factory):
         cw.write_ppp(sequence_id, ppps)
         cw.write_pvp(channel_id, pvps)
         cw.write_signal(channel_id, signal)
-    assert not main([str(tmp_crsd), "--signal-data", "-vvv"])
+    assert not main([str(tmp_crsd), "-vvv"])
     yield tmp_crsd
 
 
@@ -240,7 +240,7 @@ def example_crsdtx_file(tmp_path_factory, example_crsdsar_file):
     )
     with open(tmp_crsd, "wb") as f, crsd_io.CrsdWriter(f, new_plan) as cw:
         cw.write_ppp(sequence_id, ppps)
-    assert not main([str(tmp_crsd), "--signal-data", "-vvv"])
+    assert not main([str(tmp_crsd), "-vvv"])
     yield tmp_crsd
 
 
@@ -309,7 +309,7 @@ def example_crsdrcv_file(tmp_path_factory, example_crsdsar_file):
     with open(tmp_crsd, "wb") as f, crsd_io.CrsdWriter(f, newplan) as cw:
         cw.write_pvp(channel_id, new_pvps)
         cw.write_signal(channel_id, signal)
-    assert not main([str(tmp_crsd), "--signal-data", "-vvv"])
+    assert not main([str(tmp_crsd), "-vvv"])
     yield tmp_crsd
 
 


### PR DESCRIPTION
# Description
While saving the output of a consistency checker to a text file, I wanted to disable the color output. This PR adds the ability to control this to the consistency checkers explicitly and via [NO_COLOR](https://no-color.org/):

![image](https://github.com/user-attachments/assets/fce3a0a9-e429-47ab-ab30-365f34a574b7)

## Notes
- moves common CLI stuff into `consistency.py`
- remove `check_signal_data` from `crsd_consistency` as it is currently unused