### PR TITLE
Remove CRSD draft markings, use schema posted on nsgreg

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Valkyrie Systems Corporation to encourage the use of National Geospatial-Intelli
 
 With SARkit, you can:
 
-* read and write SAR standards files (CPHD, SICD, SIDD)
+* read and write SAR standards files (CRSD, CPHD, SICD, SIDD)
 * interact with SAR XML metadata using more convenient Python objects
 * check SAR data/metadata files for inconsistencies
 

--- a/data/example-crsd-1.0.xml
+++ b/data/example-crsd-1.0.xml
@@ -1,4 +1,4 @@
-<CRSDsar xmlns="http://api.nsgreg.nga.mil/schema/crsd/1.0_DRAFT_2025_02_25">
+<CRSDsar xmlns="http://api.nsgreg.nga.mil/schema/crsd/1.0">
   <ProductInfo>
     <ProductName>The CRSDsar Product Name</ProductName>
     <Classification>UNCLASSIFIED</Classification>

--- a/data/syntax_only/crsd/0000-syntax-only-crsd-1.0.xml
+++ b/data/syntax_only/crsd/0000-syntax-only-crsd-1.0.xml
@@ -1,4 +1,4 @@
-<CRSDsar xmlns="http://api.nsgreg.nga.mil/schema/crsd/1.0_DRAFT_2025_02_25">
+<CRSDsar xmlns="http://api.nsgreg.nga.mil/schema/crsd/1.0">
     <ProductInfo>
         <ProductName>The CRSDsar Product Name</ProductName>
         <Classification>UNCLASSIFIED</Classification>

--- a/data/syntax_only/crsd/0001-syntax-only-crsd-1.0.xml
+++ b/data/syntax_only/crsd/0001-syntax-only-crsd-1.0.xml
@@ -1,4 +1,4 @@
-<CRSDsar xmlns="http://api.nsgreg.nga.mil/schema/crsd/1.0_DRAFT_2025_02_25">
+<CRSDsar xmlns="http://api.nsgreg.nga.mil/schema/crsd/1.0">
     <ProductInfo>
         <ProductName>The CRSDsar Product Name</ProductName>
         <Classification>UNCLASSIFIED</Classification>

--- a/data/syntax_only/crsd/0002-syntax-only-crsd-1.0.xml
+++ b/data/syntax_only/crsd/0002-syntax-only-crsd-1.0.xml
@@ -1,4 +1,4 @@
-<CRSDtx xmlns="http://api.nsgreg.nga.mil/schema/crsd/1.0_DRAFT_2025_02_25">
+<CRSDtx xmlns="http://api.nsgreg.nga.mil/schema/crsd/1.0">
     <ProductInfo>
         <ProductName>The CRSDsar Product Name</ProductName>
         <Classification>UNCLASSIFIED</Classification>

--- a/data/syntax_only/crsd/0003-syntax-only-crsd-1.0.xml
+++ b/data/syntax_only/crsd/0003-syntax-only-crsd-1.0.xml
@@ -1,4 +1,4 @@
-<CRSDrcv xmlns="http://api.nsgreg.nga.mil/schema/crsd/1.0_DRAFT_2025_02_25">
+<CRSDrcv xmlns="http://api.nsgreg.nga.mil/schema/crsd/1.0">
     <ProductInfo>
         <ProductName>The CRSDsar Product Name</ProductName>
         <Classification>UNCLASSIFIED</Classification>

--- a/data/syntax_only/crsd/make_syntax_only_crsd_xmls.py
+++ b/data/syntax_only/crsd/make_syntax_only_crsd_xmls.py
@@ -166,7 +166,7 @@ def main(args=None):
         ):
             etree = lxml.etree.parse(
                 pathlib.Path(__file__).parent
-                / "manual-syntax-only-crsd-mono-sar-1.0-draft.2025-02-25.xml"
+                / "manual-syntax-only-crsd-mono-sar-1.0.xml"
             )
             mods(etree)
             version_ns = lxml.etree.QName(etree.getroot()).namespace
@@ -189,7 +189,7 @@ def main(args=None):
                 diff.diff_files
                 or {
                     pathlib.Path(__file__).name,
-                    "manual-syntax-only-crsd-mono-sar-1.0-draft.2025-02-25.xml",
+                    "manual-syntax-only-crsd-mono-sar-1.0.xml",
                     "stubs",
                 }.symmetric_difference(diff.left_only)
             )

--- a/data/syntax_only/crsd/manual-syntax-only-crsd-mono-sar-1.0.xml
+++ b/data/syntax_only/crsd/manual-syntax-only-crsd-mono-sar-1.0.xml
@@ -1,4 +1,4 @@
-<CRSDsar xmlns="http://api.nsgreg.nga.mil/schema/crsd/1.0_DRAFT_2025_02_25">
+<CRSDsar xmlns="http://api.nsgreg.nga.mil/schema/crsd/1.0">
   <ProductInfo>
     <ProductName>The CRSDsar Product Name</ProductName>
     <Classification>UNCLASSIFIED</Classification>

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -36,7 +36,7 @@ used to describe settable metadata.
      - Reader
      - Metadata
      - Writer
-   * - ⛔ CRSD [Draft] ⛔
+   * - CRSD
      - :py:class:`~sarkit.crsd.Reader`
      - :py:class:`~sarkit.crsd.Metadata`
      - :py:class:`~sarkit.crsd.Writer`
@@ -179,7 +179,7 @@ convenient Python objects.
 
    * - Format
      - XML Helper
-   * - ⛔ CRSD [Draft] ⛔
+   * - CRSD
      - :py:class:`sarkit.crsd.XmlHelper`
    * - CPHD
      - :py:class:`sarkit.cphd.XmlHelper`
@@ -272,7 +272,7 @@ SARkit provides checkers that can be used to identify inconsistencies in SAR sta
    * - Format
      - Consistency class
      - Command
-   * - ⛔ CRSD [Draft] ⛔
+   * - CRSD
      - :py:class:`sarkit.verification.CrsdConsistency`
      - :ref:`crsd-consistency-cli`
    * - CPHD

--- a/sarkit/crsd/__init__.py
+++ b/sarkit/crsd/__init__.py
@@ -9,9 +9,7 @@ documents that define the Compensated Radar Signal Data (CRSD) format.
 Supported Versions
 ==================
 
-* `CRSD 1.0 DRAFT 2025-02-25`_
-
-.. WARNING:: v1.0 DRAFT support is temporary and will be replaced upon NTB approval
+* `CRSD 1.0`_
 
 Data Structure & File Format
 ============================
@@ -96,10 +94,16 @@ Constants
 References
 ==========
 
-CRSD 1.0 DRAFT 2025-02-25
--------------------------
-TBD
+CRSD 1.0
+--------
+.. [NGA.STND.0080-1_1.0_CRSD] National Center for Geospatial Intelligence Standards,
+   "Compensated Radar Signal Data (CRSD), Vol. 1, Design & Implementation Description Document,
+   Version 1.0", 2025.
+   https://nsgreg.nga.mil/doc/view?i=5672
 
+.. [NGA.STND.0080-2_1.0_CRSD_schema_2025_02_25.xsd] National Center for Geospatial Intelligence Standards,
+   "Compensated Radar Signal Data (CRSD) XML Schema, Version 1.0", 2025.
+   https://nsgreg.nga.mil/doc/view?i=5673
 """
 
 from ._computations import (
@@ -195,15 +199,3 @@ __all__ = [
     "mask_support_array",
     "read_file_header",
 ]
-
-
-import os  # noqa: I001
-import sys  # noqa: I001
-
-print(
-    "\033[93m" if sys.stdout.isatty() and not os.environ.get("NO_COLOR") else "",
-    "WARNING: SARkit's CRSD modules are provisional and implement the 2025-02-25 draft\n",
-    "The modules will be updated and this message will be removed when the standard is published",
-    "\x1b[0m" if sys.stdout.isatty() and not os.environ.get("NO_COLOR") else "",
-    file=sys.stderr,
-)

--- a/sarkit/crsd/_io.py
+++ b/sarkit/crsd/_io.py
@@ -33,10 +33,10 @@ DEFINED_HEADER_KEYS: Final[set] = {
 }
 
 VERSION_INFO: Final[dict] = {
-    "http://api.nsgreg.nga.mil/schema/crsd/1.0_DRAFT_2025_02_25": {
+    "http://api.nsgreg.nga.mil/schema/crsd/1.0": {
         "version": "1.0",
         "date": "2025-02-25T00:00:00Z",
-        "schema": SCHEMA_DIR / "CRSD_schema_V1.0_DRAFT_2025_02_25.xsd",
+        "schema": SCHEMA_DIR / "NGA.STND.0080-2_1.0_CRSD_schema_2025_02_25.xsd",
     },
 }
 
@@ -188,7 +188,7 @@ class Reader:
         import sarkit.crsd as skcrsd
         import lxml.etree
         meta = skcrsd.Metadata(
-            xmltree=lxml.etree.parse("data/example-crsd-1.0-draft.2025-02-25.xml")
+            xmltree=lxml.etree.parse("data/example-crsd-1.0.xml")
         )
 
         file = pathlib.Path(tmpdir.name) / "foo"
@@ -460,7 +460,7 @@ class Writer:
 
         >>> import lxml.etree
 
-        >>> xmltree = lxml.etree.parse("data/example-crsd-1.0-draft.2025-02-25.xml")
+        >>> xmltree = lxml.etree.parse("data/example-crsd-1.0.xml")
         >>> first_sequence = xmltree.find("{*}Data/{*}Transmit/{*}TxSequence")
         >>> tx_id = first_sequence.findtext("{*}TxId")
         >>> num_p = int(first_sequence.findtext("{*}NumPulses"))

--- a/sarkit/crsd/schemas/NGA.STND.0080-2_1.0_CRSD_schema_2025_02_25.xsd
+++ b/sarkit/crsd/schemas/NGA.STND.0080-2_1.0_CRSD_schema_2025_02_25.xsd
@@ -2,9 +2,9 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
    elementFormDefault="qualified"
    attributeFormDefault="unqualified"
-   targetNamespace="http://api.nsgreg.nga.mil/schema/crsd/1.0_DRAFT_2025_02_25"
-   xmlns="http://api.nsgreg.nga.mil/schema/crsd/1.0_DRAFT_2025_02_25"
-   xmlns:ns="http://api.nsgreg.nga.mil/schema/crsd/1.0_DRAFT_2025_02_25"
+   targetNamespace="http://api.nsgreg.nga.mil/schema/crsd/1.0"
+   xmlns="http://api.nsgreg.nga.mil/schema/crsd/1.0"
+   xmlns:ns="http://api.nsgreg.nga.mil/schema/crsd/1.0"
    version="2025-02-25">
 
 <!-- CRSD TYPES -->

--- a/sarkit/verification/_crsd_consistency.py
+++ b/sarkit/verification/_crsd_consistency.py
@@ -193,7 +193,7 @@ class CrsdConsistency(con.ConsistencyChecker):
 
             >>> import sarkit.verification as skver
 
-            >>> with open("data/example-crsd-1.0-draft.2025-02-25.xml", "r") as f:
+            >>> with open("data/example-crsd-1.0.xml", "r") as f:
             ...     con = skver.CrsdConsistency.from_file(f)
             >>> con.check()
             >>> bool(con.passes())
@@ -208,7 +208,7 @@ class CrsdConsistency(con.ConsistencyChecker):
             import sarkit.crsd as skcrsd
             import lxml.etree
             meta = skcrsd.Metadata(
-                xmltree=lxml.etree.parse("data/example-crsd-1.0-draft.2025-02-25.xml"),
+                xmltree=lxml.etree.parse("data/example-crsd-1.0.xml"),
             )
             file = tmppath / "example.crsd"
             with file.open("wb") as f, skcrsd.Writer(f, meta) as w:
@@ -310,7 +310,7 @@ class CrsdConsistency(con.ConsistencyChecker):
 
             >>> import lxml.etree
             >>> import sarkit.verification as skver
-            >>> crsd_xmltree = lxml.etree.parse("data/example-crsd-1.0-draft.2025-02-25.xml")
+            >>> crsd_xmltree = lxml.etree.parse("data/example-crsd-1.0.xml")
             >>> con = skver.CrsdConsistency.from_parts(crsd_xmltree)
             >>> con.check()
             >>> bool(con.passes())

--- a/tests/core/crsd/test_io.py
+++ b/tests/core/crsd/test_io.py
@@ -9,7 +9,7 @@ DATAPATH = pathlib.Path(__file__).parents[3] / "data"
 
 
 def test_roundtrip(tmp_path, caplog):
-    basis_etree = lxml.etree.parse(DATAPATH / "example-crsd-1.0-draft.2025-02-25.xml")
+    basis_etree = lxml.etree.parse(DATAPATH / "example-crsd-1.0.xml")
     basis_version = lxml.etree.QName(basis_etree.getroot()).namespace
     schema = lxml.etree.XMLSchema(file=skcrsd.VERSION_INFO[basis_version]["schema"])
     schema.assertValid(basis_etree)

--- a/tests/verification/test_crsd_consistency.py
+++ b/tests/verification/test_crsd_consistency.py
@@ -17,7 +17,7 @@ from . import testing
 
 DATAPATH = pathlib.Path(__file__).parents[2] / "data"
 
-good_crsd_xml_path = DATAPATH / "example-crsd-1.0-draft.2025-02-25.xml"
+good_crsd_xml_path = DATAPATH / "example-crsd-1.0.xml"
 
 
 def _repack_support_arrays(crsd_etree):


### PR DESCRIPTION
# Description
CRSD v1.0 is now posted on the nsgreg:
- https://nsgreg.nga.mil/doc/view?i=5672
- https://nsgreg.nga.mil/doc/view?i=5673

This PR:
- replaces the schema with the one from nsgreg
- updates namespaces/file names as appropriate
- removes draft markings
- updates docs with links/citations