### PR TITLE
Support remote file reading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev-lint = [
 ]
 dev-test = [
     "pytest>=7.4.4",
+    "smart_open[http]>=7.1.0",
 ]
 dev = [
     "sarkit[dev-test,dev-lint]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
 [dependency-groups]
 test = [
     "nox>=2024.3.2",
+    "smart_open[http]>=7.1.0",
 ]
 doc = [
     "sphinx>=7.2.6",

--- a/sarkit/_iohelp.py
+++ b/sarkit/_iohelp.py
@@ -1,0 +1,27 @@
+"""
+Common IO Helper functionality
+"""
+
+import numpy as np
+
+BUFFER_SIZE = 2**27
+
+
+def fromfile(file_obj, dtype, count):
+    values = np.empty((count,), dtype)
+    max_read_items = max(BUFFER_SIZE // dtype.itemsize, 1)
+    num_to_read = count
+    num_already_read = 0
+    while num_to_read > 0:
+        read_count = min(max_read_items, num_to_read)
+        nbytes_requested = read_count * dtype.itemsize
+        array = file_obj.read(nbytes_requested)
+        nbytes_read = len(array)
+        if nbytes_read != nbytes_requested:
+            raise RuntimeError(f"Expected {nbytes_requested=}; only read {nbytes_read}")
+        values[num_already_read : num_already_read + read_count] = np.frombuffer(
+            array, dtype
+        )
+        num_already_read += read_count
+        num_to_read -= read_count
+    return values

--- a/sarkit/cphd/_io.py
+++ b/sarkit/cphd/_io.py
@@ -13,6 +13,8 @@ import lxml.etree
 import numpy as np
 import numpy.typing as npt
 
+from sarkit import _iohelp
+
 SCHEMA_DIR = importlib.resources.files("sarkit.cphd.schemas")
 SECTION_TERMINATOR: Final[bytes] = b"\f\n"
 DEFINED_HEADER_KEYS: Final[set] = {
@@ -473,12 +475,7 @@ class Reader:
         self._file_object.seek(signal_offset + self._signal_block_byte_offset)
         shape, dtype = _describe_signal(self.metadata.xmltree, channel_identifier)
         dtype = dtype.newbyteorder(">")
-        nbytes = np.prod(shape) * dtype.itemsize
-        sigarray = self._file_object.read(nbytes)
-        nbytes_read = len(sigarray)
-        if nbytes != nbytes_read:
-            raise RuntimeError(f"Expected {nbytes=}; only read {nbytes_read}")
-        return np.frombuffer(sigarray, dtype=dtype).reshape(shape)
+        return _iohelp.fromfile(self._file_object, dtype, np.prod(shape)).reshape(shape)
 
     def read_pvps(self, channel_identifier: str) -> npt.NDArray:
         """Read pvp data from a CPHD file
@@ -503,12 +500,7 @@ class Reader:
         self._file_object.seek(pvp_offset + self._pvp_block_byte_offset)
 
         pvp_dtype = get_pvp_dtype(self.metadata.xmltree).newbyteorder("B")
-        nbytes = pvp_dtype.itemsize * num_vect
-        array = self._file_object.read(nbytes)
-        nbytes_read = len(array)
-        if nbytes != nbytes_read:
-            raise RuntimeError(f"Expected {nbytes=}; only read {nbytes_read}")
-        return np.frombuffer(array, pvp_dtype).copy()
+        return _iohelp.fromfile(self._file_object, pvp_dtype, num_vect)
 
     def read_channel(self, channel_identifier: str) -> tuple[npt.NDArray, npt.NDArray]:
         """Read signal and pvp data from a CPHD file channel
@@ -544,12 +536,7 @@ class Reader:
         sa_offset = int(sa_info.find("./{*}ArrayByteOffset").text)
         self._file_object.seek(sa_offset + self._support_block_byte_offset)
         assert dtype.itemsize == int(sa_info.find("./{*}BytesPerElement").text)
-        nbytes = dtype.itemsize * np.prod(shape)
-        array = self._file_object.read(nbytes)
-        nbytes_read = len(array)
-        if nbytes != nbytes_read:
-            raise RuntimeError(f"Expected {nbytes=}; only read {nbytes_read}")
-        return np.frombuffer(array, dtype).reshape(shape).copy()
+        return _iohelp.fromfile(self._file_object, dtype, np.prod(shape)).reshape(shape)
 
     def read_support_array(self, sa_identifier, masked=True):
         """Read SupportArray"""

--- a/sarkit/crsd/_io.py
+++ b/sarkit/crsd/_io.py
@@ -14,6 +14,7 @@ import numpy as np
 import numpy.typing as npt
 
 import sarkit.cphd as skcphd
+from sarkit import _iohelp
 
 SCHEMA_DIR = importlib.resources.files("sarkit.crsd.schemas")
 SECTION_TERMINATOR: Final[bytes] = b"\f\n"
@@ -343,12 +344,7 @@ class Reader:
         self._file_object.seek(signal_offset + self._signal_block_byte_offset)
         shape, dtype = _describe_signal(self.metadata.xmltree, channel_identifier)
         dtype = dtype.newbyteorder(">")
-        nbytes = np.prod(shape) * dtype.itemsize
-        sigarray = self._file_object.read(nbytes)
-        nbytes_read = len(sigarray)
-        if nbytes != nbytes_read:
-            raise RuntimeError(f"Expected {nbytes=}; only read {nbytes_read}")
-        return np.frombuffer(sigarray, dtype=dtype).reshape(shape)
+        return _iohelp.fromfile(self._file_object, dtype, np.prod(shape)).reshape(shape)
 
     def read_signal_compressed(self) -> npt.NDArray:
         """Read signal data from a CRSD file with signal arrays stored in compressed format
@@ -379,11 +375,7 @@ class Reader:
         self._file_object.seek(self._signal_block_byte_offset)
         dtype = np.dtype("uint8")
         nbytes = int(compressed_size_str)
-        sigarray = self._file_object.read(nbytes)
-        nbytes_read = len(sigarray)
-        if nbytes != nbytes_read:
-            raise RuntimeError(f"Expected {nbytes=}; only read {nbytes_read}")
-        return np.frombuffer(sigarray, dtype=dtype)
+        return _iohelp.fromfile(self._file_object, dtype, nbytes)
 
     def read_pvps(self, channel_identifier: str) -> npt.NDArray:
         """Read pvp data from a CRSD file
@@ -409,12 +401,7 @@ class Reader:
         self._file_object.seek(pvp_offset + self._pvp_block_byte_offset)
 
         pvp_dtype = get_pvp_dtype(self.metadata.xmltree).newbyteorder("B")
-        nbytes = pvp_dtype.itemsize * num_vect
-        array = self._file_object.read(nbytes)
-        nbytes_read = len(array)
-        if nbytes != nbytes_read:
-            raise RuntimeError(f"Expected {nbytes=}; only read {nbytes_read}")
-        return np.frombuffer(array, pvp_dtype).copy()
+        return _iohelp.fromfile(self._file_object, pvp_dtype, num_vect)
 
     def read_channel(self, channel_identifier: str) -> tuple[npt.NDArray, npt.NDArray]:
         """Read signal and pvp data from a CRSD file channel
@@ -458,12 +445,7 @@ class Reader:
         self._file_object.seek(ppp_offset + self._ppp_block_byte_offset)
 
         ppp_dtype = get_ppp_dtype(self.metadata.xmltree).newbyteorder("B")
-        nbytes = ppp_dtype.itemsize * num_pulse
-        array = self._file_object.read(nbytes)
-        nbytes_read = len(array)
-        if nbytes != nbytes_read:
-            raise RuntimeError(f"Expected {nbytes=}; only read {nbytes_read}")
-        return np.frombuffer(array, ppp_dtype).copy()
+        return _iohelp.fromfile(self._file_object, ppp_dtype, num_pulse)
 
     def _read_support_array(self, sa_identifier):
         elem_format = self.metadata.xmltree.find(
@@ -481,12 +463,7 @@ class Reader:
         sa_offset = int(sa_info.find("./{*}ArrayByteOffset").text)
         self._file_object.seek(sa_offset + self._support_block_byte_offset)
         assert dtype.itemsize == int(sa_info.find("./{*}BytesPerElement").text)
-        nbytes = dtype.itemsize * np.prod(shape)
-        array = self._file_object.read(nbytes)
-        nbytes_read = len(array)
-        if nbytes != nbytes_read:
-            raise RuntimeError(f"Expected {nbytes=}; only read {nbytes_read}")
-        return np.frombuffer(array, dtype).reshape(shape).copy()
+        return _iohelp.fromfile(self._file_object, dtype, np.prod(shape)).reshape(shape)
 
     def read_support_array(self, sa_identifier, masked=True):
         """Read SupportArray"""

--- a/sarkit/sicd/_io.py
+++ b/sarkit/sicd/_io.py
@@ -473,8 +473,8 @@ class NitfReader:
         imseg_sizes = np.asarray([imseg["Data"].size for imseg in imsegs])
         imseg_offsets = np.asarray([imseg["Data"].get_offset() for imseg in imsegs])
         splits = np.cumsum(imseg_sizes // (ncols * dtype.itemsize))[:-1]
-        for split, sz, offset in zip(
-            np.array_split(sicd_pixels, splits, axis=0), imseg_sizes, imseg_offsets
+        for split, offset in zip(
+            np.array_split(sicd_pixels, splits, axis=0), imseg_offsets
         ):
             self._file_object.seek(offset)
             split[...] = _iohelp.fromfile(

--- a/sarkit/sicd/_io.py
+++ b/sarkit/sicd/_io.py
@@ -20,6 +20,7 @@ import numpy.typing as npt
 
 import sarkit.sicd._xml as sicd_xml
 import sarkit.wgs84
+from sarkit import _iohelp
 
 SPECIFICATION_IDENTIFIER: Final[str] = (
     "SICD Volume 1 Design & Implementation Description Document"
@@ -476,8 +477,9 @@ class NitfReader:
             np.array_split(sicd_pixels, splits, axis=0), imseg_sizes, imseg_offsets
         ):
             self._file_object.seek(offset)
-            array = self._file_object.read(sz)
-            split[...] = np.frombuffer(array, dtype).reshape(split.shape)
+            split[...] = _iohelp.fromfile(
+                self._file_object, dtype, np.prod(split.shape)
+            ).reshape(split.shape)
         return sicd_pixels
 
     def read_sub_image(

--- a/sarkit/sicd/_io.py
+++ b/sarkit/sicd/_io.py
@@ -475,10 +475,9 @@ class NitfReader:
         for split, sz, offset in zip(
             np.array_split(sicd_pixels, splits, axis=0), imseg_sizes, imseg_offsets
         ):
-            this_os = offset - self._file_object.tell()
-            split[...] = np.fromfile(
-                self._file_object, dtype, count=sz // dtype.itemsize, offset=this_os
-            ).reshape(split.shape)
+            self._file_object.seek(offset)
+            array = self._file_object.read(sz)
+            split[...] = np.frombuffer(array, dtype).reshape(split.shape)
         return sicd_pixels
 
     def read_sub_image(

--- a/sarkit/sidd/_io.py
+++ b/sarkit/sidd/_io.py
@@ -520,10 +520,9 @@ class NitfReader:
         for split, sz, offset in zip(
             np.array_split(image_pixels, splits, axis=0), imseg_sizes, imseg_offsets
         ):
-            this_os = offset - self._file_object.tell()
-            split[...] = np.fromfile(
-                self._file_object, dtype, count=sz // dtype.itemsize, offset=this_os
-            ).reshape(split.shape)
+            self._file_object.seek(offset)
+            array = self._file_object.read(sz)
+            split[...] = np.frombuffer(array, dtype).reshape(split.shape)
 
         return image_pixels
 

--- a/sarkit/sidd/_io.py
+++ b/sarkit/sidd/_io.py
@@ -23,6 +23,7 @@ import sarkit.sicd as sksicd
 import sarkit.sicd._io
 import sarkit.sidd as sksidd
 import sarkit.wgs84
+from sarkit import _iohelp
 
 logger = logging.getLogger(__name__)
 
@@ -521,8 +522,9 @@ class NitfReader:
             np.array_split(image_pixels, splits, axis=0), imseg_sizes, imseg_offsets
         ):
             self._file_object.seek(offset)
-            array = self._file_object.read(sz)
-            split[...] = np.frombuffer(array, dtype).reshape(split.shape)
+            split[...] = _iohelp.fromfile(
+                self._file_object, dtype, np.prod(split.shape)
+            ).reshape(split.shape)
 
         return image_pixels
 

--- a/sarkit/sidd/_io.py
+++ b/sarkit/sidd/_io.py
@@ -518,8 +518,8 @@ class NitfReader:
         imseg_sizes = np.asarray([imseg["Data"].size for imseg in imsegs])
         imseg_offsets = np.asarray([imseg["Data"].get_offset() for imseg in imsegs])
         splits = np.cumsum(imseg_sizes // (shape[-1] * dtype.itemsize))[:-1]
-        for split, sz, offset in zip(
-            np.array_split(image_pixels, splits, axis=0), imseg_sizes, imseg_offsets
+        for split, offset in zip(
+            np.array_split(image_pixels, splits, axis=0), imseg_offsets
         ):
             self._file_object.seek(offset)
             split[...] = _iohelp.fromfile(

--- a/tests/core/cphd/test_io.py
+++ b/tests/core/cphd/test_io.py
@@ -5,6 +5,7 @@ import lxml.builder
 import lxml.etree
 import numpy as np
 import pytest
+import smart_open
 
 import sarkit.cphd as skcphd
 
@@ -264,3 +265,10 @@ def test_write_support_array(is_masked, nodata_in_xml, tmp_path):
     with open(out_cphd, "rb") as f, skcphd.Reader(f) as reader:
         read_sa = reader.read_support_array(sa_id)
         assert np.array_equal(mx, read_sa)
+
+
+def test_remote_read():
+    with smart_open.open("https://www.govsco.com/content/spotlight.cphd", mode='rb') as file_object:
+        with skcphd.Reader(file_object) as r:
+            ch_id = r.metadata.xmltree.findtext("{*}Data/{*}Channel/{*}Identifier")
+            _, _ = r.read_channel(ch_id)

--- a/tests/core/cphd/test_io.py
+++ b/tests/core/cphd/test_io.py
@@ -268,7 +268,9 @@ def test_write_support_array(is_masked, nodata_in_xml, tmp_path):
 
 
 def test_remote_read():
-    with smart_open.open("https://www.govsco.com/content/spotlight.cphd", mode='rb') as file_object:
+    with smart_open.open(
+        "https://www.govsco.com/content/spotlight.cphd", mode="rb"
+    ) as file_object:
         with skcphd.Reader(file_object) as r:
             ch_id = r.metadata.xmltree.findtext("{*}Data/{*}Channel/{*}Identifier")
             _, _ = r.read_channel(ch_id)

--- a/tests/core/crsd/test_io.py
+++ b/tests/core/crsd/test_io.py
@@ -4,6 +4,7 @@ import lxml.builder
 import lxml.etree
 import numpy as np
 import pytest
+import smart_open
 
 import sarkit.crsd as skcrsd
 
@@ -174,3 +175,18 @@ def test_roundtrip_compressed(tmp_path):
         sig_array = reader.read_signal_compressed()
 
     assert sig_array.tobytes().decode() == signal_block_str
+
+
+def test_remote_read():
+    with smart_open.open(
+        "https://www.govsco.com/content/spotlight.crsd", mode="rb"
+    ) as file_object:
+        with skcrsd.Reader(file_object) as r:
+            ch_id = r.metadata.xmltree.findtext(
+                "{*}Channel/{*}Parameters/{*}Identifier"
+            )
+            _, _ = r.read_channel(ch_id)
+            seq_id = r.metadata.xmltree.findtext(
+                "{*}TxSequence/{*}Parameters/{*}Identifier"
+            )
+            _ = r.read_ppps(seq_id)

--- a/tests/core/sicd/test_io.py
+++ b/tests/core/sicd/test_io.py
@@ -5,6 +5,7 @@ import jbpy.core
 import lxml.etree
 import numpy as np
 import pytest
+import smart_open
 
 import sarkit.sicd as sksicd
 
@@ -375,3 +376,9 @@ def test_image_sizing():
     ]
 
     assert expected_imhdrs == imhdrs
+
+
+def test_remote_read():
+    with smart_open.open("https://www.govsco.com/content/spotlight.sicd", mode='rb') as file_object:
+        with sksicd.NitfReader(file_object) as r:
+            _ = r.read_image()

--- a/tests/core/sicd/test_io.py
+++ b/tests/core/sicd/test_io.py
@@ -379,6 +379,8 @@ def test_image_sizing():
 
 
 def test_remote_read():
-    with smart_open.open("https://www.govsco.com/content/spotlight.sicd", mode='rb') as file_object:
+    with smart_open.open(
+        "https://www.govsco.com/content/spotlight.sicd", mode="rb"
+    ) as file_object:
         with sksicd.NitfReader(file_object) as r:
             _ = r.read_image()

--- a/tests/core/sidd/test_io.py
+++ b/tests/core/sidd/test_io.py
@@ -648,6 +648,8 @@ def test_version_info():
 
 
 def test_remote_read():
-    with smart_open.open("https://www.govsco.com/content/spotlight.sidd", mode='rb') as file_object:
+    with smart_open.open(
+        "https://www.govsco.com/content/spotlight.sidd", mode="rb"
+    ) as file_object:
         with sksidd.NitfReader(file_object) as r:
             _ = r.read_image(0)

--- a/tests/core/sidd/test_io.py
+++ b/tests/core/sidd/test_io.py
@@ -6,6 +6,7 @@ import jbpy
 import lxml.etree
 import numpy as np
 import pytest
+import smart_open
 
 import sarkit.sidd as sksidd
 import sarkit.sidd._io
@@ -644,3 +645,9 @@ def test_version_info():
 
     for urn, info in sksidd.VERSION_INFO.items():
         assert lxml.etree.parse(info["schema"]).getroot().get("targetNamespace") == urn
+
+
+def test_remote_read():
+    with smart_open.open("https://www.govsco.com/content/spotlight.sidd", mode='rb') as file_object:
+        with sksidd.NitfReader(file_object) as r:
+            _ = r.read_image(0)

--- a/tests/core/test_iohelp.py
+++ b/tests/core/test_iohelp.py
@@ -1,0 +1,22 @@
+import numpy as np
+import pytest
+
+import sarkit._iohelp as skio
+
+
+@pytest.mark.parametrize("dtype", (np.dtype(np.float64), np.dtype(np.int64)))
+def test_compare_fromfile(tmp_path, dtype):
+    temp_file = tmp_path / "temp.bin"
+    num_items = 2.5 * skio.BUFFER_SIZE // dtype.itemsize
+    cube_root = int(num_items ** (1 / 3))
+    shape = (cube_root // 2, cube_root, 2 * cube_root)
+
+    rng = np.random.default_rng()
+    values = (rng.random(shape) * 1000).astype(dtype)
+    with open(temp_file, "wb") as f:
+        values.tofile(f)
+    with open(temp_file, "rb") as f:
+        np_arr = np.fromfile(f, dtype, np.prod(shape)).reshape(shape)
+    with open(temp_file, "rb") as f:
+        sk_arr = skio.fromfile(f, dtype, np.prod(shape)).reshape(shape)
+    assert np.array_equal(np_arr, sk_arr)


### PR DESCRIPTION
# Description

This branch attempts to address the issue raised in https://github.com/ValkyrieSystems/sarkit/issues/45

The primary impediment was `np.fromfile` and this branch removes it from the repo, replacing it with a stripped-down version that does not create a memmap.

Tests have been added to verify that web-hosted synthetic data can be read.

Closes #45