### PR TITLE
Bugfix: write CPHDs without support arrays

### DIFF
--- a/sarkit/cphd/_io.py
+++ b/sarkit/cphd/_io.py
@@ -670,10 +670,6 @@ class Writer:
                 "size": sa_size,
             }
 
-        support_block_size = max(
-            sa["size"] + sa["offset"] for sa in self._sa_size_offsets.values()
-        )
-
         def _align(val):
             return int(np.ceil(float(val) / align_to) * align_to)
 
@@ -690,7 +686,9 @@ class Writer:
             "RELEASE_INFO": cphd_xmltree.findtext("{*}CollectionID/{*}ReleaseInfo"),
         }
         if self._sa_size_offsets:
-            self._file_header_kvp["SUPPORT_BLOCK_SIZE"] = support_block_size
+            self._file_header_kvp["SUPPORT_BLOCK_SIZE"] = max(
+                sa["size"] + sa["offset"] for sa in self._sa_size_offsets.values()
+            )
             self._file_header_kvp["SUPPORT_BLOCK_BYTE_OFFSET"] = (
                 np.iinfo(np.uint64).max,
             )  # placeholder

--- a/tests/core/cphd/test_io.py
+++ b/tests/core/cphd/test_io.py
@@ -82,7 +82,8 @@ def _random_support_array(cphd_xmltree, sa_id):
     )
 
 
-def test_roundtrip(tmp_path):
+@pytest.mark.parametrize("with_support_block", (True, False))
+def test_roundtrip(tmp_path, with_support_block):
     basis_etree = lxml.etree.parse(DATAPATH / "example-cphd-1.0.1.xml")
     basis_version = lxml.etree.QName(basis_etree.getroot()).namespace
     schema = lxml.etree.XMLSchema(file=skcphd.VERSION_INFO[basis_version]["schema"])
@@ -103,6 +104,11 @@ def test_roundtrip(tmp_path):
     pvps = np.zeros(num_vectors, dtype=skcphd.get_pvp_dtype(basis_etree))
     for f, (dt, _) in pvps.dtype.fields.items():
         pvps[f] = _random_array(num_vectors, dtype=dt, reshape=False)
+
+    assert basis_etree.find("{*}Data/{*}SupportArray") is not None
+    if not with_support_block:
+        for sa in basis_etree.findall(".//{*}SupportArray"):
+            sa.getparent().remove(sa)
 
     support_arrays = {}
     for data_sa_elem in basis_etree.findall("./{*}Data/{*}SupportArray"):


### PR DESCRIPTION
# Description
Credit to @bombaci-vsc for finding this. When attempting to create a CPHD Writer for an XML without support arrays, the logic for determining the support block size is run unnecessarily and errors out:

<details><summary>snippet of new test failure when run before the fix</summary>

```
>       support_block_size = max(
            sa["size"] + sa["offset"] for sa in self._sa_size_offsets.values()
        )
E       ValueError: max() iterable argument is empty

sarkit/cphd/_io.py:673: ValueError
================================================================================================================================================================ short test summary info ================================================================================================================================================================
FAILED tests/core/cphd/test_io.py::test_roundtrip[False] - ValueError: max() iterable argument is empty
============================================================================================================================================================== 1 failed, 1 passed in 0.38s ==============================================================================================================================================================
```

</details>

The fix is to move this logic down so that it is only used when appropriate (e.g. when support array metadata is present).