### PR TITLE
Improve IO API

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -53,6 +53,16 @@ add_module_names = False
 
 # doctest
 doctest_test_doctest_blocks = ""  # don't test unmarked blocks
+doctest_global_setup = """
+import pathlib
+import tempfile
+tmpdir = tempfile.TemporaryDirectory()
+tmppath = pathlib.Path(tmpdir.name)
+"""
+doctest_global_cleanup = """
+tmpdir.cleanup()
+"""
+doctest_show_successes = False
 
 # intersphinx
 intersphinx_mapping = {
@@ -66,4 +76,5 @@ numpydoc_xref_param_type = True
 numpydoc_xref_ignore = {"optional", "of"}
 numpydoc_validation_checks = {
     "PR10",  # requires a space before the colon separating the parameter name and type
+    "GL07",  # Sections are in the wrong order
 }

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -66,16 +66,11 @@ is often a small fraction of the size of a SAR data file.
 
 .. testsetup::
 
-   import pathlib
-   import tempfile
-
    import lxml.etree
    import numpy as np
 
    import sarkit.sicd as sksicd
 
-   tmpdir = tempfile.TemporaryDirectory()
-   tmppath = pathlib.Path(tmpdir.name)
    example_sicd = tmppath / "example.sicd"
    sec = {"security": {"clas": "U"}}
    parser = lxml.etree.XMLParser(remove_blank_text=True)
@@ -88,11 +83,6 @@ is often a small fraction of the size of a SAR data file.
    )
    with open(example_sicd, "wb") as f, sksicd.NitfWriter(f, sicd_meta):
        pass  # don't currently care about the pixels
-
-
-.. testcleanup::
-
-   tmpdir.cleanup()
 
 .. doctest::
 

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -27,37 +27,38 @@ Some features require additional dependencies which can be installed using packa
 
 Reading and writing files
 =========================
-SARkit provides reader/writer classes that are intended to be used as context managers and plan classes that are used to
-describe file contents and metadata prior to writing.
+SARkit provides reader/writer classes that are intended to be used as context managers and metadata classes that are
+used to describe settable metadata.
 
 .. list-table::
 
    * - Format
      - Reader
-     - Plan
+     - Metadata
      - Writer
    * - ⛔ CRSD [Draft] ⛔
-     - :py:class:`~sarkit.crsd.CrsdReader`
-     - :py:class:`~sarkit.crsd.CrsdPlan`
-     - :py:class:`~sarkit.crsd.CrsdWriter`
+     - :py:class:`~sarkit.crsd.Reader`
+     - :py:class:`~sarkit.crsd.Metadata`
+     - :py:class:`~sarkit.crsd.Writer`
    * - CPHD
-     - :py:class:`~sarkit.cphd.CphdReader`
-     - :py:class:`~sarkit.cphd.CphdPlan`
-     - :py:class:`~sarkit.cphd.CphdWriter`
+     - :py:class:`~sarkit.cphd.Reader`
+     - :py:class:`~sarkit.cphd.Metadata`
+     - :py:class:`~sarkit.cphd.Writer`
    * - SICD
-     - :py:class:`~sarkit.sicd.SicdNitfReader`
-     - :py:class:`~sarkit.sicd.SicdNitfPlan`
-     - :py:class:`~sarkit.sicd.SicdNitfWriter`
+     - :py:class:`~sarkit.sicd.NitfReader`
+     - :py:class:`~sarkit.sicd.NitfMetadata`
+     - :py:class:`~sarkit.sicd.NitfWriter`
    * - SIDD
-     - :py:class:`~sarkit.sidd.SiddNitfReader`
-     - :py:class:`~sarkit.sidd.SiddNitfPlan`
-     - :py:class:`~sarkit.sidd.SiddNitfWriter`
+     - :py:class:`~sarkit.sidd.NitfReader`
+     - :py:class:`~sarkit.sidd.NitfMetadata`
+     - :py:class:`~sarkit.sidd.NitfWriter`
 
 
 Reading
 -------
 
-Readers are instantiated with a `file object` and file contents are accessed via format-specific attributes and methods.
+Readers are instantiated with a `file object` and file contents are accessed via the ``metadata`` attribute and
+format-specific methods.
 In general, only the container information is accessed upon instantiation; further file access is deferred until
 data access methods are called.
 This pattern makes it faster to read components out of large files and is especially valuable for metadata access which
@@ -79,13 +80,13 @@ is often a small fraction of the size of a SAR data file.
    sec = {"security": {"clas": "U"}}
    parser = lxml.etree.XMLParser(remove_blank_text=True)
    example_sicd_xmltree = lxml.etree.parse("data/example-sicd-1.4.0.xml", parser)
-   sicd_plan = sksicd.SicdNitfPlan(
-       sicd_xmltree=example_sicd_xmltree,
-       header_fields={"ostaid": "nowhere", "ftitle": "SARkit example SICD FTITLE"} | sec,
-       is_fields={"isorce": "this sensor"} | sec,
-       des_fields=sec,
+   sicd_meta = sksicd.NitfMetadata(
+       xmltree=example_sicd_xmltree,
+       file_header_part={"ostaid": "nowhere", "ftitle": "SARkit example SICD FTITLE"} | sec,
+       im_subheader_part={"isorce": "this sensor"} | sec,
+       de_subheader_part=sec,
    )
-   with open(example_sicd, "wb") as f, sksicd.SicdNitfWriter(f, sicd_plan):
+   with open(example_sicd, "wb") as f, sksicd.NitfWriter(f, sicd_meta):
        pass  # don't currently care about the pixels
 
 
@@ -95,74 +96,72 @@ is often a small fraction of the size of a SAR data file.
 
 .. doctest::
 
-   >>> with example_sicd.open("rb") as f, sksicd.SicdNitfReader(f) as reader:
+   >>> with example_sicd.open("rb") as f, sksicd.NitfReader(f) as reader:
    ...     pixels = reader.read_image()
    ...     pixels.shape
    (5727, 2362)
 
-   # Reader attributes, but not methods, can be safely accessed outside of the
+   # Metadata, but not methods, can be safely accessed outside of the
    # context manager's context
 
    # Access specific NITF fields that are called out in the SAR standards
-   >>> reader.header_fields.ftitle
+   >>> reader.metadata.file_header_part.ftitle
    'SARkit example SICD FTITLE'
 
    # XML metadata is returned as lxml.etree.ElementTree objects
-   >>> (reader.sicd_xmltree.findtext(".//{*}FullImage/{*}NumRows"),
-   ...  reader.sicd_xmltree.findtext(".//{*}FullImage/{*}NumCols"))
+   >>> (reader.metadata.xmltree.findtext(".//{*}FullImage/{*}NumRows"),
+   ...  reader.metadata.xmltree.findtext(".//{*}FullImage/{*}NumCols"))
    ('5727', '2362')
 
 
-Plans
------
+Metadata
+--------
 
-``Plan`` objects contain everything except the data.
+``Metadata`` objects contain all of the standard-specific settable metadata.
 This includes XML instance(s) and container metadata (PDD-settable NITF fields, CPHD header fields, etc.).
-SARkit relies on plans because for many of the SAR standards it is more efficient to know up front what a file will
-contain before writing.
 
-Plans can be built from their components:
+Metadata objects can be built from their components:
 
 .. doctest::
 
-   >>> plan_a = sksicd.SicdNitfPlan(
-   ...     sicd_xmltree=example_sicd_xmltree,
-   ...     header_fields={"ostaid": "my location", "security": {"clas": "U"}},
-   ...     is_fields={"isorce": "my sensor", "security": {"clas": "U"}},
-   ...     des_fields={"security": {"clas": "U"}},
+   >>> new_metadata = sksicd.NitfMetadata(
+   ...     xmltree=example_sicd_xmltree,
+   ...     file_header_part={"ostaid": "my location", "security": {"clas": "U"}},
+   ...     im_subheader_part={"isorce": "my sensor", "security": {"clas": "U"}},
+   ...     de_subheader_part={"security": {"clas": "U"}},
    ... )
 
-Plans are also available from readers:
+Metadata objects are also available from readers:
 
 .. doctest::
 
-   >>> plan_b = reader.nitf_plan
+   >>> read_metadata = reader.metadata
 
 
 Writing
 -------
 
-Writers are instantiated with a `file object` and a ``Plan`` object.
+Writers are instantiated with a `file object` and a ``Metadata`` object.
+SARkit relies on upfront metadata because for many of the SAR standards it is more efficient to know what a file will
+contain before writing.
 Similar to reading, instantiating a writer sets up the file while data is written using format-specific methods.
-
-.. warning:: Plans should not be modified after creation of a writer.
 
 .. doctest::
 
    >>> written_sicd = tmppath / "written.sicd"
-   >>> with written_sicd.open("wb") as f, sksicd.SicdNitfWriter(f, plan_b) as writer:
+   >>> with written_sicd.open("wb") as f, sksicd.NitfWriter(f, read_metadata) as writer:
    ...     writer.write_image(pixels)
 
    >>> with written_sicd.open("rb") as f:
    ...     f.read(9).decode()
    'NITF02.10'
 
-SARkit sanity checks some aspects on write but it is up to the user to ensure consistency of the plan and data:
+SARkit sanity checks some aspects on write but it is up to the user to ensure consistency of the metadata and data:
 
 .. doctest::
 
    >>> bad_sicd = tmppath / "bad.sicd"
-   >>> with bad_sicd.open("wb") as f, sksicd.SicdNitfWriter(f, plan_b) as writer:
+   >>> with bad_sicd.open("wb") as f, sksicd.NitfWriter(f, read_metadata) as writer:
    ...     writer.write_image(pixels.view(np.uint8))
    Traceback (most recent call last):
    ValueError: Array dtype (uint8) does not match expected dtype (complex64) for PixelType=RE32F_IM32F
@@ -180,7 +179,7 @@ For simple operations, `xml.etree.ElementTree` and/or `lxml` are often sufficien
 
 .. doctest::
 
-   >>> reader.sicd_xmltree.findtext(".//{*}ModeType")
+   >>> example_sicd_xmltree.findtext(".//{*}ModeType")
    'SPOTLIGHT'
 
 For complicated metadata, SARkit provides XML helper classes that can be used to transcode between XML and more
@@ -207,7 +206,7 @@ XmlHelpers are instantiated with an `lxml.etree.ElementTree` which can then be m
 .. doctest::
 
    >>> import sarkit.sicd as sksicd
-   >>> xmlhelp = sksicd.XmlHelper(reader.sicd_xmltree)
+   >>> xmlhelp = sksicd.XmlHelper(example_sicd_xmltree)
    >>> xmlhelp.load(".//{*}ModeType")
    'SPOTLIGHT'
 
@@ -216,7 +215,7 @@ can be used when you already have an element object:
 
 .. doctest::
 
-   >>> tcoa_poly_elem = reader.sicd_xmltree.find(".//{*}TimeCOAPoly")
+   >>> tcoa_poly_elem = example_sicd_xmltree.find(".//{*}TimeCOAPoly")
    >>> xmlhelp.load_elem(tcoa_poly_elem)
    array([[1.2206226]])
 
@@ -236,7 +235,7 @@ shortcuts for ``find`` + :py:class:`~sarkit.sicd.XmlHelper.load_elem` /
 .. doctest::
 
    # find + set_elem/load_elem
-   >>> elem = reader.sicd_xmltree.find("{*}ImageData/{*}SCPPixel")
+   >>> elem = example_sicd_xmltree.find("{*}ImageData/{*}SCPPixel")
    >>> xmlhelp.set_elem(elem, [123, 456])
    >>> xmlhelp.load_elem(elem)
    array([123, 456])

--- a/sarkit/cphd/__init__.py
+++ b/sarkit/cphd/__init__.py
@@ -64,7 +64,7 @@ Constants
      - `dict` of {xml namespace: version-specific information}
    * - ``DEFINED_HEADER_KEYS``
      - :external:py:obj:`set` of KVP keys defined in the standard
-   * - ``CPHD_SECTION_TERMINATOR``
+   * - ``SECTION_TERMINATOR``
      - Two-byte sequence that marks the end of the file header
    * - ``TRANSCODERS``
      - `dict` of {name: transcoder}

--- a/sarkit/cphd/__init__.py
+++ b/sarkit/cphd/__init__.py
@@ -18,10 +18,10 @@ Data Structure & File Format
 .. autosummary::
    :toctree: generated/
 
-   CphdFileHeaderFields
-   CphdReader
-   CphdPlan
-   CphdWriter
+   FileHeaderPart
+   Metadata
+   Reader
+   Writer
    read_file_header
    get_pvp_dtype
    binary_format_string_to_dtype
@@ -96,13 +96,13 @@ CPHD 1.1.0
 """
 
 from ._io import (
-    CPHD_SECTION_TERMINATOR,
     DEFINED_HEADER_KEYS,
+    SECTION_TERMINATOR,
     VERSION_INFO,
-    CphdFileHeaderFields,
-    CphdPlan,
-    CphdReader,
-    CphdWriter,
+    FileHeaderPart,
+    Metadata,
+    Reader,
+    Writer,
     binary_format_string_to_dtype,
     dtype_to_binary_format_string,
     get_pvp_dtype,
@@ -134,29 +134,29 @@ from ._xml import (
 )
 
 __all__ = [
-    "CPHD_SECTION_TERMINATOR",
     "DEFINED_HEADER_KEYS",
+    "SECTION_TERMINATOR",
     "TRANSCODERS",
     "VERSION_INFO",
     "AddedPvpType",
     "BoolType",
-    "CphdFileHeaderFields",
-    "CphdPlan",
-    "CphdReader",
-    "CphdWriter",
     "DblType",
     "EnuType",
+    "FileHeaderPart",
     "HexType",
     "ImageAreaCornerPointsType",
     "IntType",
     "LatLonHaeType",
     "LatLonType",
     "LineSampType",
+    "Metadata",
     "ParameterType",
     "Poly2dType",
     "PolyType",
     "PvpType",
+    "Reader",
     "TxtType",
+    "Writer",
     "XdtType",
     "XmlHelper",
     "XyType",

--- a/sarkit/cphd/_io.py
+++ b/sarkit/cphd/_io.py
@@ -70,21 +70,34 @@ def _to_binary_format_string_recursive(dtype):
 
 
 def dtype_to_binary_format_string(dtype: np.dtype) -> str:
-    """Return the CPHD Binary Format string (table 10-2) description of a numpy.dtype.
+    """Return the binary format string corresponding to a `numpy.dtype`.
+
+    See the "Allowed Binary Formats" table in the Design & Implementation Description Document
 
     Parameters
     ----------
     dtype : `numpy.dtype`
-        (e.g., numpy.int8, numpy.int32, numpy.complex64, etc.)
-
-        The dtype to be converted to PVP type string.
+        Data-type about which to get binary format string.
+        Endianness is ignored.
 
     Returns
     -------
-    result : str
-        PVP type designator for the specified `numpy.dtype`
-        (e.g., ``"I1"``, ``"I4"``, ``"CF8"``, etc.).
+    str
+        Binary format string for the specified `numpy.dtype`
 
+    Examples
+    --------
+
+    .. doctest::
+
+        >>> import numpy as np
+        >>> import sarkit.cphd as skcphd
+
+        >>> skcphd.dtype_to_binary_format_string(np.uint8)
+        'U1'
+
+        >>> skcphd.dtype_to_binary_format_string(np.dtype([('a', np.int16), ('b', 'S30')]))
+        'a=I2;b=S30;'
     """
     result = _to_binary_format_string_recursive(dtype)
 
@@ -122,19 +135,33 @@ def _single_binary_format_string_to_dtype(form):
 
 
 def binary_format_string_to_dtype(format_string: str) -> np.dtype:
-    """Return the numpy.dtype for CPHD Binary Format string (table 10-2).
+    """Return the `numpy.dtype` corresponding to a binary format string.
+
+    See the "Allowed Binary Formats" table in the Design & Implementation Description Document
 
     Parameters
     ----------
     format_string : str
-        PVP type designator (e.g., ``"I1"``, ``"I4"``, ``"CF8"``, etc.).
+        Binary format string about which to get the dtype.
 
     Returns
     -------
-    dtype : `numpy.dtype`
-        The equivalent `numpy.dtype` of the PVP format string
-        (e.g., numpy.int8, numpy.int32, numpy.complex64, etc.).
+    `numpy.dtype`
+        `numpy.dtype` corresponding to the binary format string (in native byte order)
 
+    Examples
+    --------
+
+    .. doctest::
+
+        >>> import numpy as np
+        >>> import sarkit.cphd as skcphd
+
+        >>> skcphd.binary_format_string_to_dtype('U1')
+        dtype('uint8')
+
+        >>> skcphd.binary_format_string_to_dtype('a=I2;b=S30;')
+        dtype([('a', '<i2'), ('b', 'S30')])
     """
     components = format_string.split(";")
 
@@ -217,7 +244,7 @@ class Metadata:
 
 
 def read_file_header(file):
-    """Read a CPHD file header.
+    """Read a file header.
 
     The file object's position is assumed to be at the start of the file.
 
@@ -229,7 +256,7 @@ def read_file_header(file):
     Returns
     -------
     file_type_header : str
-        File type from the first line of a CPHD file
+        File type from the first line of the file
     kvp_list : dict[str, str]
         Key-Value list of header fields
     """
@@ -506,7 +533,7 @@ class Writer:
 
     Examples
     --------
-    >>> with output_path.open('wb') as file, Writer(file, plan) as writer:
+    >>> with output_path.open('wb') as file, Writer(file, metadata) as writer:
     ...     writer.write_signal("1", signal)
     ...     writer.write_pvp("1", pvp)
 

--- a/sarkit/crsd/__init__.py
+++ b/sarkit/crsd/__init__.py
@@ -17,10 +17,10 @@ Data Structure & File Format
 .. autosummary::
    :toctree: generated/
 
-   CrsdFileHeaderFields
-   CrsdReader
-   CrsdPlan
-   CrsdWriter
+   FileHeaderPart
+   Metadata
+   Reader
+   Writer
    read_file_header
    get_pvp_dtype
    get_ppp_dtype
@@ -86,7 +86,7 @@ Constants
      - `dict` of {xml namespace: version-specific information}
    * - ``DEFINED_HEADER_KEYS``
      - :external:py:obj:`set` of KVP keys defined in the standard
-   * - ``CRSD_SECTION_TERMINATOR``
+   * - ``SECTION_TERMINATOR``
      - Two-byte sequence that marks the end of the file header
    * - ``TRANSCODERS``
      - `dict` of {name: transcoder}
@@ -109,13 +109,13 @@ from ._computations import (
     compute_ref_point_parameters,
 )
 from ._io import (
-    CRSD_SECTION_TERMINATOR,
     DEFINED_HEADER_KEYS,
+    SECTION_TERMINATOR,
     VERSION_INFO,
-    CrsdFileHeaderFields,
-    CrsdPlan,
-    CrsdReader,
-    CrsdWriter,
+    FileHeaderPart,
+    Metadata,
+    Reader,
+    Writer,
     binary_format_string_to_dtype,
     dtype_to_binary_format_string,
     get_ppp_dtype,
@@ -150,31 +150,31 @@ from ._xml import (
 )
 
 __all__ = [
-    "CRSD_SECTION_TERMINATOR",
     "DEFINED_HEADER_KEYS",
+    "SECTION_TERMINATOR",
     "TRANSCODERS",
     "VERSION_INFO",
     "AddedPxpType",
     "BoolType",
-    "CrsdFileHeaderFields",
-    "CrsdPlan",
-    "CrsdReader",
-    "CrsdWriter",
     "DblType",
     "EdfType",
     "EnuType",
+    "FileHeaderPart",
     "HexType",
     "ImageAreaCornerPointsType",
     "IntType",
     "LatLonHaeType",
     "LatLonType",
     "LineSampType",
+    "Metadata",
     "MtxType",
     "ParameterType",
     "Poly2dType",
     "PolyType",
     "PxpType",
+    "Reader",
     "TxtType",
+    "Writer",
     "XdtType",
     "XmlHelper",
     "XyType",

--- a/sarkit/crsd/_io.py
+++ b/sarkit/crsd/_io.py
@@ -15,7 +15,7 @@ import numpy.typing as npt
 import sarkit.cphd as skcphd
 
 SCHEMA_DIR = importlib.resources.files("sarkit.crsd.schemas")
-CRSD_SECTION_TERMINATOR: Final[bytes] = b"\f\n"
+SECTION_TERMINATOR: Final[bytes] = b"\f\n"
 DEFINED_HEADER_KEYS: Final[set] = {
     "XML_BLOCK_SIZE",
     "XML_BLOCK_BYTE_OFFSET",
@@ -41,56 +41,53 @@ VERSION_INFO: Final[dict] = {
 }
 
 
-dtype_to_binary_format_string = skcphd.dtype_to_binary_format_string
-binary_format_string_to_dtype = skcphd.binary_format_string_to_dtype
+# Happens to match CPHD
+def dtype_to_binary_format_string(dtype: np.dtype) -> str:
+    return skcphd.dtype_to_binary_format_string(dtype)
 
+
+# Happens to match CPHD
+def binary_format_string_to_dtype(format_string: str) -> np.dtype:
+    return skcphd.binary_format_string_to_dtype(format_string)
+
+
+dtype_to_binary_format_string.__doc__ = getattr(
+    skcphd.dtype_to_binary_format_string, "__doc__", ""
+).replace("cphd", "crsd")
+binary_format_string_to_dtype.__doc__ = getattr(
+    skcphd.binary_format_string_to_dtype, "__doc__", ""
+).replace("cphd", "crsd")
 
 mask_support_array = skcphd.mask_support_array
 
 
 @dataclasses.dataclass(kw_only=True)
-class CrsdFileHeaderFields:
+class FileHeaderPart:
     """CRSD header fields which are set per program specific Product Design Document
 
     Attributes
     ----------
-    classification : str
-        File classification
-    release_info : str
-        File release info
-    additional_kvps : dict of {str : str}, optional
-        Dictionary with additional key-value pairs
+    additional_kvps : dict of {str : str}
+        Additional key-value pairs
     """
 
-    classification: str
-    release_info: str
     additional_kvps: dict[str, str] = dataclasses.field(default_factory=dict)
-
-    def __post_init__(self):
-        if self.additional_kvps is None:
-            self.additional_kvps = {}
 
 
 @dataclasses.dataclass(kw_only=True)
-class CrsdPlan:
-    """Class describing the plan for creating a CRSD file
+class Metadata:
+    """Settable CRSD metadata
 
     Attributes
     ----------
-    file_header : :py:class:`CrsdFileHeaderFields`
+    file_header_part : FileHeaderPart
         CRSD File Header fields which can be set
-    crsd_xmltree : lxml.etree.ElementTree
-        CRSD XML ElementTree
-
-    See Also
-    --------
-    CrsdReader
-    CrsdWriter
-    CrsdFileHeaderFields
+    xmltree : lxml.etree.ElementTree
+        CRSD XML
     """
 
-    file_header: CrsdFileHeaderFields
-    crsd_xmltree: lxml.etree.ElementTree
+    file_header_part: FileHeaderPart = dataclasses.field(default_factory=FileHeaderPart)
+    xmltree: lxml.etree.ElementTree
 
 
 read_file_header = skcphd.read_file_header
@@ -163,10 +160,10 @@ def get_pvp_dtype(crsd_xmltree):
     return _get_pxp_dtype(crsd_xmltree.find("./{*}PVP"))
 
 
-class CrsdReader:
+class Reader:
     """Read a CRSD file
 
-    A CrsdReader object can be used as a context manager in a ``with`` statement.
+    A Reader object can be used as a context manager in a ``with`` statement.
     Attributes, but not methods, can be safely accessed outside of the context manager's context.
 
     Parameters
@@ -176,33 +173,18 @@ class CrsdReader:
 
     Examples
     --------
-    >>> with crsd_path.open('rb') as file, CrsdReader(file) as reader:
-    ...     crsd_xmltree = reader.crsd_xmltree
+    >>> with crsd_path.open('rb') as file, Reader(file) as reader:
+    ...     crsd_xmltree = reader.metadata.xmltree
     ...     signal, pvp = reader.read_channel(<chan_id>)
 
     Attributes
     ----------
-    file_header : :py:class:`CrsdFileHeaderFields`
-       CRSD header dataclass
-    crsd_xmltree : lxml.etree.ElementTree
-        CRSD XML ElementTree
-    plan : :py:class:`CrsdPlan`
-        A CrsdPlan object suitable for use in a CrsdWriter
-    xml_block_size : int
-    xml_block_byte_offset : int
-    ppp_block_size : int or None
-    ppp_block_byte_offset : int or None
-    pvp_block_size : int or None
-    pvp_block_byte_offset : int or None
-    signal_block_size : int or None
-    signal_block_byte_offset : int or None
-    support_block_size : int
-    support_block_byte_offset : int
+    metadata : Metadata
+       CRSD metadata
 
     See Also
     --------
-    CrsdPlan
-    CrsdWriter
+    Writer
     """
 
     def __init__(self, file):
@@ -214,79 +196,73 @@ class CrsdReader:
         extra_header_keys = set(self._kvp_list.keys()) - DEFINED_HEADER_KEYS
         additional_kvps = {key: self._kvp_list[key] for key in extra_header_keys}
 
-        self.file_header = CrsdFileHeaderFields(
-            classification=self._kvp_list["CLASSIFICATION"],
-            release_info=self._kvp_list["RELEASE_INFO"],
-            additional_kvps=additional_kvps,
-        )
-        self._file_object.seek(self.xml_block_byte_offset)
+        self._file_object.seek(self._xml_block_byte_offset)
         xml_bytes = self._file_object.read(int(self._kvp_list["XML_BLOCK_SIZE"]))
-        self.crsd_xmltree = lxml.etree.fromstring(xml_bytes).getroottree()
 
-        self.plan = CrsdPlan(
-            crsd_xmltree=self.crsd_xmltree,
-            file_header=self.file_header,
+        self.metadata = Metadata(
+            xmltree=lxml.etree.fromstring(xml_bytes).getroottree(),
+            file_header_part=FileHeaderPart(additional_kvps=additional_kvps),
         )
 
     @property
-    def xml_block_byte_offset(self) -> int:
+    def _xml_block_byte_offset(self) -> int:
         """Offset to the XML block"""
         return int(self._kvp_list["XML_BLOCK_BYTE_OFFSET"])
 
     @property
-    def xml_block_size(self) -> int:
+    def _xml_block_size(self) -> int:
         """Size of the XML block"""
         return int(self._kvp_list["XML_BLOCK_SIZE"])
 
     @property
-    def pvp_block_byte_offset(self) -> int | None:
+    def _pvp_block_byte_offset(self) -> int | None:
         """Offset to the PVP block"""
         if (n := self._kvp_list.get("PVP_BLOCK_BYTE_OFFSET")) is not None:
             return int(n)
         return None
 
     @property
-    def pvp_block_size(self) -> int | None:
+    def _pvp_block_size(self) -> int | None:
         """Size of the PVP block"""
         if (n := self._kvp_list.get("PVP_BLOCK_SIZE")) is not None:
             return int(n)
         return None
 
     @property
-    def ppp_block_byte_offset(self) -> int | None:
+    def _ppp_block_byte_offset(self) -> int | None:
         """Offset to the PPP block"""
         if (n := self._kvp_list.get("PPP_BLOCK_BYTE_OFFSET")) is not None:
             return int(n)
         return None
 
     @property
-    def ppp_block_size(self) -> int | None:
+    def _ppp_block_size(self) -> int | None:
         """Size of the PPP block"""
         if (n := self._kvp_list.get("PPP_BLOCK_SIZE")) is not None:
             return int(n)
         return None
 
     @property
-    def signal_block_byte_offset(self) -> int | None:
+    def _signal_block_byte_offset(self) -> int | None:
         """Offset to the Signal block"""
         if (n := self._kvp_list.get("SIGNAL_BLOCK_BYTE_OFFSET")) is not None:
             return int(n)
         return None
 
     @property
-    def signal_block_size(self) -> int | None:
+    def _signal_block_size(self) -> int | None:
         """Size of the Signal block"""
         if (n := self._kvp_list.get("SIGNAL_BLOCK_SIZE")) is not None:
             return int(n)
         return None
 
     @property
-    def support_block_byte_offset(self) -> int:
+    def _support_block_byte_offset(self) -> int:
         """Offset to the Support block"""
         return int(self._kvp_list["SUPPORT_BLOCK_BYTE_OFFSET"])
 
     @property
-    def support_block_size(self) -> int:
+    def _support_block_size(self) -> int:
         """Size of the Support block"""
         return int(self._kvp_list["SUPPORT_BLOCK_SIZE"])
 
@@ -304,7 +280,7 @@ class CrsdReader:
             2D array of complex samples
 
         """
-        channel_info = self.crsd_xmltree.find(
+        channel_info = self.metadata.xmltree.find(
             f"{{*}}Data/{{*}}Receive/{{*}}Channel[{{*}}Identifier='{channel_identifier}']"
         )
         num_vect = int(channel_info.find("./{*}NumVectors").text)
@@ -312,11 +288,11 @@ class CrsdReader:
         shape = (num_vect, num_samp)
 
         signal_offset = int(channel_info.find("./{*}SignalArrayByteOffset").text)
-        assert self.signal_block_byte_offset is not None  # placate mypy
-        self._file_object.seek(signal_offset + self.signal_block_byte_offset)
+        assert self._signal_block_byte_offset is not None  # placate mypy
+        self._file_object.seek(signal_offset + self._signal_block_byte_offset)
 
         signal_dtype = binary_format_string_to_dtype(
-            self.crsd_xmltree.find("./{*}Data/{*}Receive/{*}SignalArrayFormat").text
+            self.metadata.xmltree.find("./{*}Data/{*}Receive/{*}SignalArrayFormat").text
         ).newbyteorder("B")
 
         return np.fromfile(
@@ -337,16 +313,16 @@ class CrsdReader:
             CRSD PVP array
 
         """
-        channel_info = self.crsd_xmltree.find(
+        channel_info = self.metadata.xmltree.find(
             f"{{*}}Data/{{*}}Receive/{{*}}Channel[{{*}}Identifier='{channel_identifier}']"
         )
         num_vect = int(channel_info.find("./{*}NumVectors").text)
 
         pvp_offset = int(channel_info.find("./{*}PVPArrayByteOffset").text)
-        assert self.pvp_block_byte_offset is not None  # placate mypy
-        self._file_object.seek(pvp_offset + self.pvp_block_byte_offset)
+        assert self._pvp_block_byte_offset is not None  # placate mypy
+        self._file_object.seek(pvp_offset + self._pvp_block_byte_offset)
 
-        pvp_dtype = get_pvp_dtype(self.crsd_xmltree).newbyteorder("B")
+        pvp_dtype = get_pvp_dtype(self.metadata.xmltree).newbyteorder("B")
         return np.fromfile(self._file_object, pvp_dtype, count=num_vect)
 
     def read_channel(self, channel_identifier: str) -> tuple[npt.NDArray, npt.NDArray]:
@@ -381,25 +357,25 @@ class CrsdReader:
             CRSD PPP array
 
         """
-        channel_info = self.crsd_xmltree.find(
+        channel_info = self.metadata.xmltree.find(
             f"{{*}}Data/{{*}}Transmit/{{*}}TxSequence[{{*}}Identifier='{sequence_identifier}']"
         )
         num_pulse = int(channel_info.find("./{*}NumPulses").text)
 
         ppp_offset = int(channel_info.find("./{*}PPPArrayByteOffset").text)
-        assert self.ppp_block_byte_offset is not None  # placate mypy
-        self._file_object.seek(ppp_offset + self.ppp_block_byte_offset)
+        assert self._ppp_block_byte_offset is not None  # placate mypy
+        self._file_object.seek(ppp_offset + self._ppp_block_byte_offset)
 
-        ppp_dtype = get_ppp_dtype(self.crsd_xmltree).newbyteorder("B")
+        ppp_dtype = get_ppp_dtype(self.metadata.xmltree).newbyteorder("B")
         return np.fromfile(self._file_object, ppp_dtype, count=num_pulse)
 
     def _read_support_array(self, sa_identifier):
-        elem_format = self.crsd_xmltree.find(
+        elem_format = self.metadata.xmltree.find(
             f"{{*}}SupportArray/*[{{*}}Identifier='{sa_identifier}']/{{*}}ElementFormat"
         )
         dtype = binary_format_string_to_dtype(elem_format.text).newbyteorder("B")
 
-        sa_info = self.crsd_xmltree.find(
+        sa_info = self.metadata.xmltree.find(
             f"{{*}}Data/{{*}}Support/{{*}}SupportArray[{{*}}Identifier='{sa_identifier}']"
         )
         num_rows = int(sa_info.find("./{*}NumRows").text)
@@ -407,7 +383,7 @@ class CrsdReader:
         shape = (num_rows, num_cols)
 
         sa_offset = int(sa_info.find("./{*}ArrayByteOffset").text)
-        self._file_object.seek(sa_offset + self.support_block_byte_offset)
+        self._file_object.seek(sa_offset + self._support_block_byte_offset)
         assert dtype.itemsize == int(sa_info.find("./{*}BytesPerElement").text)
         array = np.fromfile(self._file_object, dtype, count=np.prod(shape)).reshape(
             shape
@@ -419,7 +395,7 @@ class CrsdReader:
         array = self._read_support_array(sa_identifier)
         if not masked:
             return array
-        nodata = self.crsd_xmltree.findtext(
+        nodata = self.metadata.xmltree.findtext(
             f"{{*}}SupportArray/*[{{*}}Identifier='{sa_identifier}']/{{*}}NODATA"
         )
         return mask_support_array(array, nodata)
@@ -435,48 +411,47 @@ class CrsdReader:
         self.done()
 
 
-class CrsdWriter:
+class Writer:
     """Write a CRSD file
 
-    A CrsdWriter object can be used as a context manager in a ``with`` statement.
+    A Writer object can be used as a context manager in a ``with`` statement.
 
     Parameters
     ----------
     file : `file object`
         CRSD file to write
-    plan : :py:class:`CrsdPlan`
-        A CrsdPlan object
+    metadata : Metadata
+        CRSD metadata to write
 
     Notes
     -----
-    plan should not be modified after creation of a writer
+    ``metadata`` should not be modified after creation of a writer
 
     Examples
     --------
-    >>> with output_path.open('wb') as file, CrsdWriter(file, plan) as writer:
+    >>> with output_path.open('wb') as file, Writer(file, metadata) as writer:
     ...     writer.write_signal("1", signal)
     ...     writer.write_pvp("1", pvp)
 
     See Also
     --------
-    CrsdPlan
-    CrsdReader
+    Reader
     """
 
-    def __init__(self, file, plan):
+    def __init__(self, file, metadata: Metadata):
         align_to = 64
         self._file_object = file
 
-        self._plan = plan
+        self._metadata = metadata
 
-        xml_block_body = lxml.etree.tostring(plan.crsd_xmltree, encoding="utf-8")
+        xml_block_body = lxml.etree.tostring(metadata.xmltree, encoding="utf-8")
 
         self._sequence_size_offsets = {}
-        if plan.crsd_xmltree.find("./{*}Data/{*}Transmit") is not None:
+        if metadata.xmltree.find("./{*}Data/{*}Transmit") is not None:
             ppp_itemsize = int(
-                plan.crsd_xmltree.find("./{*}Data/{*}Transmit/{*}NumBytesPPP").text
+                metadata.xmltree.find("./{*}Data/{*}Transmit/{*}NumBytesPPP").text
             )
-            for seq_node in plan.crsd_xmltree.findall(
+            for seq_node in metadata.xmltree.findall(
                 "./{*}Data/{*}Transmit/{*}TxSequence"
             ):
                 sequence_identifier = seq_node.find("./{*}Identifier").text
@@ -490,14 +465,14 @@ class CrsdWriter:
                 }
 
         self._channel_size_offsets = {}
-        if plan.crsd_xmltree.find("./{*}Data/{*}Receive") is not None:
+        if metadata.xmltree.find("./{*}Data/{*}Receive") is not None:
             signal_itemsize = binary_format_string_to_dtype(
-                plan.crsd_xmltree.find("./{*}Data/{*}Receive/{*}SignalArrayFormat").text
+                metadata.xmltree.find("./{*}Data/{*}Receive/{*}SignalArrayFormat").text
             ).itemsize
             pvp_itemsize = int(
-                plan.crsd_xmltree.find("./{*}Data/{*}Receive/{*}NumBytesPVP").text
+                metadata.xmltree.find("./{*}Data/{*}Receive/{*}NumBytesPVP").text
             )
-            for chan_node in plan.crsd_xmltree.findall(
+            for chan_node in metadata.xmltree.findall(
                 "./{*}Data/{*}Receive/{*}Channel"
             ):
                 channel_identifier = chan_node.find("./{*}Identifier").text
@@ -523,9 +498,7 @@ class CrsdWriter:
                 }
 
         self._sa_size_offsets = {}
-        for sa_node in plan.crsd_xmltree.findall(
-            "./{*}Data/{*}Support/{*}SupportArray"
-        ):
+        for sa_node in metadata.xmltree.findall("./{*}Data/{*}Support/{*}SupportArray"):
             sa_identifier = sa_node.find("./{*}Identifier").text
             sa_offset = int(sa_node.find("./{*}ArrayByteOffset").text)
             sa_size = (
@@ -547,8 +520,10 @@ class CrsdWriter:
             return int(np.ceil(float(val) / align_to) * align_to)
 
         self._file_header_kvp = {
-            "CLASSIFICATION": plan.file_header.classification,
-            "RELEASE_INFO": plan.file_header.release_info,
+            "CLASSIFICATION": metadata.xmltree.findtext(
+                "{*}ProductInfo/{*}Classification"
+            ),
+            "RELEASE_INFO": metadata.xmltree.findtext("{*}ProductInfo/{*}ReleaseInfo"),
             "XML_BLOCK_SIZE": len(xml_block_body),
             "XML_BLOCK_BYTE_OFFSET": np.iinfo(np.uint64).max,  # placeholder
         }
@@ -586,11 +561,11 @@ class CrsdWriter:
             np.iinfo(np.uint64).max,
         )  # placeholder
 
-        self._file_header_kvp.update(plan.file_header.additional_kvps)
+        self._file_header_kvp.update(metadata.file_header_part.additional_kvps)
 
         def _serialize_header():
             version = VERSION_INFO[
-                lxml.etree.QName(plan.crsd_xmltree.getroot()).namespace
+                lxml.etree.QName(metadata.xmltree.getroot()).namespace
             ]["version"]
             if self._sequence_size_offsets and self._channel_size_offsets:
                 file_type = "CRSDsar"
@@ -604,7 +579,7 @@ class CrsdWriter:
             header_str += "".join(
                 (f"{key} := {value}\n" for key, value in self._file_header_kvp.items())
             )
-            return header_str.encode() + CRSD_SECTION_TERMINATOR
+            return header_str.encode() + SECTION_TERMINATOR
 
         next_offset = _align(len(_serialize_header()))
 
@@ -612,7 +587,7 @@ class CrsdWriter:
         next_offset = _align(
             next_offset
             + self._file_header_kvp["XML_BLOCK_SIZE"]
-            + len(CRSD_SECTION_TERMINATOR)
+            + len(SECTION_TERMINATOR)
         )
 
         self._file_header_kvp["SUPPORT_BLOCK_BYTE_OFFSET"] = next_offset
@@ -633,12 +608,12 @@ class CrsdWriter:
         self._file_object.seek(0)
         self._file_object.write(_serialize_header())
         self._file_object.seek(self._file_header_kvp["XML_BLOCK_BYTE_OFFSET"])
-        self._file_object.write(xml_block_body + CRSD_SECTION_TERMINATOR)
+        self._file_object.write(xml_block_body + SECTION_TERMINATOR)
 
-        self._signal_arrays_written = set()
-        self._pvp_arrays_written = set()
-        self._ppp_arrays_written = set()
-        self._support_arrays_written = set()
+        self._signal_arrays_written: set[str] = set()
+        self._pvp_arrays_written: set[str] = set()
+        self._ppp_arrays_written: set[str] = set()
+        self._support_arrays_written: set[str] = set()
 
     def write_signal(self, channel_identifier: str, signal_array: npt.NDArray):
         """Write signal data to a CRSD file
@@ -651,6 +626,7 @@ class CrsdWriter:
             2D array of complex samples
 
         """
+        # TODO Add support for partial CRSD writing
         assert (
             signal_array.nbytes
             == self._channel_size_offsets[channel_identifier]["signal_size"]
@@ -663,9 +639,6 @@ class CrsdWriter:
         )
         output_dtype = signal_array.dtype.newbyteorder(">")
         signal_array.astype(output_dtype, copy=False).tofile(self._file_object)
-
-        # TODO Add support for partial CRSD writing
-        return
 
     def write_pvp(self, channel_identifier: str, pvp_array: npt.NDArray):
         """Write pvp data to a CRSD file
@@ -690,7 +663,6 @@ class CrsdWriter:
         )
         output_dtype = pvp_array.dtype.newbyteorder(">")
         pvp_array.astype(output_dtype, copy=False).tofile(self._file_object)
-        return
 
     def write_ppp(self, sequence_identifier: str, ppp_array: npt.NDArray):
         """Write ppp data to a CRSD file
@@ -715,7 +687,6 @@ class CrsdWriter:
         )
         output_dtype = ppp_array.dtype.newbyteorder(">")
         ppp_array.astype(output_dtype, copy=False).tofile(self._file_object)
-        return
 
     def write_support_array(
         self, support_array_identifier: str, support_array: npt.NDArray
@@ -730,6 +701,7 @@ class CrsdWriter:
             Array of support data
 
         """
+        # TODO: support masked arrays ala CPHD
         assert (
             support_array.nbytes
             == self._sa_size_offsets[support_array_identifier]["size"]
@@ -747,7 +719,7 @@ class CrsdWriter:
         """Warn about unwritten arrays declared in the XML"""
         channel_names = set(
             node.text
-            for node in self._plan.crsd_xmltree.findall(
+            for node in self._metadata.xmltree.findall(
                 "./{*}Data/{*}Receive/{*}Channel/{*}Identifier"
             )
         )
@@ -765,7 +737,7 @@ class CrsdWriter:
 
         sequence_names = set(
             node.text
-            for node in self._plan.crsd_xmltree.findall(
+            for node in self._metadata.xmltree.findall(
                 "./{*}Data/{*}Transmit/{*}TxSequence/{*}Identifier"
             )
         )
@@ -777,7 +749,7 @@ class CrsdWriter:
 
         sa_names = set(
             node.text
-            for node in self._plan.crsd_xmltree.findall(
+            for node in self._metadata.xmltree.findall(
                 "./{*}Data/{*}SupportArray/{*}Identifier"
             )
         )

--- a/sarkit/sicd/__init__.py
+++ b/sarkit/sicd/__init__.py
@@ -20,13 +20,13 @@ Data Structure & File Format
 .. autosummary::
    :toctree: generated/
 
-   SicdNitfHeaderFields
-   SicdNitfSecurityFields
-   SicdNitfImageSegmentFields
-   SicdNitfDESegmentFields
-   SicdNitfReader
-   SicdNitfPlan
-   SicdNitfWriter
+   NitfSecurityFields
+   NitfFileHeaderPart
+   NitfImSubheaderPart
+   NitfDeSubheaderPart
+   NitfReader
+   NitfMetadata
+   NitfWriter
 
 XML Metadata
 ============
@@ -170,13 +170,13 @@ SICD 1.4.0
 from ._io import (
     PIXEL_TYPES,
     VERSION_INFO,
-    SicdNitfDESegmentFields,
-    SicdNitfHeaderFields,
-    SicdNitfImageSegmentFields,
-    SicdNitfPlan,
-    SicdNitfReader,
-    SicdNitfSecurityFields,
-    SicdNitfWriter,
+    NitfDeSubheaderPart,
+    NitfFileHeaderPart,
+    NitfImSubheaderPart,
+    NitfMetadata,
+    NitfReader,
+    NitfSecurityFields,
+    NitfWriter,
 )
 from ._xml import (
     TRANSCODERS,
@@ -219,17 +219,17 @@ __all__ = [
     "LatLonHaeType",
     "LatLonType",
     "MtxType",
+    "NitfDeSubheaderPart",
+    "NitfFileHeaderPart",
+    "NitfImSubheaderPart",
+    "NitfMetadata",
+    "NitfReader",
+    "NitfSecurityFields",
+    "NitfWriter",
     "ParameterType",
     "Poly2dType",
     "PolyType",
     "RowColType",
-    "SicdNitfDESegmentFields",
-    "SicdNitfHeaderFields",
-    "SicdNitfImageSegmentFields",
-    "SicdNitfPlan",
-    "SicdNitfReader",
-    "SicdNitfSecurityFields",
-    "SicdNitfWriter",
     "TxtType",
     "XdtType",
     "XmlHelper",

--- a/sarkit/sicd/_io.py
+++ b/sarkit/sicd/_io.py
@@ -2,6 +2,7 @@
 Functions to read and write SICD files.
 """
 
+import copy
 import dataclasses
 import datetime
 import importlib.resources
@@ -75,43 +76,43 @@ PIXEL_TYPES: Final[dict[str, dict[str, Any]]] = {
 
 
 @dataclasses.dataclass(kw_only=True)
-class SicdNitfSecurityFields:
+class NitfSecurityFields:
     """NITF Security Header/Subheader fields
 
     Attributes
     ----------
     clas : str
-        File Security Classification
+        Security Classification
     clsy : str
-        File Security Classification System
+        Security Classification System
     code : str
-        File Codewords
+        Codewords
     ctlh : str
-        File Control and Handling
+        Control and Handling
     rel : str
-        File Releasing Instructions
+        Releasing Instructions
     dctp : str
-        File Declassification Type
+        Declassification Type
     dcdt : str
-        File Declassification Date
+        Declassification Date
     dcxm : str
-        File Declassification Exemption
+        Declassification Exemption
     dg : str
-        File Downgrade
+        Downgrade
     dgdt : str
-        File Downgrade Date
+        Downgrade Date
     cltx : str
-        File Classification Text
+        Classification Text
     catp : str
-        File Classification Authority Type
+        Classification Authority Type
     caut : str
-        File Classification Authority
+        Classification Authority
     crsn : str
-        File Classification Reason
+        Classification Reason
     srdt : str
-        File Security Source Date
+        Security Source Date
     ctln : str
-        File Security Control Number
+        Security Control Number
     """
 
     clas: str
@@ -180,7 +181,7 @@ class SicdNitfSecurityFields:
 
 
 @dataclasses.dataclass(kw_only=True)
-class SicdNitfHeaderFields:
+class NitfFileHeaderPart:
     """NITF header fields which are set according to a Program Specific Implementation Document
 
     Attributes
@@ -189,7 +190,7 @@ class SicdNitfHeaderFields:
         Originating Station ID
     ftitle : str
         File Title
-    security : :py:class:`SicdNitfSecurityFields`
+    security : NitfSecurityFields
         Security Tags with "FS" prefix
     oname : str
         Originator's Name
@@ -199,7 +200,7 @@ class SicdNitfHeaderFields:
 
     ostaid: str
     ftitle: str = ""
-    security: SicdNitfSecurityFields
+    security: NitfSecurityFields
     oname: str = ""
     ophone: str = ""
 
@@ -209,18 +210,18 @@ class SicdNitfHeaderFields:
         return cls(
             ostaid=file_header.OSTAID,
             ftitle=file_header.FTITLE,
-            security=SicdNitfSecurityFields._from_security_tags(file_header.Security),
+            security=NitfSecurityFields._from_security_tags(file_header.Security),
             oname=file_header.ONAME,
             ophone=file_header.OPHONE,
         )
 
     def __post_init__(self):
         if isinstance(self.security, dict):
-            self.security = SicdNitfSecurityFields(**self.security)
+            self.security = NitfSecurityFields(**self.security)
 
 
 @dataclasses.dataclass(kw_only=True)
-class SicdNitfImageSegmentFields:
+class NitfImSubheaderPart:
     """NITF image header fields which are set according to a Program Specific Implementation Document
 
     Attributes
@@ -229,7 +230,7 @@ class SicdNitfImageSegmentFields:
        Target Identifier
     iid2 : str
         Image Identifier 2
-    security : :py:class:`SicdNitfSecurityFields`
+    security : NitfSecurityFields
         Security Tags with "IS" prefix
     isorce : str
         Image Source
@@ -240,7 +241,7 @@ class SicdNitfImageSegmentFields:
     ## IS fields are applied to all segments
     tgtid: str = ""
     iid2: str = ""
-    security: SicdNitfSecurityFields
+    security: NitfSecurityFields
     isorce: str
     icom: list[str] = dataclasses.field(default_factory=list)
 
@@ -250,7 +251,7 @@ class SicdNitfImageSegmentFields:
         return cls(
             tgtid=image_header.TGTID,
             iid2=image_header.IID2,
-            security=SicdNitfSecurityFields._from_security_tags(image_header.Security),
+            security=NitfSecurityFields._from_security_tags(image_header.Security),
             isorce=image_header.ISORCE,
             icom=[
                 val.to_bytes().decode().rstrip() for val in image_header.Comments.values
@@ -259,16 +260,16 @@ class SicdNitfImageSegmentFields:
 
     def __post_init__(self):
         if isinstance(self.security, dict):
-            self.security = SicdNitfSecurityFields(**self.security)
+            self.security = NitfSecurityFields(**self.security)
 
 
 @dataclasses.dataclass(kw_only=True)
-class SicdNitfDESegmentFields:
-    """NITF DE header fields which are set according to a Program Specific Implementation Document
+class NitfDeSubheaderPart:
+    """NITF DES subheader fields which are set according to a Program Specific Implementation Document
 
     Attributes
     ----------
-    security : :py:class:`SicdNitfSecurityFields`
+    security : NitfSecurityFields
         Security Tags with "DES" prefix
     desshrp : str
         Responsible Party - Organization Identifier
@@ -280,7 +281,7 @@ class SicdNitfDESegmentFields:
         Abstract. Brief narrative summary of the content of the DES.
     """
 
-    security: SicdNitfSecurityFields
+    security: NitfSecurityFields
     desshrp: str = ""
     desshli: str = ""
     desshlin: str = ""
@@ -290,7 +291,7 @@ class SicdNitfDESegmentFields:
     def _from_header(cls, de_header: sarkit._nitf.nitf.DataExtensionHeader) -> Self:
         """Construct from a NITF DataExtensionHeader object"""
         return cls(
-            security=SicdNitfSecurityFields._from_security_tags(de_header.Security),
+            security=NitfSecurityFields._from_security_tags(de_header.Security),
             desshrp=de_header.UserHeader.DESSHRP,
             desshli=de_header.UserHeader.DESSHLI,
             desshlin=de_header.UserHeader.DESSHLIN,
@@ -299,52 +300,60 @@ class SicdNitfDESegmentFields:
 
     def __post_init__(self):
         if isinstance(self.security, dict):
-            self.security = SicdNitfSecurityFields(**self.security)
+            self.security = NitfSecurityFields(**self.security)
 
 
 @dataclasses.dataclass(kw_only=True)
-class SicdNitfPlan:
-    """Class describing the plan for creating a SICD NITF Container
+class NitfMetadata:
+    """Settable SICD NITF metadata
 
     Attributes
     ----------
-    sicd_xmltree : lxml.etree.ElementTree
-        SICD XML ElementTree
-    header_fields : :py:class:`SicdNitfHeaderFields`
+    xmltree : lxml.etree.ElementTree
+        SICD XML
+    file_header_part : NitfFileHeaderPart
         NITF File Header fields which can be set
-    is_fields : :py:class:`SicdNitfImageSegmentFields`
-        NITF Image Segment Header fields which can be set
-    des_fields : :py:class:`SicdNitfDESegmentFields`
-        NITF DE Segment Header fields which can be set
-
-    See Also
-    --------
-    SicdNitfReader
-    SicdNitfWriter
-    SicdNitfSecurityFields
-    SicdNitfHeaderFields
-    SicdNitfImageSegmentFields
-    SicdNitfDESegmentFields
+    im_subheader_part : NitfImSubheaderPart
+        NITF image subheader fields which can be set
+    de_subheader_part : NitfDeSubheaderPart
+        NITF DES subheader fields which can be set
     """
 
-    sicd_xmltree: lxml.etree.ElementTree
-    header_fields: SicdNitfHeaderFields
-    is_fields: SicdNitfImageSegmentFields
-    des_fields: SicdNitfDESegmentFields
+    xmltree: lxml.etree.ElementTree
+    file_header_part: NitfFileHeaderPart
+    im_subheader_part: NitfImSubheaderPart
+    de_subheader_part: NitfDeSubheaderPart
 
     def __post_init__(self):
-        if isinstance(self.header_fields, dict):
-            self.header_fields = SicdNitfHeaderFields(**self.header_fields)
-        if isinstance(self.is_fields, dict):
-            self.is_fields = SicdNitfImageSegmentFields(**self.is_fields)
-        if isinstance(self.des_fields, dict):
-            self.des_fields = SicdNitfDESegmentFields(**self.des_fields)
+        if isinstance(self.file_header_part, dict):
+            self.file_header_part = NitfFileHeaderPart(**self.file_header_part)
+        if isinstance(self.im_subheader_part, dict):
+            self.im_subheader_part = NitfImSubheaderPart(**self.im_subheader_part)
+        if isinstance(self.de_subheader_part, dict):
+            self.de_subheader_part = NitfDeSubheaderPart(**self.de_subheader_part)
+
+    def __eq__(self, other):
+        if isinstance(other, NitfMetadata):
+            self_parts = (
+                lxml.etree.tostring(self.xmltree, method="c14n"),
+                self.file_header_part,
+                self.im_subheader_part,
+                self.de_subheader_part,
+            )
+            other_parts = (
+                lxml.etree.tostring(other.xmltree, method="c14n"),
+                other.file_header_part,
+                other.im_subheader_part,
+                other.de_subheader_part,
+            )
+            return self_parts == other_parts
+        return False
 
 
-class SicdNitfReader:
+class NitfReader:
     """Read a SICD NITF
 
-    A SicdNitfReader object can be used as a context manager in a ``with`` statement.
+    A NitfReader object can be used as a context manager in a ``with`` statement.
     Attributes, but not methods, can be safely accessed outside of the context manager's context.
 
     Parameters
@@ -354,23 +363,18 @@ class SicdNitfReader:
 
     Examples
     --------
-    >>> with sicd_path.open('rb') as file, SicdNitfReader(file) as reader:
-    ...     sicd_xmltree = reader.sicd_xmltree
+    >>> with sicd_path.open('rb') as file, NitfReader(file) as reader:
+    ...     sicd_xmltree = reader.metadata.xmltree
     ...     pixels = reader.read_image()
 
     Attributes
     ----------
-    sicd_xmltree : lxml.etree.ElementTree
-    header_fields : SicdNitfHeaderFields
-    is_fields : SicdNitfImageSegmentFields
-    des_fields : SicdNitfDESegmentFields
-    nitf_plan : :py:class:`SicdNitfPlan`
-        A SicdNitfPlan object suitable for use in a SicdNitfWriter
+    metadata : NitfMetadata
+        SICD NITF metadata
 
     See Also
     --------
-    SicdNitfPlan
-    SicdNitfWriter
+    NitfWriter
     """
 
     def __init__(self, file):
@@ -403,38 +407,18 @@ class SicdNitfReader:
         sicd_xmltree = lxml.etree.fromstring(
             self._nitf_reader.nitf_details.get_des_bytes(0)
         ).getroottree()
-        nitf_header_fields = SicdNitfHeaderFields._from_header(nitf_details.nitf_header)
-        nitf_image_fields = SicdNitfImageSegmentFields._from_header(
+        nitf_header_fields = NitfFileHeaderPart._from_header(nitf_details.nitf_header)
+        nitf_image_fields = NitfImSubheaderPart._from_header(
             nitf_details.img_headers[0]
         )
-        nitf_de_fields = SicdNitfDESegmentFields._from_header(des_header)
+        nitf_de_fields = NitfDeSubheaderPart._from_header(des_header)
 
-        self.nitf_plan = SicdNitfPlan(
-            sicd_xmltree=sicd_xmltree,
-            header_fields=nitf_header_fields,
-            is_fields=nitf_image_fields,
-            des_fields=nitf_de_fields,
+        self.metadata = NitfMetadata(
+            xmltree=sicd_xmltree,
+            file_header_part=nitf_header_fields,
+            im_subheader_part=nitf_image_fields,
+            de_subheader_part=nitf_de_fields,
         )
-
-    @property
-    def sicd_xmltree(self) -> lxml.etree.ElementTree:
-        """SICD XML tree"""
-        return self.nitf_plan.sicd_xmltree
-
-    @property
-    def header_fields(self) -> SicdNitfHeaderFields:
-        """NITF File Header fields"""
-        return self.nitf_plan.header_fields
-
-    @property
-    def is_fields(self) -> SicdNitfImageSegmentFields:
-        """NITF Image Segment Subheader fields"""
-        return self.nitf_plan.is_fields
-
-    @property
-    def des_fields(self) -> SicdNitfDESegmentFields:
-        """NITF DE Segment Subheader fields"""
-        return self.nitf_plan.des_fields
 
     def read_image(self) -> npt.NDArray:
         """Read the entire pixel array
@@ -445,9 +429,9 @@ class SicdNitfReader:
             SICD image array
         """
         self._file_object.seek(self._initial_offset)
-        nrows = int(self.sicd_xmltree.findtext("{*}ImageData/{*}NumRows"))
-        ncols = int(self.sicd_xmltree.findtext("{*}ImageData/{*}NumCols"))
-        pixel_type = self.sicd_xmltree.findtext("{*}ImageData/{*}PixelType")
+        nrows = int(self.metadata.xmltree.findtext("{*}ImageData/{*}NumRows"))
+        ncols = int(self.metadata.xmltree.findtext("{*}ImageData/{*}NumCols"))
+        pixel_type = self.metadata.xmltree.findtext("{*}ImageData/{*}PixelType")
         dtype = PIXEL_TYPES[pixel_type]["dtype"].newbyteorder(">")
         sicd_pixels = np.empty((nrows, ncols), dtype)
         imseg_sizes = self._nitf_reader.nitf_details.img_segment_sizes[
@@ -536,40 +520,26 @@ def _create_des_manager(sicd_xmltree, des_fields):
     return sicd_des
 
 
-class SicdNitfWriter:
+class NitfWriter:
     """Write a SICD NITF
 
-    A SicdNitfWriter object can be used as a context manager in a ``with`` statement.
+    A NitfWriter object can be used as a context manager in a ``with`` statement.
 
     Parameters
     ----------
     file : `file object`
         SICD NITF file to write
-    nitf_plan : :py:class:`SicdNitfPlan`
-        NITF plan object
-
-    Notes
-    -----
-    nitf_plan should not be modified after creation of a writer
-
-    Examples
-    --------
-    >>> plan = SicdNitfPlan(sicd_xmltree=sicd_xmltree,
-    ...                     header_fields=SicdNitfHeaderFields(ostaid='my location',
-    ...                                                        security=SicdNitfSecurityFields(clas='U')),
-    ...                     is_fields=SicdNitfImageSegmentFields(isorce='my sensor',
-    ...                                                          security=SicdNitfSecurityFields(clas='U')),
-    ...                     des_fields=SicdNitfDESegmentFields(security=SicdNitfSecurityFields(clas='U')))
-    >>> with output_path.open('wb') as file, SicdNitfWriter(file, plan) as writer:
-    ...     writer.write_image(pixel_array)
+    metadata : NitfMetadata
+        SICD NITF metadata to write (copied on construction)
 
     See Also
     --------
-    SicdNitfPlan
-    SicdNitfReader
+    NitfReader
     """
 
-    def __init__(self, file, nitf_plan: SicdNitfPlan):
+    # TODO: add example to docstring
+
+    def __init__(self, file, metadata: NitfMetadata):
         self._file_object = file
 
         self._initial_offset = self._file_object.tell()
@@ -578,10 +548,8 @@ class SicdNitfWriter:
                 "seek(0) must be the start of the NITF"
             )  # this is a NITFDetails limitation
 
-        self._nitf_plan = nitf_plan
-        sicd_xmltree = nitf_plan.sicd_xmltree
-
-        """Create a SICD NITF from a pixel array and metadata."""
+        self._metadata = copy.deepcopy(metadata)
+        sicd_xmltree = self._metadata.xmltree
         xmlns = lxml.etree.QName(sicd_xmltree.getroot()).namespace
         schema = lxml.etree.XMLSchema(file=VERSION_INFO[xmlns]["schema"])
         if not schema.validate(sicd_xmltree):
@@ -596,12 +564,12 @@ class SicdNitfWriter:
         now_dt = datetime.datetime.now(datetime.timezone.utc)
         header = sarkit._nitf.nitf_elements.nitf_head.NITFHeader(
             CLEVEL=3,
-            OSTAID=self._nitf_plan.header_fields.ostaid,
+            OSTAID=self._metadata.file_header_part.ostaid,
             FDT=now_dt.strftime("%Y%m%d%H%M%S"),
-            FTITLE=self._nitf_plan.header_fields.ftitle,
-            Security=self._nitf_plan.header_fields.security._as_security_tags(),
-            ONAME=self._nitf_plan.header_fields.oname,
-            OPHONE=self._nitf_plan.header_fields.ophone,
+            FTITLE=self._metadata.file_header_part.ftitle,
+            Security=self._metadata.file_header_part.security._as_security_tags(),
+            ONAME=self._metadata.file_header_part.oname,
+            OPHONE=self._metadata.file_header_part.ophone,
             FL=0,
         )
 
@@ -636,10 +604,10 @@ class SicdNitfWriter:
                 IDATIM=xml_helper.load("./{*}Timeline/{*}CollectStart").strftime(
                     "%Y%m%d%H%M%S"
                 ),
-                TGTID=self._nitf_plan.is_fields.tgtid,
-                IID2=self._nitf_plan.is_fields.iid2,
-                Security=self._nitf_plan.is_fields.security._as_security_tags(),
-                ISORCE=self._nitf_plan.is_fields.isorce,
+                TGTID=self._metadata.im_subheader_part.tgtid,
+                IID2=self._metadata.im_subheader_part.iid2,
+                Security=self._metadata.im_subheader_part.security._as_security_tags(),
+                ISORCE=self._metadata.im_subheader_part.isorce,
                 NROWS=this_rows,
                 NCOLS=cols,
                 PVTYPE=PIXEL_TYPES[pixel_type]["pvtype"],
@@ -652,7 +620,7 @@ class SicdNitfWriter:
                 Comments=sarkit._nitf.nitf_elements.image.ImageComments(
                     [
                         sarkit._nitf.nitf_elements.image.ImageComment(COMMENT=comment)
-                        for comment in self._nitf_plan.is_fields.icom
+                        for comment in self._metadata.im_subheader_part.icom
                     ]
                 ),
                 IC="NC",
@@ -673,7 +641,7 @@ class SicdNitfWriter:
             )
             image_managers.append(sarkit._nitf.nitf.ImageSubheaderManager(subhead))
 
-        sicd_des = _create_des_manager(sicd_xmltree, self._nitf_plan.des_fields)
+        sicd_des = _create_des_manager(sicd_xmltree, self._metadata.de_subheader_part)
 
         sicd_details = sarkit._nitf.nitf.NITFWritingDetails(
             header,
@@ -700,16 +668,14 @@ class SicdNitfWriter:
             If not given, `array` must be the full SICD image.
 
         """
-        pixel_type = self._nitf_plan.sicd_xmltree.findtext(
-            "./{*}ImageData/{*}PixelType"
-        )
+        pixel_type = self._metadata.xmltree.findtext("./{*}ImageData/{*}PixelType")
         if PIXEL_TYPES[pixel_type]["dtype"] != array.dtype.newbyteorder("="):
             raise ValueError(
                 f"Array dtype ({array.dtype}) does not match expected dtype ({PIXEL_TYPES[pixel_type]['dtype']}) "
                 f"for PixelType={pixel_type}"
             )
 
-        xml_helper = sicd_xml.XmlHelper(self._nitf_plan.sicd_xmltree)
+        xml_helper = sicd_xml.XmlHelper(self._metadata.xmltree)
         rows = xml_helper.load("./{*}ImageData/{*}NumRows")
         cols = xml_helper.load("./{*}ImageData/{*}NumCols")
         sicd_shape = np.asarray((rows, cols))
@@ -749,7 +715,7 @@ class SicdNitfWriter:
         """
         Flush to disk and close any opened file descriptors.
 
-        Called automatically when SicdNitfWriter is used as a context manager
+        Called automatically when used as a context manager
         """
         self._nitf_writer.close()
 

--- a/sarkit/sidd/__init__.py
+++ b/sarkit/sidd/__init__.py
@@ -18,18 +18,18 @@ Data Structure & File Format
 .. autosummary::
    :toctree: generated/
 
-   SiddNitfHeaderFields
-   SiddNitfSecurityFields
-   SiddNitfImageSegmentFields
-   SiddNitfDESegmentFields
-   SiddNitfReader
-   SiddNitfPlan
-   SiddNitfPlanProductImageInfo
-   SiddNitfPlanLegendInfo
-   SiddNitfPlanDedInfo
-   SiddNitfPlanProductSupportXmlInfo
-   SiddNitfPlanSicdXmlInfo
-   SiddNitfWriter
+   NitfSecurityFields
+   NitfFileHeaderPart
+   NitfImSubheaderPart
+   NitfDeSubheaderPart
+   NitfReader
+   NitfMetadata
+   NitfProductImageMetadata
+   NitfLegendMetadata
+   NitfDedMetadata
+   NitfProductSupportXmlMetadata
+   NitfSicdXmlMetadata
+   NitfWriter
    SegmentationImhdr
    segmentation_algorithm
 
@@ -117,19 +117,19 @@ from ._io import (
     LI_MAX,
     PIXEL_TYPES,
     VERSION_INFO,
+    NitfDedMetadata,
+    NitfDeSubheaderPart,
+    NitfFileHeaderPart,
+    NitfImSubheaderPart,
+    NitfLegendMetadata,
+    NitfMetadata,
+    NitfProductImageMetadata,
+    NitfProductSupportXmlMetadata,
+    NitfReader,
+    NitfSecurityFields,
+    NitfSicdXmlMetadata,
+    NitfWriter,
     SegmentationImhdr,
-    SiddNitfDESegmentFields,
-    SiddNitfHeaderFields,
-    SiddNitfImageSegmentFields,
-    SiddNitfPlan,
-    SiddNitfPlanDedInfo,
-    SiddNitfPlanLegendInfo,
-    SiddNitfPlanProductImageInfo,
-    SiddNitfPlanProductSupportXmlInfo,
-    SiddNitfPlanSicdXmlInfo,
-    SiddNitfReader,
-    SiddNitfSecurityFields,
-    SiddNitfWriter,
     segmentation_algorithm,
 )
 from ._xml import (
@@ -172,6 +172,18 @@ __all__ = [
     "IntListType",
     "IntType",
     "LatLonType",
+    "NitfDeSubheaderPart",
+    "NitfDedMetadata",
+    "NitfFileHeaderPart",
+    "NitfImSubheaderPart",
+    "NitfLegendMetadata",
+    "NitfMetadata",
+    "NitfProductImageMetadata",
+    "NitfProductSupportXmlMetadata",
+    "NitfReader",
+    "NitfSecurityFields",
+    "NitfSicdXmlMetadata",
+    "NitfWriter",
     "ParameterType",
     "PolyCoef1dType",
     "PolyCoef2dType",
@@ -180,18 +192,6 @@ __all__ = [
     "RowColIntType",
     "SegmentationImhdr",
     "SfaPointType",
-    "SiddNitfDESegmentFields",
-    "SiddNitfHeaderFields",
-    "SiddNitfImageSegmentFields",
-    "SiddNitfPlan",
-    "SiddNitfPlanDedInfo",
-    "SiddNitfPlanLegendInfo",
-    "SiddNitfPlanProductImageInfo",
-    "SiddNitfPlanProductSupportXmlInfo",
-    "SiddNitfPlanSicdXmlInfo",
-    "SiddNitfReader",
-    "SiddNitfSecurityFields",
-    "SiddNitfWriter",
     "TxtType",
     "XdtType",
     "XmlHelper",

--- a/sarkit/sidd/_io.py
+++ b/sarkit/sidd/_io.py
@@ -94,18 +94,18 @@ ILOC_MAX: Final[int] = 99_999
 
 
 # SICD implementation happens to match, reuse it
-class SiddNitfSecurityFields(sksicd.SicdNitfSecurityFields):
+class NitfSecurityFields(sksicd.SicdNitfSecurityFields):
     __doc__ = sksicd.SicdNitfSecurityFields.__doc__
 
 
 # SICD implementation happens to match, reuse it
-class SiddNitfHeaderFields(sksicd.SicdNitfHeaderFields):
+class NitfFileHeaderPart(sksicd.SicdNitfHeaderFields):
     __doc__ = sksicd.SicdNitfHeaderFields.__doc__
 
 
 @dataclasses.dataclass(kw_only=True)
-class SiddNitfImageSegmentFields:
-    """NITF image header fields which are set according to a Program Specific Implementation Document
+class NitfImSubheaderPart:
+    """NITF image subheader fields which are set according to a Program Specific Implementation Document
 
     Attributes
     ----------
@@ -113,7 +113,7 @@ class SiddNitfImageSegmentFields:
         Target Identifier
     iid2 : str
         Image Identifier 2
-    security : :py:class:`SiddNitfSecurityFields`
+    security : NitfSecurityFields
         Security Tags with "IS" prefix
     icom : list of str
         Image Comments
@@ -122,7 +122,7 @@ class SiddNitfImageSegmentFields:
     ## IS fields are applied to all segments
     tgtid: str = ""
     iid2: str = ""
-    security: SiddNitfSecurityFields
+    security: NitfSecurityFields
     icom: list[str] = dataclasses.field(default_factory=list)
 
     @classmethod
@@ -131,7 +131,7 @@ class SiddNitfImageSegmentFields:
         return cls(
             tgtid=image_header.TGTID,
             iid2=image_header.IID2,
-            security=SiddNitfSecurityFields._from_security_tags(image_header.Security),
+            security=NitfSecurityFields._from_security_tags(image_header.Security),
             icom=[
                 val.to_bytes().decode().rstrip() for val in image_header.Comments.values
             ],
@@ -139,295 +139,136 @@ class SiddNitfImageSegmentFields:
 
     def __post_init__(self):
         if isinstance(self.security, dict):
-            self.security = SiddNitfSecurityFields(**self.security)
+            self.security = NitfSecurityFields(**self.security)
 
 
 # SICD implementation happens to match, reuse it
-class SiddNitfDESegmentFields(sksicd.SicdNitfDESegmentFields):
+class NitfDeSubheaderPart(sksicd.SicdNitfDESegmentFields):
     __doc__ = sksicd.SicdNitfDESegmentFields.__doc__
 
 
 @dataclasses.dataclass
-class SiddNitfPlanProductImageInfo:
-    """Metadata necessary for describing the plan to add a product image to a SIDD
+class NitfLegendMetadata:
+    """SIDD NITF legend metadata"""
+
+    def __post_init__(self):
+        raise NotImplementedError()
+
+
+@dataclasses.dataclass(kw_only=True)
+class NitfProductImageMetadata:
+    """SIDD NITF product image metadata
 
     Attributes
     ----------
-    sidd_xmltree : lxml.etree.ElementTree
-        SIDD product metadata XML ElementTree
-    is_fields : :py:class:`SiddNitfImageSegmentFields`
-        NITF Image Segment Header fields which can be set
-    des_fields : :py:class:`SiddNitfDESegmentFields`
-        NITF DE Segment Header fields which can be set
-
-    See Also
-    --------
-    SiddNitfPlan
-    SiddNitfPlanLegendInfo
-    SiddNitfPlanDedInfo
-    SiddNitfPlanProductSupportXmlInfo
-    SiddNitfPlanSicdXmlInfo
+    xmltree : lxml.etree.ElementTree
+        SIDD XML
+    im_subheader_part : NitfImSubheaderPart
+        NITF image subheader fields which can be set
+    de_subheader_part : NitfDeSubheaderPart
+        NITF DES subheader fields which can be set
+    legends : list of NitfLegendMetadata
+        Metadata for legend(s) attached to this image
     """
 
-    sidd_xmltree: lxml.etree.ElementTree
-    is_fields: SiddNitfImageSegmentFields
-    des_fields: SiddNitfDESegmentFields
+    xmltree: lxml.etree.ElementTree
+    im_subheader_part: NitfImSubheaderPart
+    de_subheader_part: NitfDeSubheaderPart
+    legends: list[NitfLegendMetadata] = dataclasses.field(default_factory=list)
 
     def __post_init__(self):
-        if isinstance(self.is_fields, dict):
-            self.is_fields = SiddNitfImageSegmentFields(**self.is_fields)
-            self.des_fields = SiddNitfDESegmentFields(**self.des_fields)
+        _validate_xml(self.xmltree)
+        if isinstance(self.im_subheader_part, dict):
+            self.im_subheader_part = NitfImSubheaderPart(**self.im_subheader_part)
+        if isinstance(self.de_subheader_part, dict):
+            self.de_subheader_part = NitfDeSubheaderPart(**self.de_subheader_part)
 
 
 @dataclasses.dataclass
-class SiddNitfPlanLegendInfo:
-    """Metadata necessary for describing the plan to add a legend to a SIDD
-
-    See Also
-    --------
-    SiddNitfPlan
-    SiddNitfPlanProductImageInfo
-    SiddNitfPlanDedInfo
-    SiddNitfPlanProductSupportXmlInfo
-    SiddNitfPlanSicdXmlInfo
-    """
+class NitfDedMetadata:
+    """SIDD NITF DED metadata"""
 
     def __post_init__(self):
         raise NotImplementedError()
 
 
 @dataclasses.dataclass
-class SiddNitfPlanDedInfo:
-    """Metadata necessary for describing the plan to add Digital Elevation Data (DED) to a SIDD
-
-    See Also
-    --------
-    SiddNitfPlan
-    SiddNitfPlanProductImageInfo
-    SiddNitfPlanLegendInfo
-    SiddNitfPlanProductSupportXmlInfo
-    SiddNitfPlanSicdXmlInfo
-    """
-
-    def __post_init__(self):
-        raise NotImplementedError()
-
-
-@dataclasses.dataclass
-class SiddNitfPlanProductSupportXmlInfo:
-    """Metadata necessary for describing the plan to add a Product Support XML to a SIDD
-
-    See Also
-    --------
-    SiddNitfPlan
-    SiddNitfPlanProductImageInfo
-    SiddNitfPlanLegendInfo
-    SiddNitfPlanDedInfo
-    SiddNitfPlanSicdXmlInfo
-    """
-
-    product_support_xmltree: lxml.etree.ElementTree
-    des_fields: SiddNitfDESegmentFields
-
-    def __post_init__(self):
-        if isinstance(self.des_fields, dict):
-            self.des_fields = SiddNitfDESegmentFields(**self.des_fields)
-
-
-@dataclasses.dataclass
-class SiddNitfPlanSicdXmlInfo:
-    """Metadata necessary for describing the plan to add SICD XML to a SIDD
-
-    See Also
-    --------
-    SiddNitfPlan
-    SiddNitfPlanProductImageInfo
-    SiddNitfPlanLegendInfo
-    SiddNitfPlanDedInfo
-    SiddNitfPlanProductSupportXmlInfo
-    """
-
-    sicd_xmltree: lxml.etree.ElementTree
-    des_fields: sksicd.SicdNitfDESegmentFields
-
-    def __post_init__(self):
-        if isinstance(self.des_fields, dict):
-            self.des_fields = sksicd.SicdNitfDESegmentFields(**self.des_fields)
-
-
-class SiddNitfPlan:
-    """Class describing the plan for creating a SIDD NITF Container
-
-    Parameters
-    ----------
-    header_fields : :py:class:`SiddNitfHeaderFields`
-        NITF Header fields
+class NitfProductSupportXmlMetadata:
+    """SIDD NITF product support XML metadata
 
     Attributes
     ----------
-    header_fields : :py:class:`SiddNitfHeaderFields`
-        NITF File Header fields which can be set
-    images : list of :py:class:`SiddNitfPlanProductImageInfo`
-        List of image information
-    legends : list of :py:class:`SiddNitfPlanLegendInfo`
-        List of legend information
-    ded : :py:class:`SiddNitfPlanDedInfo`
-        DED information
-    product_support_xmls : list of :py:class:`SiddNitfPlanProductSupportXmlInfo`
-        List of SICD XML information
-    sicd_xmls : list of :py:class:`SiddNitfPlanSicdXmlInfo`
-        List of SICD XML information
-
-    See Also
-    --------
-    SiddNitfReader
-    SiddNitfWriter
-    SiddNitfSecurityFields
-    SiddNitfHeaderFields
-    SiddNitfImageSegmentFields
-    SiddNitfDESegmentFields
-    SiddNitfPlanProductImageInfo
-    SiddNitfPlanLegendInfo
+    xmltree : lxml.etree.ElementTree
+        SIDD product support XML
+    de_subheader_part : NitfDeSubheaderPart
+        NITF DES subheader fields which can be set
     """
 
-    def __init__(self, header_fields: SiddNitfHeaderFields | dict):
-        self.header_fields = header_fields
-        if isinstance(self.header_fields, dict):
-            self.header_fields = SiddNitfHeaderFields(**self.header_fields)
-        self._images: list[SiddNitfPlanProductImageInfo] = []
-        self._legends: list[SiddNitfPlanLegendInfo] = []
-        self._ded: SiddNitfPlanDedInfo | None = None
-        self._product_support_xmls: list[SiddNitfPlanProductSupportXmlInfo] = []
-        self._sicd_xmls: list[SiddNitfPlanSicdXmlInfo] = []
+    xmltree: lxml.etree.ElementTree
+    de_subheader_part: NitfDeSubheaderPart
 
-    @property
-    def images(self) -> list[SiddNitfPlanProductImageInfo]:
-        return self._images
+    def __post_init__(self):
+        if isinstance(self.de_subheader_part, dict):
+            self.de_subheader_part = NitfDeSubheaderPart(**self.de_subheader_part)
 
-    @property
-    def legends(self) -> list[SiddNitfPlanLegendInfo]:
-        return self._legends
 
-    @property
-    def ded(self) -> SiddNitfPlanDedInfo | None:
-        return self._ded
+@dataclasses.dataclass
+class NitfSicdXmlMetadata:
+    """SIDD NITF SICD XML metadata
 
-    @property
-    def product_support_xmls(self) -> list[SiddNitfPlanProductSupportXmlInfo]:
-        return self._product_support_xmls
+    Attributes
+    ----------
+    xmltree : lxml.etree.ElementTree
+        SICD XML
+    de_subheader_part : NitfDeSubheaderPart
+        NITF DES subheader fields which can be set
+    """
 
-    @property
-    def sicd_xmls(self) -> list[SiddNitfPlanSicdXmlInfo]:
-        return self._sicd_xmls
+    xmltree: lxml.etree.ElementTree
+    de_subheader_part: sksicd.SicdNitfDESegmentFields
 
-    def add_image(
-        self,
-        sidd_xmltree: lxml.etree.ElementTree,
-        is_fields: SiddNitfImageSegmentFields,
-        des_fields: SiddNitfDESegmentFields,
-    ) -> int:
-        """Add a SAR product to the plan
-
-        Parameters
-        ----------
-        sidd_xmltree : lxml.etree.ElementTree
-            SIDD XML ElementTree
-        is_fields : :py:class:`SiddNitfImageSegmentFields`
-            NITF Image Segment Header fields which can be set
-        des_fields : :py:class:`SiddNitfDESegmentFields`
-            NITF DE Segment Header fields which can be set
-
-        Returns
-        -------
-        int
-            The image number of the newly added SAR image
-        """
-        _validate_xml(sidd_xmltree)
-
-        self._images.append(
-            SiddNitfPlanProductImageInfo(
-                sidd_xmltree, is_fields=is_fields, des_fields=des_fields
+    def __post_init__(self):
+        if isinstance(self.de_subheader_part, dict):
+            self.de_subheader_part = sksicd.SicdNitfDESegmentFields(
+                **self.de_subheader_part
             )
-        )
-        return len(self._images) - 1
-
-    def add_product_support_xml(
-        self, ps_xmltree: lxml.etree.ElementTree, des_fields: SiddNitfDESegmentFields
-    ) -> int:
-        """Add a Product Support XML to the plan
-
-        Parameters
-        ----------
-        ps_xmltree : lxml.etree.ElementTree
-            Product Support XML ElementTree
-        des_fields : :py:class:`SiddNitfDESegmentFields`
-            NITF DE Segment Header fields which can be set
-
-        Returns
-        -------
-        int
-            The index of the newly added Product Support XML
-        """
-        self.product_support_xmls.append(
-            SiddNitfPlanProductSupportXmlInfo(ps_xmltree, des_fields)
-        )
-        return len(self.product_support_xmls) - 1
-
-    def add_sicd_xml(
-        self,
-        sicd_xmltree: lxml.etree.ElementTree,
-        des_fields: sksicd.SicdNitfDESegmentFields,
-    ) -> int:
-        """Add a SICD XML to the plan
-
-        Parameters
-        ----------
-        sicd_xmltree : lxml.etree.ElementTree
-            SICD XML ElementTree
-        des_fields : :py:class:`sicdio.SicdNitfDESegmentFields`
-            NITF DE Segment Header fields which can be set
-
-        Returns
-        -------
-        int
-            The index of the newly added SICD XML
-        """
-        self.sicd_xmls.append(SiddNitfPlanSicdXmlInfo(sicd_xmltree, des_fields))
-        return len(self.sicd_xmls) - 1
-
-    def add_legend(
-        self, attached_to: int, location: tuple[int, int], shape: tuple[int, int]
-    ) -> int:
-        """Add a Legend to the plan
-
-        Parameters
-        ----------
-        attached_to : int
-            SAR image number to attach legend to
-        location : tuple of int
-            (row, column) of the SAR image to place first legend pixel
-        shape : tuple of int
-            Dimension of the legend (Number of Rows, Number of Columns)
-
-        """
-        raise NotImplementedError()
-
-    def add_ded(self, shape: tuple[int, int]) -> int:
-        """Add a DED to the plan
-
-        Parameters
-        ----------
-        shape : tuple of int
-            Dimension of the DED (Number of Rows, Number of Columns)
-
-        """
-        raise NotImplementedError()
 
 
-class SiddNitfReader:
+@dataclasses.dataclass(kw_only=True)
+class NitfMetadata:
+    """Settable SIDD NITF metadata
+
+    Attributes
+    ----------
+    file_header_part : NitfFileHeaderPart
+        NITF file header fields which can be set
+    images : list of NitfProductImageMetadata
+        Settable metadata for the product image(s)
+    ded : NitfDedMetadata or None
+        Settable metadata for the Digital Elevation Data
+    product_support_xmls : list of NitfProductSupportXmlMetadata
+        Settable metadata for the product support XML(s)
+    sicd_xmls : list of NitfSicdXmlMetadata
+        Settable metadata for the SICD XML(s)
+    """
+
+    file_header_part: NitfFileHeaderPart
+    images: list[NitfProductImageMetadata] = dataclasses.field(default_factory=list)
+    ded: NitfDedMetadata | None = None
+    product_support_xmls: list[NitfProductSupportXmlMetadata] = dataclasses.field(
+        default_factory=list
+    )
+    sicd_xmls: list[NitfSicdXmlMetadata] = dataclasses.field(default_factory=list)
+
+    def __post_init__(self):
+        if isinstance(self.file_header_part, dict):
+            self.file_header_part = NitfFileHeaderPart(**self.file_header_part)
+
+
+class NitfReader:
     """Read a SIDD NITF
 
-    A SiddNitfReader object should be used as a context manager in a ``with`` statement.
+    A NitfReader object should be used as a context manager in a ``with`` statement.
     Attributes, but not methods, can be safely accessed outside of the context manager's context.
 
     Parameters
@@ -437,23 +278,18 @@ class SiddNitfReader:
 
     Examples
     --------
-    >>> with sidd_path.open('rb') as file, SiddNitfReader(file) as reader:
-    ...     sidd_xmltree = reader.images[0].sidd_xmltree
+    >>> with sidd_path.open('rb') as file, NitfReader(file) as reader:
+    ...     sidd_xmltree = reader.metadata.images[0].xmltree
     ...     pixels = reader.read_image(0)
 
     Attributes
     ----------
-    images : list of :py:class:`SiddNitfPlanProductImageInfo`
-    header_fields : :py:class:`SiddNitfHeaderFields`
-    product_support_xmls : list of :py:class:`SiddNitfPlanProductSupportXmlInfo`
-    sicd_xmls : list of :py:class:`SiddNitfPlanSicdXmlInfo`
-    plan : :py:class:`SiddNitfPlan`
-        A SiddNitfPlan object suitable for use in a SiddNitfWriter
+    metadata : NitfMetadata
+        SIDD NITF metadata
 
     See Also
     --------
-    SiddNitfPlan
-    SiddNitfWriter
+    NitfWriter
     """
 
     def __init__(self, file):
@@ -494,10 +330,10 @@ class SiddNitfReader:
             ),
         )
 
-        self.header_fields = SiddNitfHeaderFields._from_header(
+        self.header_fields = NitfFileHeaderPart._from_header(
             self._nitf_details.nitf_header
         )
-        self.plan = SiddNitfPlan(header_fields=self.header_fields)
+        self.metadata = NitfMetadata(file_header_part=self.header_fields)
 
         image_number = 0
         for idx in range(self._nitf_details.des_subheader_offsets.size):
@@ -514,40 +350,42 @@ class SiddNitfReader:
                     continue
 
                 if "SIDD" in xmltree.getroot().tag:
-                    nitf_de_fields = SiddNitfDESegmentFields._from_header(des_header)
-                    if len(self.plan.images) < len(image_segment_collections):
+                    nitf_de_fields = NitfDeSubheaderPart._from_header(des_header)
+                    if len(self.metadata.images) < len(image_segment_collections):
                         # user settable fields should be the same for all image segments
                         im_idx = im_segments[image_number][0]
-                        im_fields = SiddNitfImageSegmentFields._from_header(
-                            self._nitf_details.img_headers[im_idx]
-                        )
-                        self.plan.add_image(
-                            sidd_xmltree=xmltree,
-                            is_fields=im_fields,
-                            des_fields=nitf_de_fields,
+                        self.metadata.images.append(
+                            NitfProductImageMetadata(
+                                xmltree=xmltree,
+                                im_subheader_part=NitfImSubheaderPart._from_header(
+                                    self._nitf_details.img_headers[im_idx]
+                                ),
+                                de_subheader_part=nitf_de_fields,
+                            )
                         )
                         image_number += 1
                     else:
                         # No matching product image, treat it as a product support XML
-                        self.plan.add_product_support_xml(xmltree, nitf_de_fields)
+                        self.metadata.product_support_xmls.append(
+                            NitfProductSupportXmlMetadata(xmltree, nitf_de_fields)
+                        )
                 elif "SICD" in xmltree.getroot().tag:
                     nitf_de_fields = sksicd.SicdNitfDESegmentFields._from_header(
                         des_header
                     )
-                    self.plan.add_sicd_xml(xmltree, nitf_de_fields)
+                    self.metadata.sicd_xmls.append(
+                        NitfSicdXmlMetadata(xmltree, nitf_de_fields)
+                    )
                 else:
-                    nitf_de_fields = SiddNitfDESegmentFields._from_header(des_header)
-                    self.plan.add_product_support_xml(xmltree, nitf_de_fields)
+                    nitf_de_fields = NitfDeSubheaderPart._from_header(des_header)
+                    self.metadata.product_support_xmls.append(
+                        NitfProductSupportXmlMetadata(xmltree, nitf_de_fields)
+                    )
 
         # TODO Legends
         # TODO DED
-        assert not self.plan.legends
-        assert not self.plan.ded
-
-    @property
-    def images(self) -> list[SiddNitfPlanProductImageInfo]:
-        """List of images contained in the SIDD"""
-        return self.plan.images
+        assert not any(x.legends for x in self.metadata.images)
+        assert not self.metadata.ded
 
     def read_image(self, image_number: int) -> npt.NDArray:
         """Read the entire pixel array
@@ -564,16 +402,6 @@ class SiddNitfReader:
         """
         return self._nitf_reader.read(index=image_number)
 
-    @property
-    def product_support_xmls(self) -> list[SiddNitfPlanProductSupportXmlInfo]:
-        """List of Product Support XML instances contained in the SIDD"""
-        return self.plan.product_support_xmls
-
-    @property
-    def sicd_xmls(self) -> list[SiddNitfPlanSicdXmlInfo]:
-        """List of SICD XML contained in the SIDD"""
-        return self.plan.sicd_xmls
-
     def __enter__(self):
         return self
 
@@ -581,42 +409,77 @@ class SiddNitfReader:
         return
 
 
-class SiddNitfWriter:
+class NitfWriter:
     """Write a SIDD NITF
 
-    A SiddNitfWriter object should be used as a context manager in a ``with`` statement.
+    A NitfWriter object should be used as a context manager in a ``with`` statement.
 
     Parameters
     ----------
     file : `file object`
         SIDD NITF file to write
-    nitf_plan : :py:class:`SiddNitfPlan`
-        NITF plan object
+    metadata : NitfMetadata
+        SIDD NITF metadata to write
 
     Notes
     -----
-    nitf_plan should not be modified after creation of a writer
+    ``metadata`` should not be modified after creation of a writer
 
     Examples
     --------
-    >>> plan = SiddNitfPlan(header_fields=SiddNitfHeaderFields(ostaid='my location',
-    ...                                                        security=SiddNitfSecurityFields(clas='U')))
-    >>> image_index = plan.add_image(is_fields=SiddNitfImageSegmentFields(security=SiddNitfSecurityFields(clas='U')),
-    ...                              des_fields=SiddNitfDESegmentFields(security=SiddNitfSecurityFields(clas='U')))
-    >>> with output_path.open('wb') as file, SiddNitfWriter(file, plan) as writer:
-    ...     writer.write_image(image_index, pixel_array)
+    Write a SIDD NITF with a single product image
+
+    .. doctest::
+
+        >>> import sarkit.sidd as sksidd
+
+    Build the product image description and pixels
+
+    .. doctest::
+
+        >>> import lxml.etree
+        >>> sidd_xml = lxml.etree.parse("data/example-sidd-3.0.0.xml")
+
+        >>> sec = sksidd.NitfSecurityFields(clas="U")
+        >>> img_meta = sksidd.NitfProductImageMetadata(
+        ...     xmltree=sidd_xml,
+        ...     im_subheader_part=sksidd.NitfImSubheaderPart(security=sec),
+        ...     de_subheader_part=sksidd.NitfDeSubheaderPart(security=sec),
+        ... )
+
+        >>> import numpy as np
+        >>> img_to_write = np.zeros(
+        ...     sksidd.XmlHelper(sidd_xml).load("{*}Measurement/{*}PixelFootprint"),
+        ...     dtype=sksidd.PIXEL_TYPES[sidd_xml.findtext("{*}Display/{*}PixelType")]["dtype"],
+        ... )
+
+    Place the product image in a NITF metadata object
+
+    .. doctest::
+
+        >>> meta = sksidd.NitfMetadata(
+        ...     file_header_part=sksidd.NitfFileHeaderPart(ostaid="my station", security=sec),
+        ...     images=[img_meta],
+        ... )
+
+    Write the SIDD NITF to a file
+
+    .. doctest::
+
+        >>> from tempfile import NamedTemporaryFile
+        >>> outfile = NamedTemporaryFile()
+        >>> with sksidd.NitfWriter(outfile, meta) as w:
+        ...     w.write_image(0, img_to_write)
 
     See Also
     --------
-    SiddNitfPlan
-    SiddNitfReader
+    NitfReader
     """
 
-    def __init__(self, file, nitf_plan):
+    def __init__(self, file, metadata: NitfMetadata):
         self._file = file
-        self._nitf_plan = nitf_plan
-
-        self._images_written = set()
+        self._metadata = metadata
+        self._images_written: set[int] = set()
 
         self._initial_offset = self._file.tell()
         if self._initial_offset != 0:
@@ -628,21 +491,25 @@ class SiddNitfWriter:
         now_dt = datetime.datetime.now(datetime.timezone.utc)
         header = sarkit._nitf.nitf_elements.nitf_head.NITFHeader(
             CLEVEL=3,
-            OSTAID=self._nitf_plan.header_fields.ostaid,
+            OSTAID=self._metadata.file_header_part.ostaid,
             FDT=now_dt.strftime("%Y%m%d%H%M%S"),
-            FTITLE=self._nitf_plan.header_fields.ftitle,
-            Security=self._nitf_plan.header_fields.security._as_security_tags(),
-            ONAME=self._nitf_plan.header_fields.oname,
-            OPHONE=self._nitf_plan.header_fields.ophone,
+            FTITLE=self._metadata.file_header_part.ftitle,
+            Security=self._metadata.file_header_part.security._as_security_tags(),
+            ONAME=self._metadata.file_header_part.oname,
+            OPHONE=self._metadata.file_header_part.ophone,
             FL=0,
         )
 
         image_managers = []
-        image_segment_collections = {}  # image_num -> [image_segment, ...]
-        image_segment_coordinates = {}  # image_num -> [(first_row, last_row, first_col, last_col), ...]
+        image_segment_collections: dict[
+            int, list[int]
+        ] = {}  # image_num -> [image_segment, ...]
+        image_segment_coordinates: dict[
+            int, list[tuple[int, int, int, int]]
+        ] = {}  # image_num -> [(first_row, last_row, first_col, last_col), ...]
         current_start_row = 0
         _, _, imhdrs = segmentation_algorithm(
-            (img.sidd_xmltree for img in self._nitf_plan.images)
+            (img.xmltree for img in self._metadata.images)
         )
         for idx, imhdr in enumerate(imhdrs):
             if imhdr.ialvl == 0:
@@ -657,8 +524,8 @@ class SiddNitfWriter:
             )
             current_start_row += imhdr.nrows
 
-            imageinfo = self._nitf_plan.images[image_num]
-            xml_helper = sarkit.sidd._xml.XmlHelper(imageinfo.sidd_xmltree)
+            imageinfo = self._metadata.images[image_num]
+            xml_helper = sarkit.sidd._xml.XmlHelper(imageinfo.xmltree)
             pixel_info = PIXEL_TYPES[xml_helper.load("./{*}Display/{*}PixelType")]
 
             icp = xml_helper.load("./{*}GeoData/{*}ImageCorners")
@@ -670,9 +537,9 @@ class SiddNitfWriter:
                 IDATIM=xml_helper.load(
                     "./{*}ExploitationFeatures/{*}Collection/{*}Information/{*}CollectionDateTime"
                 ).strftime("%Y%m%d%H%M%S"),
-                TGTID=imageinfo.is_fields.tgtid,
-                IID2=imageinfo.is_fields.iid2,
-                Security=imageinfo.is_fields.security._as_security_tags(),
+                TGTID=imageinfo.im_subheader_part.tgtid,
+                IID2=imageinfo.im_subheader_part.iid2,
+                Security=imageinfo.im_subheader_part.security._as_security_tags(),
                 ISORCE=xml_helper.load(
                     "./{*}ExploitationFeatures/{*}Collection/{*}Information/{*}SensorName"
                 ),
@@ -692,7 +559,7 @@ class SiddNitfWriter:
                 Comments=sarkit._nitf.nitf_elements.image.ImageComments(
                     [
                         sarkit._nitf.nitf_elements.image.ImageComment(COMMENT=comment)
-                        for comment in imageinfo.is_fields.icom
+                        for comment in imageinfo.im_subheader_part.icom
                     ]
                 ),
                 IC="NC",
@@ -717,23 +584,23 @@ class SiddNitfWriter:
             image_managers.append(sarkit._nitf.nitf.ImageSubheaderManager(subhead))
 
         # TODO add image_managers for legends
-        assert not self._nitf_plan.legends
+        assert not any(x.legends for x in self._metadata.images)
         # TODO add image_managers for DED
-        assert not self._nitf_plan.ded
+        assert not self._metadata.ded
 
         # DE Segments
 
         des_managers = []
-        for imageinfo in self._nitf_plan.images:
-            xmlns = lxml.etree.QName(imageinfo.sidd_xmltree.getroot()).namespace
-            xml_helper = sarkit.sidd._xml.XmlHelper(imageinfo.sidd_xmltree)
+        for imageinfo in self._metadata.images:
+            xmlns = lxml.etree.QName(imageinfo.xmltree.getroot()).namespace
+            xml_helper = sarkit.sidd._xml.XmlHelper(imageinfo.xmltree)
             icp = xml_helper.load("./{*}GeoData/{*}ImageCorners")
             desshlpg = ""
             for icp_lat, icp_lon in itertools.chain(icp, [icp[0]]):
                 desshlpg += f"{icp_lat:0=+12.8f}{icp_lon:0=+13.8f}"
 
             deshead = sarkit._nitf.nitf_elements.des.DataExtensionHeader(
-                Security=imageinfo.des_fields.security._as_security_tags(),
+                Security=imageinfo.de_subheader_part.security._as_security_tags(),
                 UserHeader=sarkit._nitf.nitf_elements.des.XMLDESSubheader(
                     DESSHSI=SPECIFICATION_IDENTIFIER,
                     DESSHSV=VERSION_INFO[xmlns]["version"],
@@ -741,27 +608,24 @@ class SiddNitfWriter:
                     DESSHTN=xmlns,
                     DESSHDT=now_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
                     DESSHLPG=desshlpg,
-                    DESSHRP=imageinfo.des_fields.desshrp,
-                    DESSHLI=imageinfo.des_fields.desshli,
-                    DESSHLIN=imageinfo.des_fields.desshlin,
-                    DESSHABS=imageinfo.des_fields.desshabs,
+                    DESSHRP=imageinfo.de_subheader_part.desshrp,
+                    DESSHLI=imageinfo.de_subheader_part.desshli,
+                    DESSHLIN=imageinfo.de_subheader_part.desshlin,
+                    DESSHABS=imageinfo.de_subheader_part.desshabs,
                 ),
             )
             des_managers.append(
                 sarkit._nitf.nitf.DESSubheaderManager(
-                    deshead, lxml.etree.tostring(imageinfo.sidd_xmltree)
+                    deshead, lxml.etree.tostring(imageinfo.xmltree)
                 )
             )
 
         # Product Support XML DES
-        for prodinfo in self._nitf_plan.product_support_xmls:
+        for prodinfo in self._metadata.product_support_xmls:
             sidd_uh = des_managers[0].subheader.UserHeader
-            xmlns = (
-                lxml.etree.QName(prodinfo.product_support_xmltree.getroot()).namespace
-                or ""
-            )
+            xmlns = lxml.etree.QName(prodinfo.xmltree.getroot()).namespace or ""
             deshead = sarkit._nitf.nitf_elements.des.DataExtensionHeader(
-                Security=prodinfo.des_fields.security._as_security_tags(),
+                Security=prodinfo.de_subheader_part.security._as_security_tags(),
                 UserHeader=sarkit._nitf.nitf_elements.des.XMLDESSubheader(
                     DESSHSI=sidd_uh.DESSHSI,
                     DESSHSV="v" + sidd_uh.DESSHSV,
@@ -769,23 +633,23 @@ class SiddNitfWriter:
                     DESSHTN=xmlns,
                     DESSHDT=now_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
                     DESSHLPG="",
-                    DESSHRP=prodinfo.des_fields.desshrp,
-                    DESSHLI=prodinfo.des_fields.desshli,
-                    DESSHLIN=prodinfo.des_fields.desshlin,
-                    DESSHABS=prodinfo.des_fields.desshabs,
+                    DESSHRP=prodinfo.de_subheader_part.desshrp,
+                    DESSHLI=prodinfo.de_subheader_part.desshli,
+                    DESSHLIN=prodinfo.de_subheader_part.desshlin,
+                    DESSHABS=prodinfo.de_subheader_part.desshabs,
                 ),
             )
             des_managers.append(
                 sarkit._nitf.nitf.DESSubheaderManager(
-                    deshead, lxml.etree.tostring(prodinfo.product_support_xmltree)
+                    deshead, lxml.etree.tostring(prodinfo.xmltree)
                 )
             )
 
         # SICD XML DES
-        for sicd_xml_info in self._nitf_plan.sicd_xmls:
+        for sicd_xml_info in self._metadata.sicd_xmls:
             des_managers.append(
                 sarkit.sicd._io._create_des_manager(
-                    sicd_xml_info.sicd_xmltree, sicd_xml_info.des_fields
+                    sicd_xml_info.xmltree, sicd_xml_info.de_subheader_part
                 )
             )
 
@@ -846,7 +710,7 @@ class SiddNitfWriter:
 
     def __exit__(self, *args, **kwargs):
         self._nitf_writer.close()
-        images_expected = set(range(len(self._nitf_plan.images)))
+        images_expected = set(range(len(self._metadata.images)))
         images_missing = images_expected - self._images_written
         if images_missing:
             logger.warning(
@@ -884,7 +748,7 @@ def segmentation_algorithm(
         Number of NITF image segments
     fhdr_li: list of int
         Length of each NITF image segment
-    imhdr: list of :py:class:`SegmentationImhdr`
+    imhdr: list of SegmentationImhdr
         Image Segment subheader information
     """
     z = 0

--- a/sarkit/verification/_cphd_consistency.py
+++ b/sarkit/verification/_cphd_consistency.py
@@ -179,8 +179,8 @@ class CphdConsistency(con.ConsistencyChecker):
                 pvps = None
             except etree.XMLSyntaxError:
                 infile.seek(0, os.SEEK_SET)
-                reader = skcphd.CphdReader(infile)
-                cphdroot = reader.cphd_xmltree
+                reader = skcphd.Reader(infile)
+                cphdroot = reader.metadata.xmltree
                 infile.seek(0, os.SEEK_SET)
                 _, kvp_list = skcphd.read_file_header(infile)
                 pvps = {}

--- a/sarkit/verification/_crsd_consistency.py
+++ b/sarkit/verification/_crsd_consistency.py
@@ -173,8 +173,8 @@ class CrsdConsistency(con.ConsistencyChecker):
                 ppps = None
             except etree.XMLSyntaxError:
                 infile.seek(0, os.SEEK_SET)
-                reader = skcrsd.CrsdReader(infile)
-                crsdroot = reader.crsd_xmltree
+                reader = skcrsd.Reader(infile)
+                crsdroot = reader.metadata.xmltree
                 infile.seek(0, os.SEEK_SET)
                 _, kvp_list = skcrsd.read_file_header(infile)
                 pvps = {}
@@ -214,7 +214,7 @@ class CrsdConsistency(con.ConsistencyChecker):
         """
         assert self.filename is not None
         assert self.kvp_list is not None
-        with open(self.filename, "rb") as fd, skcrsd.CrsdReader(fd) as reader:
+        with open(self.filename, "rb") as fd, skcrsd.Reader(fd) as reader:
             return reader.read_support_array(sa_id)
 
     def _get_channel_pvps(self, channel_id):
@@ -2068,7 +2068,7 @@ class CrsdConsistency(con.ConsistencyChecker):
             xml_offset = int(self.kvp_list["XML_BLOCK_BYTE_OFFSET"])
             with open(self.filename, "rb") as fd:
                 header_and_pad = fd.read(xml_offset)
-            end_of_header = header_and_pad.find(skcrsd.CRSD_SECTION_TERMINATOR)
+            end_of_header = header_and_pad.find(skcrsd.SECTION_TERMINATOR)
             with self.need("section terminator exists before XML block"):
                 assert end_of_header > 0
             with self.need("pad between header and XML is zeros"):
@@ -2091,7 +2091,7 @@ class CrsdConsistency(con.ConsistencyChecker):
             with open(self.filename, "rb") as fd:
                 fd.seek(xml_offset + xml_size)
                 with self.need("section terminator at end of XML block"):
-                    assert fd.read(2) == skcrsd.CRSD_SECTION_TERMINATOR
+                    assert fd.read(2) == skcrsd.SECTION_TERMINATOR
 
     def check_pad_before_binary_blocks(self):
         """Pad before binary blocks is null bytes"""

--- a/tests/core/crsd/test_io.py
+++ b/tests/core/crsd/test_io.py
@@ -64,31 +64,31 @@ def test_roundtrip(tmp_path, caplog):
         dt = skcrsd.binary_format_string_to_dtype(format_str)
         support_arrays[sa_id] = _random_array((nrows, ncols), dt)
 
-    crsd_plan = skcrsd.CrsdPlan(
-        file_header=skcrsd.CrsdFileHeaderFields(
-            classification="UNCLASSIFIED",
-            release_info="UNRESTRICTED",
+    crsd_metadata = skcrsd.Metadata(
+        file_header_part=skcrsd.FileHeaderPart(
             additional_kvps={"k1": "v1", "k2": "v2"},
         ),
-        crsd_xmltree=basis_etree,
+        xmltree=basis_etree,
     )
     out_crsd = tmp_path / "out.crsd"
     with open(out_crsd, "wb") as f:
-        with skcrsd.CrsdWriter(f, crsd_plan) as writer:
+        with skcrsd.Writer(f, crsd_metadata) as writer:
             writer.write_signal(channel_ids[0], basis_signal)
             writer.write_pvp(channel_ids[0], pvps)
             for k, v in support_arrays.items():
                 writer.write_support_array(k, v)
             writer.write_ppp(sequence_ids[0], ppps)
 
-    with open(out_crsd, "rb") as f, skcrsd.CrsdReader(f) as reader:
+    with open(out_crsd, "rb") as f, skcrsd.Reader(f) as reader:
         read_sig, read_pvp = reader.read_channel(channel_ids[0])
         read_support_arrays = {}
-        for sa_id in reader.crsd_xmltree.findall("./{*}SupportArray/*/{*}Identifier"):
+        for sa_id in reader.metadata.xmltree.findall(
+            "./{*}SupportArray/*/{*}Identifier"
+        ):
             read_support_arrays[sa_id.text] = reader.read_support_array(sa_id.text)
         read_ppp = reader.read_ppps(sequence_ids[0])
 
-    assert crsd_plan.file_header == reader.file_header
+    assert crsd_metadata.file_header_part == reader.metadata.file_header_part
     assert np.array_equal(basis_signal, read_sig)
     assert np.array_equal(pvps, read_pvp)
     assert np.array_equal(ppps, read_ppp)
@@ -98,6 +98,6 @@ def test_roundtrip(tmp_path, caplog):
         for f in support_arrays
     )
     assert lxml.etree.tostring(
-        reader.crsd_xmltree, method="c14n"
+        reader.metadata.xmltree, method="c14n"
     ) == lxml.etree.tostring(basis_etree, method="c14n")
     assert not caplog.text

--- a/tests/verification/test_cphd_consistency.py
+++ b/tests/verification/test_cphd_consistency.py
@@ -23,12 +23,8 @@ def example_cphd_file(tmp_path_factory):
     cphd_etree = etree.parse(good_cphd_xml_path)
     xmlhelp = skcphd.XmlHelper(cphd_etree)
 
-    cphd_plan = skcphd.CphdPlan(
-        file_header=skcphd.CphdFileHeaderFields(
-            classification="UNCLASSIFIED",
-            release_info="UNRESTRICTED",
-        ),
-        cphd_xmltree=cphd_etree,
+    cphd_plan = skcphd.Metadata(
+        xmltree=cphd_etree,
     )
     pvp_dtype = skcphd.get_pvp_dtype(cphd_etree)
 
@@ -84,7 +80,7 @@ def example_cphd_file(tmp_path_factory):
     tmp_cphd = (
         tmp_path_factory.mktemp("data") / good_cphd_xml_path.with_suffix(".cphd").name
     )
-    with open(tmp_cphd, "wb") as f, skcphd.CphdWriter(f, cphd_plan) as cw:
+    with open(tmp_cphd, "wb") as f, skcphd.Writer(f, cphd_plan) as cw:
         cw.write_pvp("1", pvps)
         cw.write_signal("1", signal)
     assert not main([str(tmp_cphd), "--signal-data"])

--- a/tests/verification/test_crsd_consistency.py
+++ b/tests/verification/test_crsd_consistency.py
@@ -167,14 +167,10 @@ def example_crsdsar_file(tmp_path_factory):
     )
     sequence_id = crsd_etree.findtext("{*}TxSequence/{*}Parameters/{*}Identifier")
     channel_id = crsd_etree.findtext("{*}Channel/{*}Parameters/{*}Identifier")
-    newplan = skcrsd.CrsdPlan(
-        file_header=skcrsd.CrsdFileHeaderFields(
-            classification="UNCLASSIFIED",
-            release_info="UNRESTRICTED",
-        ),
-        crsd_xmltree=crsd_etree,
+    new_meta = skcrsd.Metadata(
+        xmltree=crsd_etree,
     )
-    with open(tmp_crsd, "wb") as f, skcrsd.CrsdWriter(f, newplan) as cw:
+    with open(tmp_crsd, "wb") as f, skcrsd.Writer(f, new_meta) as cw:
         cw.write_ppp(sequence_id, ppps)
         cw.write_pvp(channel_id, pvps)
         cw.write_signal(channel_id, signal)
@@ -205,8 +201,8 @@ def _replace_error(crsd_etree, sensor_type):
 
 @pytest.fixture(scope="session")
 def example_crsdtx_file(tmp_path_factory, example_crsdsar_file):
-    with open(example_crsdsar_file, "rb") as f, skcrsd.CrsdReader(f) as cr:
-        crsd_etree = cr.crsd_xmltree
+    with open(example_crsdsar_file, "rb") as f, skcrsd.Reader(f) as cr:
+        crsd_etree = cr.metadata.xmltree
         sequence_id = crsd_etree.findtext("{*}TxSequence/{*}Parameters/{*}Identifier")
         ppps = cr.read_ppps(sequence_id)
     crsd_etree.find(".//{*}RefPulseIndex").text = crsd_etree.find(
@@ -230,14 +226,10 @@ def example_crsdtx_file(tmp_path_factory, example_crsdsar_file):
         tmp_path_factory.mktemp("data") / good_crsd_xml_path.with_suffix(".crsd").name
     )
 
-    new_plan = skcrsd.CrsdPlan(
-        file_header=skcrsd.CrsdFileHeaderFields(
-            classification="UNCLASSIFIED",
-            release_info="UNRESTRICTED",
-        ),
-        crsd_xmltree=crsd_etree,
+    new_meta = skcrsd.Metadata(
+        xmltree=crsd_etree,
     )
-    with open(tmp_crsd, "wb") as f, skcrsd.CrsdWriter(f, new_plan) as cw:
+    with open(tmp_crsd, "wb") as f, skcrsd.Writer(f, new_meta) as cw:
         cw.write_ppp(sequence_id, ppps)
     assert not main([str(tmp_crsd), "-vvv"])
     yield tmp_crsd
@@ -245,8 +237,8 @@ def example_crsdtx_file(tmp_path_factory, example_crsdsar_file):
 
 @pytest.fixture(scope="session")
 def example_crsdrcv_file(tmp_path_factory, example_crsdsar_file):
-    with open(example_crsdsar_file, "rb") as f, skcrsd.CrsdReader(f) as cr:
-        crsd_etree = cr.crsd_xmltree
+    with open(example_crsdsar_file, "rb") as f, skcrsd.Reader(f) as cr:
+        crsd_etree = cr.metadata.xmltree
         channel_id = crsd_etree.findtext("{*}Channel/{*}Parameters/{*}Identifier")
         pvps = cr.read_pvps(channel_id)
         signal = cr.read_signal(channel_id)
@@ -298,14 +290,10 @@ def example_crsdrcv_file(tmp_path_factory, example_crsdsar_file):
         tmp_path_factory.mktemp("data") / good_crsd_xml_path.with_suffix(".crsd").name
     )
 
-    newplan = skcrsd.CrsdPlan(
-        file_header=skcrsd.CrsdFileHeaderFields(
-            classification="UNCLASSIFIED",
-            release_info="UNRESTRICTED",
-        ),
-        crsd_xmltree=crsd_etree,
+    new_meta = skcrsd.Metadata(
+        xmltree=crsd_etree,
     )
-    with open(tmp_crsd, "wb") as f, skcrsd.CrsdWriter(f, newplan) as cw:
+    with open(tmp_crsd, "wb") as f, skcrsd.Writer(f, new_meta) as cw:
         cw.write_pvp(channel_id, new_pvps)
         cw.write_signal(channel_id, signal)
     assert not main([str(tmp_crsd), "-vvv"])
@@ -950,7 +938,7 @@ def ant_patched_crsd_con(crsd_con, monkeypatch):
                 ),
             )
 
-        monkeypatch.setattr(skcrsd.CrsdReader, "read_support_array", dummy)
+        monkeypatch.setattr(skcrsd.Reader, "read_support_array", dummy)
         return crsd_con, data
 
     return func

--- a/tests/verification/test_sicd_consistency.py
+++ b/tests/verification/test_sicd_consistency.py
@@ -21,13 +21,13 @@ def example_sicd_file(tmp_path_factory):
         tmp_path_factory.mktemp("data") / good_sicd_xml_path.with_suffix(".sicd").name
     )
     sec = {"security": {"clas": "U"}}
-    sicd_plan = sksicd.SicdNitfPlan(
-        sicd_xmltree=sicd_etree,
-        header_fields={"ostaid": "nowhere"} | sec,
-        is_fields={"isorce": "this sensor"} | sec,
-        des_fields=sec,
+    sicd_meta = sksicd.NitfMetadata(
+        xmltree=sicd_etree,
+        file_header_part={"ostaid": "nowhere"} | sec,
+        im_subheader_part={"isorce": "this sensor"} | sec,
+        de_subheader_part=sec,
     )
-    with open(tmp_sicd, "wb") as f, sksicd.SicdNitfWriter(f, sicd_plan):
+    with open(tmp_sicd, "wb") as f, sksicd.NitfWriter(f, sicd_meta):
         pass  # don't currently care about the pixels
     assert not main([str(tmp_sicd)])
     yield tmp_sicd


### PR DESCRIPTION
# Description
As mentioned in #22, this PR aims to improve the IO API, primarily by proposing more descriptive, less-redundant names but also by tweaking the concept of "Plans" into a settable "Metadata" classes that are perhaps more natural to move across readers and writers, and also by improving the API documentation by way of more rigorous examples.

Docs for this PR can be found here: https://sarkit.readthedocs.io/en/io-api-iteration/

## Notes
- removes redundant `Fmt` from `sarkit.fmt.FmtObj` -> `sarkit.fmt.Obj` and from some scoped kwargs (e.g. `CphdPlan(cphd_xmltree=...)` --> `Metadata(xmltree=...)`
- use suffix `Part` on objects that only surface certain fields of the things they represent
  - `sarkit.cphd.CphdFileHeaderFields` -> `sarkit.cphd.FileHeaderPart`
- `Plan`s are now `Metadata`
  - this was motivated by the current, odd relationship between Readers and Plans. The writer/user guide only associate "plans" with writing, but then the readers create a "plan" object and surface it (and sometimes some of its subfields as attributes; see: `CphdReader.plan`, `CphdReader.cphd_xmltree` and `CphdReader.plan.cphd_xmltree`). Changing the name to `Metadata` is intended to clarify what is in the object and how it can be used. Now each `Reader` will contain a `metadata` attribute which can then be used to retrieve values or passed to a `Writer`
- `Writer` s now copy metadata on construction; thus removing the temptation from users and need for warnings
- expanded Reader/Writer docstring examples now all use `doctest`

### CRSD & CPHD-specific
- Retrieve `CLASSIFICATION` and `RELEASE_INFO` from the XML instead of allowing these to be set independently
- Removes the `<>_block_size` and `<>_block_byte_offset` attributes from the public API; this is meant to reinforce that **only the settable metadata is accessible**. This is a far easier argument to make from the SICD/SIDD side because the NITFs can contain huge swaths of metadata that we don't want to describe in SARkit. The goal is to have someone use the right reader for the right job, not have SARkit take over all of the vagaries of reading the container.
- Cleaned up some of the docstrings for shared functions (e.g., so that CRSD docs don't inadvertently reference CPHD)

### SIDD-specific
- ~~`SiddNitfPlan`~~ `NitfMetadata` is now a dataclass like all of the others, so that you can interact with it in a similar fashion. Originally the `add_<thing>` methods were motivated by trying to set things appropriately for the complicated cases like legends, which need to attach to images. We now enforce this by construction by moving `legends` into a `NitfProductImageMetadata`. This solves the annoying association issue, removes a decent amount of boilerplate, and makes the SIDD metadata behave like all of the others.


# What's next?
Much of the consistency checker API in `sarkit.verification` is a holdover from old VSC code that was ported into SARPy and is a bit out of step with the rest of the library. We'll be doing a similar treatment in improving that portion of the API