### PR TITLE
python 3.13 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup PDM and Python
       uses: pdm-project/setup-pdm@v4
       with:
-        python-version: 3.12
+        python-version: 3.13
     - name: Install dependencies
       run: |
         pdm lock -G :all
@@ -75,7 +75,7 @@ jobs:
     - name: Setup PDM and Python
       uses: pdm-project/setup-pdm@v4
       with:
-        python-version: 3.12
+        python-version: 3.13
     - name: Install dependencies
       run: |
         pdm lock -G :all

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ default:
   - export PDM_CHECK_UPDATE=false
 
 current_env:
-  image: python:3.12
+  image: python:3.13
   stage: build
   script:
   - pdm lock -G:all

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.12"
+    python: "3.13"
   jobs:
     post_create_environment:
       - pip install --upgrade pdm

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![PyPI - Version](https://img.shields.io/pypi/v/sarkit)](https://pypi.org/project/sarkit/)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/sarkit)
 [![PyPI - License](https://img.shields.io/pypi/l/sarkit)](./LICENSE)
+[![SPEC 0 — Minimum Supported Dependencies](https://img.shields.io/badge/SPEC-0-green?labelColor=%23004811&color=%235CA038)](https://scientific-python.org/specs/spec-0000/)
 <br>
 [![Tests](https://github.com/ValkyrieSystems/sarkit/actions/workflows/tests.yml/badge.svg)](https://github.com/ValkyrieSystems/sarkit/actions/workflows/tests.yml)
 [![Documentation Status](https://readthedocs.org/projects/sarkit/badge/?version=latest)](https://sarkit.readthedocs.io/en/latest/?badge=latest)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
# Description
This PR adds explicit python=3.13 support to SARkit in accordance with [Scientific Python SPEC0](https://scientific-python.org/specs/spec-0000/).

- update classifier in pyproject.toml
- add [SPEC0 badge](https://scientific-python.org/specs/spec-0000/#badges) to README to communicate/capture our dependency strategy
- test with python=3.13 in gitlab/github CI
- use [python=3.13 in RTD](https://docs.readthedocs.com/platform/stable/config-file/v2.html#build-tools-python)

I activated a hidden RTD build from this branch to demonstrate that RTD works as expected: https://sarkit.readthedocs.io/en/python-3.13-support/

