### PR TITLE
Docs: identify/fix missing references

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,7 +73,7 @@ intersphinx_mapping = {
 
 # numpydoc
 numpydoc_xref_param_type = True
-numpydoc_xref_ignore = {"optional", "of"}
+numpydoc_xref_ignore = {"optional", "of", "N"}
 numpydoc_validation_checks = {
     "PR10",  # requires a space before the colon separating the parameter name and type
     "GL07",  # Sections are in the wrong order

--- a/noxfile.py
+++ b/noxfile.py
@@ -20,6 +20,7 @@ def docs(session):
         "docs/source",
         "docs/build",
         "--fail-on-warning",
+        "--nitpicky",
         "--keep-going",
         "--fresh-env",
         "--write-all",

--- a/sarkit/_xmlhelp.py
+++ b/sarkit/_xmlhelp.py
@@ -584,7 +584,7 @@ class MtxType(Type):
 
     Attributes
     ----------
-    shape : 2-tuple of ints
+    shape : tuple of (int, int)
         Expected shape of the matrix.
 
     """

--- a/sarkit/cphd/_io.py
+++ b/sarkit/cphd/_io.py
@@ -196,14 +196,13 @@ def mask_support_array(
     array : np.ndarray
         Support array to compare to NODATA and create a masked array from
     nodata_hex : str, optional
-        If None, create a maskedarray with all array elements valid. Otherwise, use the hex string to
+        If None, all array elements are valid. Otherwise, use the hex string to
         compare to the values in ``array`` to make the mask
 
     Returns
     -------
-    masked_array : MaskedArray
-        `numpy.ma.MaskedArray` corresponding to the valid elements of ``array``
-
+    masked_array : :py:class:`~numpy.ma.MaskedArray`
+        ``array`` with NODATA elements masked
     """
     if nodata_hex is None:
         return np.ma.array(array)
@@ -251,7 +250,7 @@ def read_file_header(file):
 
     Parameters
     ----------
-    file : file_like
+    file : `file object`
         The open file object, which will be progressively read.
 
     Returns

--- a/sarkit/sicd/_io.py
+++ b/sarkit/sicd/_io.py
@@ -727,7 +727,7 @@ class NitfWriter:
         ----------
         array : ndarray
             2D array of complex pixels
-        start : tuple of ints, optional
+        start : tuple of (int, int), optional
             The start index (first_row, first_col) of `array` in the SICD image.
             If not given, `array` must be the full SICD image.
 

--- a/sarkit/sicd/projection/_params.py
+++ b/sarkit/sicd/projection/_params.py
@@ -124,7 +124,7 @@ class MetadataParams:
 
         Returns
         -------
-        MetadataParamList
+        MetadataParams
             The metadata parameter list object initialized with values from the XML.
 
         """

--- a/sarkit/verification/_sicd_consistency.py
+++ b/sarkit/verification/_sicd_consistency.py
@@ -177,7 +177,7 @@ class SicdConsistency(con.ConsistencyChecker):
         Path to SICD XML Schema (Bypass auto selection of SICD schema)
     version_override : str, optional
         Bypass auto detection of SICD version.  Required if schema_override is specified.  eg: "1.1.0"
-    ntf : NITFDetails, optional
+    ntf : ``NITFDetails``, optional
         Header information from a NITF file
     """
 


### PR DESCRIPTION
# Description
Semi-regularly, I've inadvertently broken links/references in the documentation while working on changes. I think it would be useful to enable [`--nitpicky` in sphinx-build](https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-n) so that we can hopefully identify/address these as they crop up without having to just find them in the rendered docs later. Here was the log before I made the changes:

```
/home/vscuser/git/glweb/software/third-party/sarkit/sarkit/_xmlhelp.py:docstring of sarkit._xmlhelp.XyzPolyType.parse_elem:14: WARNING: py:obj reference target not found: N [ref.obj]
/home/vscuser/git/glweb/software/third-party/sarkit/sarkit/_xmlhelp.py:docstring of sarkit._xmlhelp.XyzPolyType.set_elem:10: WARNING: py:obj reference target not found: N [ref.obj]
/home/vscuser/git/glweb/software/third-party/sarkit/sarkit/cphd/_io.py:docstring of sarkit.cphd._io.mask_support_array:18: WARNING: py:obj reference target not found: MaskedArray [ref.obj]
/home/vscuser/git/glweb/software/third-party/sarkit/sarkit/cphd/_io.py:docstring of sarkit.cphd._io.read_file_header:8: WARNING: py:obj reference target not found: file_like [ref.obj]
/home/vscuser/git/glweb/software/third-party/sarkit/sarkit/crsd/_xml.py:docstring of sarkit.crsd._xml.MtxType:8: WARNING: py:obj reference target not found: ints [ref.obj]
/home/vscuser/git/glweb/software/third-party/sarkit/sarkit/_xmlhelp.py:docstring of sarkit._xmlhelp.XyzPolyType.parse_elem:14: WARNING: py:obj reference target not found: N [ref.obj]
/home/vscuser/git/glweb/software/third-party/sarkit/sarkit/_xmlhelp.py:docstring of sarkit._xmlhelp.XyzPolyType.set_elem:10: WARNING: py:obj reference target not found: N [ref.obj]
/home/vscuser/git/glweb/software/third-party/sarkit/sarkit/cphd/_io.py:docstring of sarkit.cphd._io.mask_support_array:18: WARNING: py:obj reference target not found: MaskedArray [ref.obj]
/home/vscuser/git/glweb/software/third-party/sarkit/sarkit/cphd/_io.py:docstring of sarkit.cphd._io.read_file_header:8: WARNING: py:obj reference target not found: file_like [ref.obj]
/home/vscuser/git/glweb/software/third-party/sarkit/sarkit/sicd/_xml.py:docstring of sarkit.sicd._xml.MtxType:8: WARNING: py:obj reference target not found: ints [ref.obj]
/home/vscuser/git/glweb/software/third-party/sarkit/sarkit/sicd/_io.py:docstring of sarkit.sicd._io.NitfWriter.write_image:10: WARNING: py:obj reference target not found: ints [ref.obj]
/home/vscuser/git/glweb/software/third-party/sarkit/sarkit/_xmlhelp.py:docstring of sarkit._xmlhelp.XyzPolyType.parse_elem:14: WARNING: py:obj reference target not found: N [ref.obj]
/home/vscuser/git/glweb/software/third-party/sarkit/sarkit/_xmlhelp.py:docstring of sarkit._xmlhelp.XyzPolyType.set_elem:10: WARNING: py:obj reference target not found: N [ref.obj]
/home/vscuser/git/glweb/software/third-party/sarkit/sarkit/sicd/projection/_params.py:docstring of sarkit.sicd.projection._params.MetadataParams.from_xml:14: WARNING: py:obj reference target not found: MetadataParamList [ref.obj]
/home/vscuser/git/glweb/software/third-party/sarkit/sarkit/_xmlhelp.py:docstring of sarkit._xmlhelp.XyzPolyType.parse_elem:14: WARNING: py:obj reference target not found: N [ref.obj]
/home/vscuser/git/glweb/software/third-party/sarkit/sarkit/_xmlhelp.py:docstring of sarkit._xmlhelp.XyzPolyType.set_elem:10: WARNING: py:obj reference target not found: N [ref.obj]
/home/vscuser/git/glweb/software/third-party/sarkit/sarkit/verification/_sicd_consistency.py:docstring of sarkit.verification._sicd_consistency.SicdConsistency:16: WARNING: py:obj reference target not found: NITFDetails [ref.obj]
```