### PR TITLE
Support numpy>=1.25.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dynamic = ["version"]
 
 dependencies = [
     "lxml>=5.1.0",
-    "numpy>=1.26.3",
+    "numpy>=1.25.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# Description
This PR broadens numpy support to include `>=1.25.0` to match https://scientific-python.org/specs/spec-0000/

![image](https://github.com/user-attachments/assets/794a8d92-f7e0-4a54-9673-d96f899492bc)
