### PR TITLE
Consistency API revision

### DIFF
--- a/sarkit/cphd/_io.py
+++ b/sarkit/cphd/_io.py
@@ -283,11 +283,11 @@ def read_file_header(file):
     Returns
     -------
     file_type_header : str
-        File type from the first line of the file
-    kvp_list : dict[str, str]
-        Key-Value list of header fields
+        File type header from the first line of the file
+    kvp_list : dict of {str : str}
+        Key-Value pair list of header fields
     """
-    file_type_header = file.readline().decode().strip("\n")
+    file_type_header = file.readline().decode()
 
     kvp_list = {}
     while (line := file.readline()) != SECTION_TERMINATOR:

--- a/sarkit/verification/__init__.py
+++ b/sarkit/verification/__init__.py
@@ -19,17 +19,29 @@ Python Interface
    CrsdConsistency
    SicdConsistency
 
-In general, users will create a Consistency instance with ``from_file``, e.g.
+Consistency objects should be instantiated using ``from_parts`` when data components are available in memory or
+``from_file`` when data has already been serialized into a standard format.
 
 .. doctest::
 
    >>> import sarkit.verification as skver
-   >>> sicdcon = skver.SicdConsistency.from_file("data/example-sicd-1.4.0.xml")
-   >>> sicdcon.check()
-   >>> bool(sicdcon.failures())
-   False
-   >>> bool(sicdcon.passes())
+
+   >>> with open("data/example-cphd-1.0.1.xml", "r") as f:
+   ...     con = skver.CphdConsistency.from_file(f)
+   >>> con.check()
+   >>> bool(con.passes())
    True
+   >>> bool(con.failures())
+   False
+
+   >>> import lxml.etree
+   >>> cphd_xmltree = lxml.etree.parse("data/example-cphd-1.0.1.xml")
+   >>> con = skver.CphdConsistency.from_parts(cphd_xmltree)
+   >>> con.check()
+   >>> bool(con.passes())
+   True
+   >>> bool(con.failures())
+   False
 
 Command-Line Interface
 ----------------------

--- a/sarkit/verification/_consistency.py
+++ b/sarkit/verification/_consistency.py
@@ -505,7 +505,6 @@ class ConsistencyChecker(object):
         parser.add_argument(
             "--color",
             action=argparse.BooleanOptionalAction,
-            dest="color",
             help="colorize output",
         )
 

--- a/sarkit/verification/_cphd_consistency.py
+++ b/sarkit/verification/_cphd_consistency.py
@@ -85,7 +85,7 @@ class CphdConsistency(con.ConsistencyChecker):
     pvps : dict of {str : ndarray}, optional
         CPHD Per-Vector-Parameters keyed by channel identifier
     schema_override : `path-like object`, optional
-        Path to CPHD XML Schema (Bypass auto selection of CPHD schema)
+        Path to XML Schema. If None, tries to find a version-specific schema
     file : `file object`, optional
         CPHD file; when specified, portions of the file not specified in other parameters may be read
     """
@@ -153,7 +153,7 @@ class CphdConsistency(con.ConsistencyChecker):
         file : `file object`
             CPHD or CPHD XML file to check
         schema : str, optional
-            Path to CPHD XML Schema. If None, tries to find a version-specific schema
+            Path to XML Schema. If None, tries to find a version-specific schema
         thorough : bool, optional
             Run checks that may seek/read through large portions of the file.
             file must stay open to run checks. Ignored if file is CPHD XML.
@@ -173,17 +173,12 @@ class CphdConsistency(con.ConsistencyChecker):
 
         .. testsetup::
 
-            import pathlib
-            import tempfile
-
             import sarkit.cphd as skcphd
             import lxml.etree
             meta = skcphd.Metadata(
                 xmltree=lxml.etree.parse("data/example-cphd-1.0.1.xml"),
             )
-            tmpdir = tempfile.TemporaryDirectory()
-            tmppath = pathlib.Path(tmpdir.name)
-            file = pathlib.Path(tmpdir.name) / "example.cphd"
+            file = tmppath / "example.cphd"
             with file.open("wb") as f, skcphd.Writer(f, meta) as w:
                 f.seek(
                     w._file_header_kvp["SIGNAL_BLOCK_BYTE_OFFSET"]
@@ -191,10 +186,6 @@ class CphdConsistency(con.ConsistencyChecker):
                     - 1
                 )
                 f.write(b"0")
-
-        .. testcleanup::
-
-            tmpdir.cleanup()
 
         .. doctest::
 
@@ -269,7 +260,7 @@ class CphdConsistency(con.ConsistencyChecker):
         pvps : dict of {str : ndarray], optional
             CPHD Per-Vector-Parameters keyed by channel identifier
         schema : str, optional
-            Path to CPHD XML Schema. If None, tries to find a version-specific schema
+            Path to XML Schema. If None, tries to find a version-specific schema
 
         Returns
         -------

--- a/sarkit/verification/_crsd_consistency.py
+++ b/sarkit/verification/_crsd_consistency.py
@@ -86,7 +86,7 @@ class CrsdConsistency(con.ConsistencyChecker):
     pvps : dict of {str : ndarray}, optional
         Per-Vector-Parameters keyed by channel identifier
     schema_override : `path-like object`, optional
-        Path to XML Schema (Bypass auto selection of schema)
+        Path to XML Schema. If None, tries to find a version-specific schema
     file : `file object`, optional
         CRSD file; when specified, portions of the file not specified in other parameters may be read
     """
@@ -171,7 +171,7 @@ class CrsdConsistency(con.ConsistencyChecker):
         file : `file object`
             CRSD or CRSD XML file to check
         schema : str, optional
-            Path to CRSD XML Schema. If None, tries to find a version-specific schema
+            Path to XML Schema. If None, tries to find a version-specific schema
         thorough : bool, optional
             Run checks that may seek/read through large portions of the file.
             file must stay open to run checks. Ignored if file is CRSD XML.
@@ -205,17 +205,12 @@ class CrsdConsistency(con.ConsistencyChecker):
 
         .. testsetup::
 
-            import pathlib
-            import tempfile
-
             import sarkit.crsd as skcrsd
             import lxml.etree
             meta = skcrsd.Metadata(
                 xmltree=lxml.etree.parse("data/example-crsd-1.0-draft.2025-02-25.xml"),
             )
-            tmpdir = tempfile.TemporaryDirectory()
-            tmppath = pathlib.Path(tmpdir.name)
-            file = pathlib.Path(tmpdir.name) / "example.crsd"
+            file = tmppath / "example.crsd"
             with file.open("wb") as f, skcrsd.Writer(f, meta) as w:
                 f.seek(
                     w._file_header_kvp["SIGNAL_BLOCK_BYTE_OFFSET"]
@@ -223,10 +218,6 @@ class CrsdConsistency(con.ConsistencyChecker):
                     - 1
                 )
                 f.write(b"0")
-
-        .. testcleanup::
-
-            tmpdir.cleanup()
 
         .. doctest::
 

--- a/tests/verification/test_cphd_consistency.py
+++ b/tests/verification/test_cphd_consistency.py
@@ -1,6 +1,5 @@
 import copy
 import itertools
-import os
 import pathlib
 import re
 
@@ -97,13 +96,16 @@ def example_cphd_file(tmp_path_factory):
     with open(tmp_cphd, "wb") as f, skcphd.Writer(f, cphd_plan) as cw:
         cw.write_pvp("1", pvps)
         cw.write_signal("1", signal)
-    assert not main([str(tmp_cphd), "--signal-data"])
-    yield tmp_cphd
+    assert not main([str(tmp_cphd), "--thorough"])
+    f = tmp_cphd.open("rb")
+    yield f
+    f.close()
 
 
 @pytest.fixture(scope="session")
-def example_compressed_cphd(example_cphd_file):
-    with example_cphd_file.open("rb") as f, skcphd.Reader(f) as r:
+def example_compressed_cphd(example_cphd_file, tmp_path_factory):
+    example_cphd_file.seek(0)
+    with skcphd.Reader(example_cphd_file) as r:
         pvps = r.read_pvps("1")
 
     new_meta = r.metadata
@@ -115,12 +117,14 @@ def example_compressed_cphd(example_cphd_file):
     compressed_data = b"ultra-compressed"
     data_chan_elem.append(em.CompressedSignalSize(str(len(compressed_data))))
 
-    tmp_cphd = example_cphd_file.with_suffix(".compressed.cphd")
+    tmp_cphd = tmp_path_factory.mktemp("data") / "faux-compressed.cphd"
     with tmp_cphd.open("wb") as f, skcphd.Writer(f, new_meta) as w:
         w.write_pvp("1", pvps)
         w.write_signal("1", np.frombuffer(compressed_data, np.uint8))
-    assert not main([str(tmp_cphd), "--signal-data"])
-    yield tmp_cphd
+    assert not main([str(tmp_cphd), "--thorough"])
+    f = tmp_cphd.open("rb")
+    yield f
+    f.close()
 
 
 def remove_nodes(*nodes):
@@ -145,7 +149,7 @@ def good_xml_root(good_xml):
 
 @pytest.fixture
 def cphd_con_from_file(example_cphd_file):
-    return CphdConsistency.from_file(example_cphd_file)
+    return CphdConsistency.from_file(example_cphd_file, thorough=True)
 
 
 @pytest.fixture
@@ -165,7 +169,7 @@ def copy_xml(elem):
 )
 def test_from_file_cphd(fixture_name, request):
     file = request.getfixturevalue(fixture_name)
-    cphdcon = CphdConsistency.from_file(file, check_signal_data=True)
+    cphdcon = CphdConsistency.from_file(file, thorough=True)
     cphdcon.check()
     assert not cphdcon.failures()
 
@@ -192,26 +196,20 @@ def test_smoketest(xml_file):
 
 def test_main_with_ignore(good_xml_root, tmp_path):
     good_xml_root.find("./{*}Global/{*}SGN").text += "1"
-    slightly_bad_xml = os.path.join(tmp_path, "slightly_bad.xml")
+    slightly_bad_xml = tmp_path / "slightly_bad.xml"
     etree.ElementTree(good_xml_root).write(str(slightly_bad_xml))
-    assert main([slightly_bad_xml])
-    assert not main([slightly_bad_xml, "--ignore", "check_against_schema"])
+    assert main([str(slightly_bad_xml)])
+    assert not main([str(slightly_bad_xml), "--ignore", "check_against_schema"])
 
 
 def test_main_schema_args(cphd_con):
     good_schema = cphd_con.schema
-    with pytest.raises(
-        RuntimeError, match="--version must be specified if using --schema"
-    ):
-        main([str(good_cphd_xml_path), "--schema", str(good_schema)])
 
     assert not main(
         [
             str(good_cphd_xml_path),
             "--schema",
             str(good_schema),
-            "--version",
-            "1.0.1",
         ]
     )  # pass with actual schema
 
@@ -220,21 +218,19 @@ def test_main_schema_args(cphd_con):
             str(good_cphd_xml_path),
             "--schema",
             str(good_cphd_xml_path),
-            "--version",
-            "1.0.1",
         ]
     )  # fails with bogus schema
 
 
-@pytest.mark.parametrize("check_signal_data", (True, False))
-def test_with_signal_data_check(check_signal_data, example_cphd_file):
-    cphd_con = CphdConsistency.from_file(
-        example_cphd_file, check_signal_data=check_signal_data
-    )
+def test_thorough(example_cphd_file):
+    cphd_con = CphdConsistency.from_file(example_cphd_file, thorough=True)
+    cphd_con.check()
+    num_skips_thorough = len(cphd_con.skips(include_partial=True))
 
-    cphd_con.check("check_channel_signal_data", allow_prefix=True)
-    assert not cphd_con.failures()
-    assert bool(cphd_con.skips(include_partial=True)) == (not check_signal_data)
+    cphd_con = CphdConsistency.from_file(example_cphd_file)
+    cphd_con.check()
+    num_skips_default = len(cphd_con.skips(include_partial=True))
+    assert num_skips_thorough < num_skips_default
 
 
 def test_xml_schema_error(good_xml_root):
@@ -890,7 +886,7 @@ def test_signal_pvp(cphd_con_from_file):
 
 def test_header_filetype(cphd_con_from_file):
     cphd_con = cphd_con_from_file
-    cphd_con.version = "FAKE"
+    cphd_con.file_type_header = "FAKE"
 
     cphd_con.check("check_file_type_header")
     assert cphd_con.failures()

--- a/tests/verification/test_cphd_consistency.py
+++ b/tests/verification/test_cphd_consistency.py
@@ -97,9 +97,8 @@ def example_cphd_file(tmp_path_factory):
         cw.write_pvp("1", pvps)
         cw.write_signal("1", signal)
     assert not main([str(tmp_cphd), "--thorough"])
-    f = tmp_cphd.open("rb")
-    yield f
-    f.close()
+    with tmp_cphd.open("rb") as f:
+        yield f
 
 
 @pytest.fixture(scope="session")
@@ -122,9 +121,8 @@ def example_compressed_cphd(example_cphd_file, tmp_path_factory):
         w.write_pvp("1", pvps)
         w.write_signal("1", np.frombuffer(compressed_data, np.uint8))
     assert not main([str(tmp_cphd), "--thorough"])
-    f = tmp_cphd.open("rb")
-    yield f
-    f.close()
+    with tmp_cphd.open("rb") as f:
+        yield f
 
 
 def remove_nodes(*nodes):
@@ -139,7 +137,7 @@ def good_xml():
 
 @pytest.fixture
 def cphd_con(good_xml):
-    return CphdConsistency(good_xml)
+    return CphdConsistency.from_parts(good_xml)
 
 
 @pytest.fixture

--- a/tests/verification/test_crsd_consistency.py
+++ b/tests/verification/test_crsd_consistency.py
@@ -175,9 +175,8 @@ def example_crsdsar_file(tmp_path_factory):
         cw.write_pvp(channel_id, pvps)
         cw.write_signal(channel_id, signal)
     assert not main([str(tmp_crsd), "-v"])
-    f = tmp_crsd.open("rb")
-    yield f
-    f.close()
+    with tmp_crsd.open("rb") as f:
+        yield f
 
 
 def _replace_error(crsd_etree, sensor_type):
@@ -235,9 +234,8 @@ def example_crsdtx_file(tmp_path_factory, example_crsdsar_file):
     with open(tmp_crsd, "wb") as f, skcrsd.Writer(f, new_meta) as cw:
         cw.write_ppp(sequence_id, ppps)
     assert not main([str(tmp_crsd), "-vvv"])
-    f = tmp_crsd.open("rb")
-    yield f
-    f.close()
+    with tmp_crsd.open("rb") as f:
+        yield f
 
 
 @pytest.fixture(scope="session")
@@ -303,9 +301,8 @@ def example_crsdrcv_file(tmp_path_factory, example_crsdsar_file):
         cw.write_pvp(channel_id, new_pvps)
         cw.write_signal(channel_id, signal)
     assert not main([str(tmp_crsd), "-vvv"])
-    f = tmp_crsd.open("rb")
-    yield f
-    f.close()
+    with tmp_crsd.open("rb") as f:
+        yield f
 
 
 @pytest.fixture(scope="session", params=("sar", "tx", "rcv"))

--- a/tests/verification/test_crsd_consistency.py
+++ b/tests/verification/test_crsd_consistency.py
@@ -175,7 +175,9 @@ def example_crsdsar_file(tmp_path_factory):
         cw.write_pvp(channel_id, pvps)
         cw.write_signal(channel_id, signal)
     assert not main([str(tmp_crsd), "-v"])
-    yield tmp_crsd
+    f = tmp_crsd.open("rb")
+    yield f
+    f.close()
 
 
 def _replace_error(crsd_etree, sensor_type):
@@ -201,7 +203,8 @@ def _replace_error(crsd_etree, sensor_type):
 
 @pytest.fixture(scope="session")
 def example_crsdtx_file(tmp_path_factory, example_crsdsar_file):
-    with open(example_crsdsar_file, "rb") as f, skcrsd.Reader(f) as cr:
+    example_crsdsar_file.seek(0)
+    with skcrsd.Reader(example_crsdsar_file) as cr:
         crsd_etree = cr.metadata.xmltree
         sequence_id = crsd_etree.findtext("{*}TxSequence/{*}Parameters/{*}Identifier")
         ppps = cr.read_ppps(sequence_id)
@@ -232,12 +235,15 @@ def example_crsdtx_file(tmp_path_factory, example_crsdsar_file):
     with open(tmp_crsd, "wb") as f, skcrsd.Writer(f, new_meta) as cw:
         cw.write_ppp(sequence_id, ppps)
     assert not main([str(tmp_crsd), "-vvv"])
-    yield tmp_crsd
+    f = tmp_crsd.open("rb")
+    yield f
+    f.close()
 
 
 @pytest.fixture(scope="session")
 def example_crsdrcv_file(tmp_path_factory, example_crsdsar_file):
-    with open(example_crsdsar_file, "rb") as f, skcrsd.Reader(f) as cr:
+    example_crsdsar_file.seek(0)
+    with skcrsd.Reader(example_crsdsar_file) as cr:
         crsd_etree = cr.metadata.xmltree
         channel_id = crsd_etree.findtext("{*}Channel/{*}Parameters/{*}Identifier")
         pvps = cr.read_pvps(channel_id)
@@ -297,7 +303,9 @@ def example_crsdrcv_file(tmp_path_factory, example_crsdsar_file):
         cw.write_pvp(channel_id, new_pvps)
         cw.write_signal(channel_id, signal)
     assert not main([str(tmp_crsd), "-vvv"])
-    yield tmp_crsd
+    f = tmp_crsd.open("rb")
+    yield f
+    f.close()
 
 
 @pytest.fixture(scope="session", params=("sar", "tx", "rcv"))
@@ -318,7 +326,7 @@ def good_xml_root(good_xml):
 
 @pytest.fixture
 def crsd_con(example_crsd_file):
-    return CrsdConsistency.from_file(example_crsd_file)
+    return CrsdConsistency.from_file(example_crsd_file, thorough=True)
 
 
 def copy_xml(elem):
@@ -351,15 +359,39 @@ def test_main_with_ignore(good_xml_root, tmp_path):
     assert not main([slightly_bad_xml, "--ignore", "check_against_schema"])
 
 
+def test_main_schema_args(crsd_con):
+    good_schema = crsd_con.schema
+
+    assert not main(
+        [
+            str(good_crsd_xml_path),
+            "--schema",
+            str(good_schema),
+        ]
+    )  # pass with actual schema
+
+    assert main(
+        [
+            str(good_crsd_xml_path),
+            "--schema",
+            str(good_crsd_xml_path),
+        ]
+    )  # fails with bogus schema
+
+
+def test_thorough(example_crsd_file):
+    con = CrsdConsistency.from_file(example_crsd_file, thorough=True)
+    con.check()
+    num_skips_thorough = len(con.skips(include_partial=True))
+
+    con = CrsdConsistency.from_file(example_crsd_file)
+    con.check()
+    num_skips_default = len(con.skips(include_partial=True))
+    assert num_skips_thorough < num_skips_default
+
+
 def test_header_filetype(crsd_con):
-    crsd_con.crsd_type = "CRSDnope"
-
-    crsd_con.check("check_file_type_header")
-    assert crsd_con.failures()
-
-
-def test_header_filetype_version(crsd_con):
-    crsd_con.version = "FAKE"
+    crsd_con.file_type_header += "MAKEBAD"
 
     crsd_con.check("check_file_type_header")
     assert crsd_con.failures()


### PR DESCRIPTION
# Description
The current consistency API is largely a holdover from SARPy and early VSC tools and as such is a bit out of touch with the rest of SARkit. This PR proposes a few changes to the consistency API to simplify, clarify, and match the rest of SARkit.

## Notes
- CLI
  - remove `--version` (only used in `check_file_type_header`; get from file instead)
  - change `--signal-data` to `--thorough`; the current help is a lie, so I wanted to come up with a name and description that better described what is actually going on
- CphdConsistency
  - change constructor to:
    - remove `version_override` (see above)
    - accept `file_type_header` str (replaces version; natural complement to kvp_list, see `skcrsd.read_file_header` and new `from_parts` method
    - rename `cphdroot` to `cphd_xml` (because it doesn't have to be the root)
    - don't copy ~~`cphdroot`~~ `cphd_xml` on construction; the other "parts" args don't copy, so I thought this would be more consistent/intuitive
  - change `from_file` to now accept an open `file object` instead of a path-like; this is for consistency with the rest of SARkit (p.s. technically still accepts lots of things if XML due to `lxml.etree.parse`)
  - add `from_parts` as the counterpart to `from_file`
- CrsdConsistency
  - similar to CPHD
- SicdConsistency
  - don't surface private objects in public API; instead use `file-object` similar to CPHD/CRSD
- Docs
  - modify docs with doctested examples, encourage `from_parts`/`from_file` usage