### PR TITLE
Bugfix: SicdConsistency.check_nitf_imseg IID1s

### DIFF
--- a/sarkit/verification/_sicd_consistency.py
+++ b/sarkit/verification/_sicd_consistency.py
@@ -432,16 +432,15 @@ class SicdConsistency(con.ConsistencyChecker):
                     assert imhdr["IMAG"].value == "1.0"
 
             with self.need("Sequential IID1"):
-                if len(imsegs) == 1:
-                    assert imsegs[0]["SubHeader"]["IID1"].value.rstrip() == "SICD000"
-                else:
-                    expected_iid1s = [
-                        f"SICD{idx + 1:03d}   " for idx in range(len(imsegs))
-                    ]
-                    actual_iid1s = [
-                        imseg["SubHeader"]["IID1"].value for imseg in imsegs
-                    ]
-                    assert actual_iid1s == expected_iid1s
+                expected_iid1s = (
+                    ["SICD000"]
+                    if len(imsegs) == 1
+                    else sorted([f"SICD{n + 1:03d}" for n in range(len(imsegs))])
+                )
+                actual_iid1s = sorted(
+                    [imseg["SubHeader"]["IID1"].value for imseg in imsegs]
+                )
+                assert actual_iid1s == expected_iid1s
 
     def check_nitf_imseg_lvls(self) -> None:
         """Check NITF inter-Image SubHeaders Display and Attachment levels"""

--- a/tests/verification/test_crsd_consistency.py
+++ b/tests/verification/test_crsd_consistency.py
@@ -13,6 +13,8 @@ import sarkit.crsd as skcrsd
 import sarkit.wgs84
 from sarkit.verification._crsd_consistency import CrsdConsistency, main
 
+from . import testing
+
 DATAPATH = pathlib.Path(__file__).parents[2] / "data"
 
 good_crsd_xml_path = DATAPATH / "example-crsd-1.0-draft.2025-02-25.xml"
@@ -44,14 +46,7 @@ def _remove(root, pattern):
 
 
 def assert_failures(crsd_con, pattern):
-    pattern = re.compile(pattern)
-    failure_details = itertools.chain(
-        *[x["details"] for x in crsd_con.failures(omit_passed_sub=True).values()]
-    )
-    failure_messages = [x["details"] for x in failure_details]
-
-    # this construction can help improve the error message for determining why pattern is not present
-    assert any(list(map(pattern.search, failure_messages)))
+    testing.assert_failures(crsd_con, pattern)
 
 
 def assert_not_failures(crsd_con, pattern):

--- a/tests/verification/testing.py
+++ b/tests/verification/testing.py
@@ -1,0 +1,13 @@
+import itertools
+import re
+
+
+def assert_failures(con, pattern):
+    pattern = re.compile(pattern)
+    failure_details = itertools.chain(
+        *[x["details"] for x in con.failures(omit_passed_sub=True).values()]
+    )
+    failure_messages = [x["details"] for x in failure_details]
+
+    # this construction can help improve the error message for determining why pattern is not present
+    assert any(list(map(pattern.search, failure_messages)))


### PR DESCRIPTION
# Description
This PR fixes a bug found when running `sicd-consistency` against a SICD NITF with more than one image segment. For the multiple-image-segment case, there is a mismatch in the "actual" values (which were being stripped of whitespace) and the "expected" values which were being padded with whitespace.

The new test fails when run in `main`:

<details><summary>new test in main</summary>

```
pdm run pytest tests/verification/test_sicd_consistency.py::test_check_nitf_imseg
======================================================================================================================================================================= test session starts =======================================================================================================================================================================
platform linux -- Python 3.12.9, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarkit
configfile: pyproject.toml
collected 1 item                                                                                                                                                                                                                                                                                                                                                  

tests/verification/test_sicd_consistency.py F                                                                                                                                                                                                                                                                                                               [100%]

============================================================================================================================================================================ FAILURES =============================================================================================================================================================================
______________________________________________________________________________________________________________________________________________________________________ test_check_nitf_imseg ______________________________________________________________________________________________________________________________________________________________________

example_sicd_file = <_io.BufferedReader name='/data/tmp/pytest-of-vscuser/pytest-1969/data0/example-sicd-1.2.1.sicd'>, tmp_path = PosixPath('/data/tmp/pytest-of-vscuser/pytest-1969/test_check_nitf_imseg0')

    def test_check_nitf_imseg(example_sicd_file, tmp_path):
    
        with sksicd.NitfReader(example_sicd_file) as r:
            sicd_meta = r.metadata
    
        # Use SICD v1.4.0 FFDD Example 2 parameters to force segmentation
        sicd_meta.xmltree.find("{*}ImageData/{*}NumRows").text = "30000"
        sicd_meta.xmltree.find("{*}ImageData/{*}NumCols").text = "90000"
        sicd_meta.xmltree.find("{*}ImageData/{*}PixelType").text = "RE32F_IM32F"
        assert sksicd.image_segment_sizing_calculations(sicd_meta.xmltree)[0] == 3
        tmp_sicd = tmp_path / "forced_segmentation.sicd"
        with open(tmp_sicd, "wb") as f, sksicd.NitfWriter(f, sicd_meta):
            pass  # don't currently care about the pixels
    
        with tmp_sicd.open("rb") as f:
            sicd_con = SicdConsistency.from_file(f)
        sicd_con.check("check_nitf_imseg")
>       assert sicd_con.passes() and not sicd_con.failures()
E       assert ({})
E        +  where {} = passes()
E        +    where passes = <sarkit.verification._sicd_consistency.SicdConsistency object at 0x7fbf65e51760>.passes

tests/verification/test_sicd_consistency.py:708: AssertionError
===================================================================================================================================================================== short test summary info =====================================================================================================================================================================
FAILED tests/verification/test_sicd_consistency.py::test_check_nitf_imseg - assert ({})
======================================================================================================================================================================== 1 failed in 0.39s ========================================================================================================================================================================
                                                                                                                                                                                                                                                                                                                                                                   

```

</details>

Here is a printout of the checker properly failing in the new unittest with the fix:

```
(Pdb) pp sicd_con.print_result(fail_detail=True)
check_nitf_imseg: Check NITF Image SubHeaders
    [Pass] Need: Valid image subheaders
    [Pass] Need: Valid image subheaders
    [Pass] Need: Valid image subheaders
    [Error] Need: Sequential IID1
        line#437: assert actual_iid1s == expected_iid1s

         where:
         actual_iid1s == expected_iid1s = False

         where:
         actual_iid1s = ['SICD000', 'SICD000', 'SICD000']

         where:
         expected_iid1s = ['SICD001', 'SICD002', 'SICD003']
```