### PR TITLE
Use smart_open in CLI utililties

### DIFF
--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -465,6 +465,13 @@ When there are no inconsistencies, no output is produced.
    $ sicd-consistency good.sicd
    $
 
+Directly accessing URLs is supported if the `smart_open <https://github.com/piskvorky/smart_open>`_ package is installed.
+
+.. code-block:: shell-session
+
+   $ sicd-consistency https://www.example.com/good.sicd
+   $
+
 The same command can be used to run a subset of the checks against the XML.
 
 .. code-block:: shell-session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ module = [
     "lxml.*",
     "numba.*",
     "shapely.*",
+    "smart_open.*",
     "jbpy.*",
 ]
 ignore_missing_imports = true

--- a/sarkit/verification/_cphd_consistency.py
+++ b/sarkit/verification/_cphd_consistency.py
@@ -24,6 +24,11 @@ import sarkit.verification._consistency as con
 import sarkit.wgs84
 from sarkit import _constants
 
+try:
+    from smart_open import open
+except ImportError:
+    pass
+
 logger = logging.getLogger(__name__)
 
 
@@ -2041,9 +2046,7 @@ def _parser():
     parser = argparse.ArgumentParser(
         description="Analyze a CPHD and display inconsistencies"
     )
-    parser.add_argument(
-        "file_name", type=pathlib.Path, help="CPHD or CPHD XML to check"
-    )
+    parser.add_argument("file_name", help="CPHD or CPHD XML to check")
     parser.add_argument(
         "--schema",
         type=pathlib.Path,
@@ -2063,7 +2066,7 @@ def _parser():
 
 def main(args=None):
     config = _parser().parse_args(args)
-    with config.file_name.open("rb") as f:
+    with open(config.file_name, "rb") as f:
         cphd_con = CphdConsistency.from_file(
             file=f,
             schema=config.schema,

--- a/sarkit/verification/_crsd_consistency.py
+++ b/sarkit/verification/_crsd_consistency.py
@@ -19,6 +19,11 @@ import sarkit.crsd as skcrsd
 import sarkit.verification._consistency as con
 import sarkit.wgs84
 
+try:
+    from smart_open import open
+except ImportError:
+    pass
+
 logger = logging.getLogger(__name__)
 
 
@@ -2419,9 +2424,7 @@ def _parser():
     parser = argparse.ArgumentParser(
         description="Analyze a CRSD and display inconsistencies"
     )
-    parser.add_argument(
-        "file_name", type=pathlib.Path, help="CRSD or CRSD XML to check"
-    )
+    parser.add_argument("file_name", help="CRSD or CRSD XML to check")
     parser.add_argument(
         "--schema",
         type=pathlib.Path,
@@ -2441,7 +2444,7 @@ def _parser():
 
 def main(args=None):
     config = _parser().parse_args(args)
-    with config.file_name.open("rb") as f:
+    with open(config.file_name, "rb") as f:
         crsd_con = CrsdConsistency.from_file(
             file=f,
             schema=config.schema,

--- a/sarkit/verification/_sicd_consistency.py
+++ b/sarkit/verification/_sicd_consistency.py
@@ -24,6 +24,11 @@ import sarkit.verification._consistency as con
 import sarkit.wgs84
 from sarkit import _constants
 
+try:
+    from smart_open import open
+except ImportError:
+    pass
+
 logger = logging.getLogger(__name__)
 
 KAPFAC: float = 0.8859
@@ -1965,9 +1970,7 @@ def _parser():
     parser = argparse.ArgumentParser(
         description="Analyze a SICD and display inconsistencies"
     )
-    parser.add_argument(
-        "file_name", type=pathlib.Path, help="SICD or SICD XML to check"
-    )
+    parser.add_argument("file_name", help="SICD or SICD XML to check")
     parser.add_argument(
         "--schema",
         type=pathlib.Path,
@@ -1979,7 +1982,7 @@ def _parser():
 
 def main(args=None):
     config = _parser().parse_args(args)
-    with config.file_name.open("rb") as f:
+    with open(config.file_name, "rb") as f:
         sicd_con = SicdConsistency.from_file(
             file=f,
             schema=config.schema,

--- a/sarkit/verification/_sidd_consistency.py
+++ b/sarkit/verification/_sidd_consistency.py
@@ -18,6 +18,11 @@ import sarkit.sidd as sksidd
 import sarkit.verification._consistency as con
 from sarkit import wgs84
 
+try:
+    from smart_open import open
+except ImportError:
+    pass
+
 _PIXEL_INFO = {
     "MONO8I": {
         "IREP": "MONO",
@@ -1234,9 +1239,7 @@ def _parser():
     parser = argparse.ArgumentParser(
         description="Analyze a SIDD and display inconsistencies"
     )
-    parser.add_argument(
-        "file_name", type=pathlib.Path, help="SIDD or SIDD XML to check"
-    )
+    parser.add_argument("file_name", help="SIDD or SIDD XML to check")
     parser.add_argument(
         "--schema", type=pathlib.Path, help="Use a supplied schema file", default=None
     )
@@ -1247,7 +1250,7 @@ def _parser():
 def main(args=None):
     config = _parser().parse_args(args)
 
-    with config.file_name.open("rb") as file:
+    with open(config.file_name, "rb") as file:
         sidd_con = SiddConsistency.from_file(file, config.schema)
     return sidd_con.run_cli(config)
 

--- a/tests/verification/test_cphd_consistency.py
+++ b/tests/verification/test_cphd_consistency.py
@@ -1286,3 +1286,7 @@ def test_check_signal_block_packing(cphd_con):
     cphd_con.cphdroot.find("{*}Data/{*}Channel/{*}SignalArrayByteOffset").text += "1"
     cphd_con.check("check_signal_block_size_and_packing")
     testing.assert_failures(cphd_con, "SIGNAL array .+ starts at offset")
+
+
+def test_smart_open():
+    assert not main([r"https://www.govsco.com/content/spotlight.cphd", "--thorough"])

--- a/tests/verification/test_crsd_consistency.py
+++ b/tests/verification/test_crsd_consistency.py
@@ -2274,3 +2274,7 @@ def test_check_compressed_signal_block_size(example_crsdrcvcompressed_file):
     crsd_con.xmlhelp.set_elem(css, crsd_con.xmlhelp.load_elem(css) + 1)
     crsd_con.check("check_compressed_signal_block")
     assert_failures(crsd_con, "SIGNAL_BLOCK_SIZE is set equal to CompressedSignalSize")
+
+
+def test_smart_open():
+    assert not main([r"https://www.govsco.com/content/spotlight.crsd", "--thorough"])

--- a/tests/verification/test_sicd_consistency.py
+++ b/tests/verification/test_sicd_consistency.py
@@ -844,3 +844,7 @@ def test_check_error_components_posvel_corr(sicd_con, em):
     p1v1.text = "-1.1"
     sicd_con.check("check_error_components_posvel_corr")
     testing.assert_failures(sicd_con, "CorrCoefs P1V1 <= 1.0")
+
+
+def test_smart_open():
+    assert not main([r"https://www.govsco.com/content/spotlight.sicd"])

--- a/tests/verification/test_sidd_consistency.py
+++ b/tests/verification/test_sidd_consistency.py
@@ -343,3 +343,7 @@ def test_check_geodata_image_corners(example_sidd_file):
 def remove_nodes(*nodes):
     for node in nodes:
         node.getparent().remove(node)
+
+
+def test_smart_open():
+    assert not main([r"https://www.govsco.com/content/spotlight.sidd"])


### PR DESCRIPTION
This modifies the consistency checker CLIs to use `smart_open.open` if it is available.  

```
$ cphd-consistency http://umbra-open-data-catalog.s3.amazonaws.com/sar-data/tasks/3e56976b-fa2b-4035-bb71-385efde84c4a/2025-06-22-23-57-52_UMBRA-10/2025-06-22-23-57-52_UMBRA-10_CPHD.cphd
check_channel_fx_osr_Primary: FX domain vectors are sufficiently sampled for channel Primary.
    [Error] Need: FX_OSR is at least 1.1
    [Warning] Want: FX_OSR is at least 1.2
```