### PR TITLE
address np.sum(generator) deprecation warning

### DIFF
--- a/sarkit/sidd/_io.py
+++ b/sarkit/sidd/_io.py
@@ -888,7 +888,7 @@ class NitfWriter:
         ]
         imsegs = [self._jbp["ImageSegments"][idx] for idx in imseg_indices]
 
-        shape[0] = np.sum(imseg["subheader"]["NROWS"].value for imseg in imsegs)
+        shape[0] = sum(imseg["subheader"]["NROWS"].value for imseg in imsegs)
         shape[1] = imsegs[0]["subheader"]["NCOLS"].value
 
         irep = imsegs[0]["subheader"]["IREP"].value


### PR DESCRIPTION
# Description
This PR addresses the `np.sum(generator)` [DeprecationWarning](https://github.com/ValkyrieSystems/sarkit/actions/runs/16004280135/job/45146935947#step:5:60) in `sarkit.sidd._io`:

```
 tests/core/sidd/test_io.py: 24 warnings
  /home/runner/work/sarkit/sarkit/sarkit/sidd/_io.py:891: DeprecationWarning: Calling np.sum(generator) is deprecated, and in the future will give a different result. Use np.sum(np.fromiter(generator)) or the python sum builtin instead.
    shape[0] = np.sum(imseg["subheader"]["NROWS"].value for imseg in imsegs)
```