### PR TITLE
SICD: Precise R/Rdot to DEM Surface Projection (monostatic)

### DIFF
--- a/sarkit/sicd/__init__.py
+++ b/sarkit/sicd/__init__.py
@@ -67,6 +67,7 @@ In the `sarkit.sicd` namespace, there are convenience functions that operate on 
 
     image_to_ground_plane
     image_to_constant_hae_surface
+    image_to_dem_surface
     scene_to_image
 
 Constants
@@ -206,6 +207,7 @@ from ._xml import (
 )
 from .projection._derived import (
     image_to_constant_hae_surface,
+    image_to_dem_surface,
     image_to_ground_plane,
     scene_to_image,
 )
@@ -243,6 +245,7 @@ __all__ = [
     "compute_scp_coa",
     "image_segment_sizing_calculations",
     "image_to_constant_hae_surface",
+    "image_to_dem_surface",
     "image_to_ground_plane",
     "scene_to_image",
 ]

--- a/sarkit/sicd/projection/__init__.py
+++ b/sarkit/sicd/projection/__init__.py
@@ -107,6 +107,14 @@ Precise R/Rdot to Constant HAE Surface Projection
    :toctree: generated/
 
    r_rdot_to_constant_hae_surface
+
+Precise R/Rdot to DEM Surface Projection
+========================================
+
+.. autosummary::
+   :toctree: generated/
+
+   r_rdot_to_dem_surface
 """
 
 from ._calc import (
@@ -122,6 +130,7 @@ from ._calc import (
     image_grid_to_image_plane_point,
     image_plane_point_to_image_grid,
     r_rdot_to_constant_hae_surface,
+    r_rdot_to_dem_surface,
     r_rdot_to_ground_plane_bi,
     r_rdot_to_ground_plane_mono,
     scene_to_image,
@@ -162,6 +171,7 @@ __all__ = [
     "image_grid_to_image_plane_point",
     "image_plane_point_to_image_grid",
     "r_rdot_to_constant_hae_surface",
+    "r_rdot_to_dem_surface",
     "r_rdot_to_ground_plane_bi",
     "r_rdot_to_ground_plane_mono",
     "scene_to_image",

--- a/sarkit/sicd/projection/_calc.py
+++ b/sarkit/sicd/projection/_calc.py
@@ -1,5 +1,8 @@
 """Calculations from SICD Volume 3 Image Projections Description Document"""
 
+import itertools
+from collections.abc import Callable
+
 import numpy as np
 import numpy.polynomial.polynomial as npp
 import numpy.typing as npt
@@ -1333,3 +1336,143 @@ def r_rdot_to_constant_hae_surface(
     spp_tgt = sarkit.wgs84.geodetic_to_cartesian(spp_llh)
 
     return spp_tgt, delta_hae, success
+
+
+def r_rdot_to_dem_surface(
+    look: int,
+    scp: npt.ArrayLike,
+    projection_set: params.ProjectionSetsLike,
+    ecef2dem_func: Callable[[np.ndarray], np.ndarray],
+    hae_min: float,
+    hae_max: float,
+    delta_dist_dem: float,
+    *,
+    delta_dist_rrc: float = 10.0,
+    delta_hd_lim: float = 0.001,
+    **kwargs,
+) -> npt.NDArray:
+    """Project along a contour of constant range and range rate to a surface described by a Digital Elevation Model.
+
+    Parameters
+    ----------
+    look : {+1, -1}
+        +1 if SideOfTrack = L, -1 if SideOfTrack = R
+    scp : (3,) array_like
+        SCP position in ECEF coordinates (m)
+    projection_set : ProjectionSetsLike
+        Center of Aperture projection set for a single point
+    ecef2dem_func : callable
+        A function that returns an ndarray of DEM offset heights from an ndarray of positions with ECEF
+        (WGS 84 cartesian) X, Y, Z components in meters in the last dimension
+
+        .. Note:: Prior to SICD v1.5, this function was decomposed into two steps:
+
+           #. Convert ECF To DEM Coords
+           #. Get Surface Height HD
+
+    hae_min, hae_max : float
+        WGS-84 HAE values (m) that bound DEM surface points
+    delta_dist_dem : float
+        Max horizontal distance between surface points (m) for which the surface is well approximated by a straight line
+    delta_dist_rrc : float, optional
+        Max distance between adjacent points along R/Rdot contour (m)
+    delta_hd_lim : float, optional
+        Height difference threshold for determining if a point on the R/Rdot contour is on DEM surface (m)
+
+    Returns
+    -------
+    s : ndarray
+        Set of point(s) where the R/Rdot contour intersects the DEM surface with ECEF (WGS 84 cartesian) X, Y, Z
+        components in meters in the last dimension. Ordered by increasing WGS-84 HAE.
+
+    Other Parameters
+    ----------------
+    **kwargs
+        Keyword-only arguments for intermediate `r_rdot_to_constant_hae_surface` calls
+    """
+    if (
+        getattr(
+            projection_set, "ARP_COA", getattr(projection_set, "Xmt_COA", np.empty(()))
+        ).size
+        != 3
+    ):
+        raise ValueError("DEM projection only supported for scalar projection sets")
+
+    if isinstance(projection_set, params.ProjectionSetsMono):
+        # Compute center point, ctr, and the radius of R/Rdot contour
+        vmag = np.linalg.norm(projection_set.VARP_COA)
+        u_vel = projection_set.VARP_COA / vmag
+        cos_dca = -projection_set.Rdot_COA / vmag
+        sin_dca = np.sqrt(1 - cos_dca**2)
+        ctr = projection_set.ARP_COA + projection_set.R_COA * cos_dca * u_vel
+        r_rrc = projection_set.R_COA * sin_dca
+
+        # Compute unit vectors to be used to compute points located on R/Rdot contour
+        dec_arp = np.linalg.norm(projection_set.ARP_COA)
+        u_up = projection_set.ARP_COA / dec_arp
+        rry = np.cross(u_up, u_vel)
+        u_rry = rry / np.linalg.norm(rry)
+        u_rrx = np.cross(u_rry, u_vel)
+
+        # Compute projection along R/Rdot contour to surface of constant HAE at hae_max, "a"
+        a, _, success = r_rdot_to_constant_hae_surface(
+            look, scp, projection_set, hae_max, **kwargs
+        )
+        if not success:
+            return np.array([])
+
+        # Also compute the cosine and sine of the contour angle to point "a"
+        cos_ca_a = np.dot(a - ctr, u_rrx) / r_rrc
+        # sin_ca_a is unused
+
+        # Compute projection along R/Rdot contour to surface of constant HAE at hae_min, "b"
+        b, _, success = r_rdot_to_constant_hae_surface(
+            look, scp, projection_set, hae_min, **kwargs
+        )
+        if not success:
+            return np.array([])
+
+        # Also compute the cosine and sine of the contour angle to point "b"
+        cos_ca_b = np.dot(b - ctr, u_rrx) / r_rrc
+        sin_ca_b = look * np.sqrt(1 - cos_ca_b**2)
+
+        # Compute contour angle step size
+        delta_cos_rrc = delta_dist_rrc * np.abs(sin_ca_b) / r_rrc
+        delta_cos_dem = delta_dist_dem * np.abs(sin_ca_b) / r_rrc / cos_ca_b
+        delta_cos_ca = -min(delta_cos_rrc, delta_cos_dem)
+
+        # Determine number of points along R/Rdot contour to be computed
+        npts = (cos_ca_a - cos_ca_b) // delta_cos_ca + 2
+
+        # Compute the set of points along R/Rdot contour
+        n_minus_1 = np.arange(npts)
+        cos_ca = cos_ca_b + n_minus_1 * delta_cos_ca
+        sin_ca = look * np.sqrt(1 - cos_ca**2)
+        pn = ctr + r_rrc * (
+            cos_ca[..., np.newaxis] * u_rrx + sin_ca[..., np.newaxis] * u_rry
+        )
+    else:
+        raise NotImplementedError("Bistatic is not implemented yet")
+
+    # Compute DEM surface points
+    delta_hdn = ecef2dem_func(pn)
+    aobn = np.full(delta_hdn.shape, -1)
+    aobn[delta_hdn > delta_hd_lim] = 1
+    aobn[np.abs(delta_hdn) <= delta_hd_lim] = 0
+
+    s = []
+    for (p, next_p), (aob, next_aob), (delta_hd, next_delta_hd) in zip(
+        itertools.pairwise(pn),
+        itertools.pairwise(aobn),
+        itertools.pairwise(delta_hdn),
+        strict=True,
+    ):
+        if aob == 0:
+            s.append(p)
+            break
+        if (aob * next_aob) == -1:
+            # this linear interpolation is new in v1.5
+            frac = delta_hd / (delta_hd - next_delta_hd)
+            s.append(p * (1 - frac) + next_p * frac)
+
+    return np.asarray(s)

--- a/sarkit/sicd/projection/_derived.py
+++ b/sarkit/sicd/projection/_derived.py
@@ -1,11 +1,26 @@
 """Functions that can select monostatic or bistatic methods."""
 
+from collections.abc import Callable
+
 import lxml.etree
 import numpy as np
 import numpy.typing as npt
 
 from . import _calc as calc
 from . import _params as params
+
+
+def _get_projsets(sicd_xmltree, image_grid_locations):
+    """Extract metadata params and compute projection set(s), with APOs applied if available"""
+    proj_metadata = params.MetadataParams.from_xml(sicd_xmltree)
+    projection_sets = calc.compute_projection_sets(proj_metadata, image_grid_locations)
+
+    if params.AdjustableParameterOffsets.exists(sicd_xmltree):
+        adjust_param_offsets = params.AdjustableParameterOffsets.from_xml(sicd_xmltree)
+        projection_sets = calc.compute_and_apply_offsets(
+            proj_metadata, projection_sets, adjust_param_offsets
+        )
+    return proj_metadata, projection_sets
 
 
 def image_to_ground_plane(
@@ -51,14 +66,7 @@ def image_to_ground_plane(
         criteria are dependent on the collect type.
 
     """
-    proj_metadata = params.MetadataParams.from_xml(sicd_xmltree)
-    projection_sets = calc.compute_projection_sets(proj_metadata, image_grid_locations)
-
-    if params.AdjustableParameterOffsets.exists(sicd_xmltree):
-        adjust_param_offsets = params.AdjustableParameterOffsets.from_xml(sicd_xmltree)
-        projection_sets = calc.compute_and_apply_offsets(
-            proj_metadata, projection_sets, adjust_param_offsets
-        )
+    proj_metadata, projection_sets = _get_projsets(sicd_xmltree, image_grid_locations)
     method = (
         {True: "monostatic", False: "bistatic"}[proj_metadata.is_monostatic()]
         if method is None
@@ -110,37 +118,28 @@ def scene_to_image(
 ) -> tuple[npt.NDArray, npt.NDArray, bool]:
     """Map geolocated points in the three-dimensional scene to image grid locations.
 
+    Refer to :py:func:`sarkit.sicd.projection.scene_to_image` for full documentation of the outputs and other
+    parameters.
+
     Parameters
     ----------
     sicd_xmltree : lxml.etree.ElementTree
         SICD XML metadata.
-    scene_points : (..., 3) array_like
-        Array of scene points with ECEF (WGS 84 cartesian) X, Y, Z components in meters in the
-        last dimension.
-    delta_gp_s2i : float, optional
-        Ground plane displacement threshold for final ground plane point in meters.
-    maxiter : int, optional
-        Maximum number of iterations to perform.
-    bistat_delta_gp_gpp : float, optional
-        (Bistatic only) Ground plane displacement threshold for intermediate ground
-        plane points in meters.
-    bistat_maxiter : int, optional
-        (Bistatic only) Maximum number of intermediate bistatic R/Rdot to Ground Plane
-        iterations to perform per scene-to-image iteration.
 
     Returns
     -------
     image_grid_locations : (..., 2) ndarray
-        Array of image coordinates with xrow/ycol in meters in the last dimension.
-        Coordinates are NaN where there is no projection solution.
     delta_gp : ndarray
-        Ground-plane to scene displacement magnitude. Values are NaN where there is no
-        projection solution.
     success : bool
-        Whether or not all displacement magnitudes, ``delta_gp`` are less than or equal
-        to the threshold, ``delta_gp_s2i``.
-        For bistatic projections, ``success`` also requires convergence of all
-        intermediate ground plane points.
+
+    Other Parameters
+    ----------------
+    *args, **kwargs
+        For other arguments, refer to :py:func:`sarkit.sicd.projection.scene_to_image`
+
+    See Also
+    --------
+    :py:func:`sarkit.sicd.projection.scene_to_image`
     """
     proj_metadata = params.MetadataParams.from_xml(sicd_xmltree)
 
@@ -171,45 +170,31 @@ def image_to_constant_hae_surface(
 ) -> tuple[npt.NDArray, npt.NDArray, bool]:
     """Project image coordinates to a surface of constant HAE.
 
+    Refer to `r_rdot_to_constant_hae_surface` for full documentation of the outputs and other parameters.
+
     Parameters
     ----------
     sicd_xmltree : lxml.etree.ElementTree
         SICD XML metadata.
     image_grid_locations : (..., 2) array_like
         Image coordinates with xrow/ycol in meters in the last dimension.
-    hae0 : array_like
-        Surface height above the WGS-84 reference ellipsoid for projection points in meters.
-    delta_hae_max : float, optional
-        Height threshold for convergence of iterative projection sequence in meters.
-    nlim : int, optional
-        Maximum number of iterations to perform.
-    bistat_delta_gp_gpp : float, optional
-        (Bistatic only) Ground plane displacement threshold for intermediate ground
-        plane points in meters.
-    bistat_maxiter : int, optional
-        (Bistatic only) Maximum number of intermediate bistatic R/Rdot to Ground Plane
-        iterations to perform per scene-to-image iteration.
 
     Returns
     -------
     spp_tgt : (..., 3) ndarray
-        Array of points on the HAE0 surface with ECEF (WGS 84 cartesian) X, Y, Z components in meters
-        in the last dimension.
     delta_hae : ndarray
-        Height difference at point GPP relative to HAE0.
     success : bool
-        Whether or not all height differences, ``delta_hae`` are less than or equal
-        to the threshold, ``delta_hae_max``.
+
+    Other Parameters
+    ----------------
+    *args, **kwargs
+        For other arguments, refer to :py:func:`~sarkit.sicd.projection.r_rdot_to_constant_hae_surface`
+
+    See Also
+    --------
+    :py:func:`~sarkit.sicd.projection.r_rdot_to_constant_hae_surface`
     """
-    proj_metadata = params.MetadataParams.from_xml(sicd_xmltree)
-    projection_sets = calc.compute_projection_sets(proj_metadata, image_grid_locations)
-
-    if params.AdjustableParameterOffsets.exists(sicd_xmltree):
-        adjust_param_offsets = params.AdjustableParameterOffsets.from_xml(sicd_xmltree)
-        projection_sets = calc.compute_and_apply_offsets(
-            proj_metadata, projection_sets, adjust_param_offsets
-        )
-
+    proj_metadata, projection_sets = _get_projsets(sicd_xmltree, image_grid_locations)
     return calc.r_rdot_to_constant_hae_surface(
         proj_metadata.LOOK,
         proj_metadata.SCP,
@@ -219,4 +204,55 @@ def image_to_constant_hae_surface(
         nlim=nlim,
         bistat_delta_gp_gpp=bistat_delta_gp_gpp,
         bistat_maxiter=bistat_maxiter,
+    )
+
+
+def image_to_dem_surface(
+    sicd_xmltree: lxml.etree.ElementTree,
+    image_grid_location: npt.ArrayLike,
+    ecef2dem_func: Callable[[np.ndarray], np.ndarray],
+    hae_min: float,
+    hae_max: float,
+    delta_dist_dem: float,
+    *,
+    delta_dist_rrc: float = 10.0,
+    delta_hd_lim: float = 0.001,
+    **kwargs,
+) -> npt.NDArray:
+    """Project image coordinate to a surface described by a Digital Elevation Model.
+
+    Refer to `r_rdot_to_dem_surface` for full documentation of the outputs and other parameters.
+
+    Parameters
+    ----------
+    sicd_xmltree : lxml.etree.ElementTree
+        SICD XML metadata
+    image_grid_location : (2,) array_like
+        Image coordinate with xrow/ycol in meters
+
+    Returns
+    -------
+    s : ndarray
+
+    Other Parameters
+    ----------------
+    *args, **kwargs
+        For other arguments, refer to :py:func:`~sarkit.sicd.projection.r_rdot_to_dem_surface`
+
+    See Also
+    --------
+    :py:func:`~sarkit.sicd.projection.r_rdot_to_dem_surface`
+    """
+    proj_metadata, projection_sets = _get_projsets(sicd_xmltree, image_grid_location)
+    return calc.r_rdot_to_dem_surface(
+        proj_metadata.LOOK,
+        proj_metadata.SCP,
+        projection_sets,
+        ecef2dem_func=ecef2dem_func,
+        hae_min=hae_min,
+        hae_max=hae_max,
+        delta_dist_dem=delta_dist_dem,
+        delta_dist_rrc=delta_dist_rrc,
+        delta_hd_lim=delta_hd_lim,
+        **kwargs,
     )


### PR DESCRIPTION
# Description
This PR adds functionality for SICD IPDD Section 10 (Precise R/Rdot to DEM Surface Projection) to `sarkit.sicd`:

- `sarkit.sicd.image_to_dem_surface`
- `sarkit.sicd.projection.r_rdot_to_dem_surface`

## Notes:
- SICD v1.4 (and earlier) only support monostatic DEM projection
- tried to adapt a [numpydoc guideline](https://numpydoc.readthedocs.io/en/latest/format.html#method-docstrings) to reduce docstring copy-paste between the methods in `sarkit.sicd.projection` and the derived methods in `sarkit.sicd`