### PR TITLE
Document dimensionality/broadcast behavior of SICD projection dataclasses

### DIFF
--- a/sarkit/sicd/projection/__init__.py
+++ b/sarkit/sicd/projection/__init__.py
@@ -4,25 +4,38 @@ SICD Projection (:mod:`sarkit.sicd.projection`)
 ===============================================
 
 Objects and methods that implement the exploitation processing
-described in SICD Volume 3 Image Projections Description Document.
+described in SICD Volume 3 Image Projections Description Document (IPDD).
 
 Data Classes
 ============
 
 To simplify interfaces, some collections of metadata parameters are encapsulated in
-dataclasses with attributes named as similar as feasible to the IPDD. Each class
-contains a superset of the available parameters. A given instance may only specify a
-relevant subset, e.g. for when Collect_Type = MONOSTATIC vs BISTATIC.
+dataclasses with attributes named as similar as feasible to the IPDD.
 
 .. autosummary::
    :toctree: generated/
 
    AdjustableParameterOffsets
    MetadataParams
-   CoaPosVels
-   ProjectionSets
+   CoaPosVelsMono
+   CoaPosVelsBi
+   ProjectionSetsMono
+   ProjectionSetsBi
    ScenePointRRdotParams
    ScenePointGpXyParams
+
+Type Aliases
+------------
+
+.. py:type:: CoaPosVelsLike
+   :canonical: CoaPosVelsMono | CoaPosVelsBi
+
+   Represent either a monostatic or bistatic ensemble of COA positions and velocities
+
+.. py:type:: ProjectionSetsLike
+   :canonical: ProjectionSetsMono | ProjectionSetsBi
+
+   Represent either a monostatic or bistatic ensemble of COA projection sets
 
 Image Plane Parameters
 ======================
@@ -115,14 +128,28 @@ from ._calc import (
 )
 from ._params import (
     AdjustableParameterOffsets,
-    CoaPosVels,
+    CoaPosVelsBi,
+    CoaPosVelsLike,
+    CoaPosVelsMono,
     MetadataParams,
-    ProjectionSets,
+    ProjectionSetsBi,
+    ProjectionSetsLike,
+    ProjectionSetsMono,
     ScenePointGpXyParams,
     ScenePointRRdotParams,
 )
 
 __all__ = [
+    "AdjustableParameterOffsets",
+    "CoaPosVelsBi",
+    "CoaPosVelsLike",
+    "CoaPosVelsMono",
+    "MetadataParams",
+    "ProjectionSetsBi",
+    "ProjectionSetsLike",
+    "ProjectionSetsMono",
+    "ScenePointGpXyParams",
+    "ScenePointRRdotParams",
     "compute_and_apply_offsets",
     "compute_coa_pos_vel",
     "compute_coa_r_rdot",
@@ -138,13 +165,4 @@ __all__ = [
     "r_rdot_to_ground_plane_bi",
     "r_rdot_to_ground_plane_mono",
     "scene_to_image",
-]
-
-__all__ += [
-    "AdjustableParameterOffsets",
-    "CoaPosVels",
-    "MetadataParams",
-    "ProjectionSets",
-    "ScenePointGpXyParams",
-    "ScenePointRRdotParams",
 ]

--- a/sarkit/sicd/projection/_derived.py
+++ b/sarkit/sicd/projection/_derived.py
@@ -65,6 +65,7 @@ def image_to_ground_plane(
         else method
     )
     if method == "monostatic":
+        assert isinstance(projection_sets, params.ProjectionSetsMono)
         gpp_tgt = calc.r_rdot_to_ground_plane_mono(
             proj_metadata.LOOK, projection_sets, gref, ugpn
         )
@@ -73,10 +74,11 @@ def image_to_ground_plane(
         success = np.isfinite(gpp_tgt).all()
         return gpp_tgt, delta_gp, success
     if method == "bistatic":
-        bistat_projection_sets = projection_sets
-        if proj_metadata.is_monostatic():
-            bistat_projection_sets = params.ProjectionSets(
+        if isinstance(projection_sets, params.ProjectionSetsMono):
+            projection_sets = params.ProjectionSetsBi(
                 t_COA=projection_sets.t_COA,
+                tr_COA=projection_sets.t_COA,
+                tx_COA=projection_sets.t_COA,
                 Xmt_COA=projection_sets.ARP_COA,
                 VXmt_COA=projection_sets.VARP_COA,
                 Rcv_COA=projection_sets.ARP_COA,
@@ -87,7 +89,7 @@ def image_to_ground_plane(
         gpp_tgt, delta_gp, success = calc.r_rdot_to_ground_plane_bi(
             proj_metadata.LOOK,
             proj_metadata.SCP,
-            bistat_projection_sets,
+            projection_sets,
             gref,
             ugpn,
             delta_gp_gpp=bistat_delta_gp_gpp,
@@ -211,7 +213,6 @@ def image_to_constant_hae_surface(
     return calc.r_rdot_to_constant_hae_surface(
         proj_metadata.LOOK,
         proj_metadata.SCP,
-        proj_metadata.Collect_Type,
         projection_sets,
         hae0,
         delta_hae_max=delta_hae_max,


### PR DESCRIPTION
# Description
The dimensionality and behavior of SARkit's SICD projection dataclasses' attributes is undocumented and perhaps adopts an unintuitive behavior borne from convenience in the arithmetic inside some functions themselves. This PR proposes the following changes to address these deficiencies:

- split `CoaPosVels` and `ProjectionSets` into monostatic and bistatic variants
  - use TypeAliases to maintain/document interfaces that accept/produce both
- better document constructor behavior and attribute dimensionality in said classes
- add broadcasting/asarray to constructors to make these more convenient for users to instantiate
- make some interfaces more explicit
  - remove unused args from `r_rdot_from_<>` functions
  - change `compute_pt_r_rdot_parameters` to use explicit Xmt/Rcv position velocities