### PR TITLE
Bugfix: make sure all deps are installed before type checking

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -44,7 +44,9 @@ def format(session):
 
 @nox.session
 def lint(session):
-    session.run_install("pdm", "sync", "--prod", "-G", "dev-lint", external=True)
+    session.run_install(
+        "pdm", "sync", "--prod", "-G", "dev-lint", "-G", "all", external=True
+    )
     session.run("ruff", "check")
     session.run(
         "ruff",


### PR DESCRIPTION
# Description
This PR fixes a latent bug wherein our `lint` nox session is calling mypy in a session that does not explicitly install all dependencies. Although it isn't causing any issues for now, if an extra were to add a dependency with typing, mypy would fail to find it.