### PR TITLE
Bugfix: non-UTC XDT handling

### DIFF
--- a/data/syntax_only/sidd/0000-syntax-only-sidd-3.0.xml
+++ b/data/syntax_only/sidd/0000-syntax-only-sidd-3.0.xml
@@ -329,7 +329,7 @@
           <sicommon:ModeID>SyntheticModeID</sicommon:ModeID>
         </RadarMode>
         <CollectionDateTime>1969-07-20T20:17:40.000000Z</CollectionDateTime>
-        <LocalDateTime>1969-07-20T20:17:40.000000Z</LocalDateTime>
+        <LocalDateTime>1969-07-20T13:17:40.000000</LocalDateTime>
         <CollectionDuration>6.28318</CollectionDuration>
         <Resolution>
           <sicommon:Range>1.0</sicommon:Range>

--- a/data/syntax_only/sidd/0001-syntax-only-sidd-3.0.xml
+++ b/data/syntax_only/sidd/0001-syntax-only-sidd-3.0.xml
@@ -254,7 +254,7 @@
           <sicommon:ModeID>SyntheticModeID</sicommon:ModeID>
         </RadarMode>
         <CollectionDateTime>1969-07-20T20:17:40.000000Z</CollectionDateTime>
-        <LocalDateTime>1969-07-20T20:17:40.000000Z</LocalDateTime>
+        <LocalDateTime>1969-07-20T13:17:40.000000</LocalDateTime>
         <CollectionDuration>6.28318</CollectionDuration>
         <Resolution>
           <sicommon:Range>1.0</sicommon:Range>

--- a/data/syntax_only/sidd/0002-syntax-only-sidd-3.0.xml
+++ b/data/syntax_only/sidd/0002-syntax-only-sidd-3.0.xml
@@ -288,7 +288,7 @@
           <sicommon:ModeID>SyntheticModeID</sicommon:ModeID>
         </RadarMode>
         <CollectionDateTime>1969-07-20T20:17:40.000000Z</CollectionDateTime>
-        <LocalDateTime>1969-07-20T20:17:40.000000Z</LocalDateTime>
+        <LocalDateTime>1969-07-20T13:17:40.000000</LocalDateTime>
         <CollectionDuration>6.28318</CollectionDuration>
         <Resolution>
           <sicommon:Range>1.0</sicommon:Range>

--- a/sarkit/sicd/_xml.py
+++ b/sarkit/sicd/_xml.py
@@ -255,6 +255,8 @@ class XsdHelper(skxml.XsdHelper):
             "{urn:SICD:1.4.0}Matrix6x6Type": MtxType((6, 6)),
         }
         easy = sicd_110 | sicd_121 | sicd_130 | sicd_140
+        if tag is not None and lxml.etree.QName(tag).localname == "CalibrationDate":
+            return skxt.XdtType(force_utc=False)
         if typename.startswith("{http://www.w3.org/2001/XMLSchema}"):
             return known_builtins[typename]
         if typename in easy:

--- a/sarkit/sidd/_xml.py
+++ b/sarkit/sidd/_xml.py
@@ -472,6 +472,8 @@ class XsdHelper(skxml.XsdHelper):
             "<UNNAMED>-{urn:SIDD:3.0.0}ImageCornersType/{urn:SIDD:3.0.0}ICP"
         ]
 
+        if tag in ("{urn:SIDD:2.0.0}LocalDateTime", "{urn:SIDD:3.0.0}LocalDateTime"):
+            return skxt.XdtType(force_utc=False)
         if typename.startswith("{http://www.w3.org/2001/XMLSchema}"):
             return known_builtins[typename]
         if typename in easy:

--- a/tests/core/xmlhelp/test_transcoders.py
+++ b/tests/core/xmlhelp/test_transcoders.py
@@ -7,18 +7,30 @@ import pytest
 import sarkit.xmlhelp._transcoders as skxt
 
 
-def test_xdt_naive():
+@pytest.mark.parametrize("force_utc", (True, False))
+def test_xdt_naive(force_utc):
+    xdt_t = skxt.XdtType(force_utc=force_utc)
     dt = datetime.datetime.now()
-    elem = skxt.XdtType().make_elem("Xdt", dt)
-    assert skxt.XdtType().parse_elem(elem) == dt.replace(tzinfo=datetime.timezone.utc)
+    elem = xdt_t.make_elem("Xdt", dt)
+    if force_utc:
+        assert elem.text.endswith("Z")
+        assert xdt_t.parse_elem(elem) == dt.replace(tzinfo=datetime.timezone.utc)
+    else:
+        assert xdt_t.parse_elem(elem) == dt
 
 
-def test_xdt_aware():
+@pytest.mark.parametrize("force_utc", (True, False))
+def test_xdt_aware(force_utc):
+    xdt_t = skxt.XdtType(force_utc=force_utc)
     dt = datetime.datetime.now(
         tz=datetime.timezone(offset=datetime.timedelta(hours=5.5))
     )
-    elem = skxt.XdtType().make_elem("Xdt", dt)
-    assert skxt.XdtType().parse_elem(elem) == dt
+    elem = xdt_t.make_elem("Xdt", dt)
+    if force_utc:
+        assert elem.text.endswith("Z")
+        assert xdt_t.parse_elem(elem) == dt
+    else:
+        assert xdt_t.parse_elem(elem) == dt.replace(tzinfo=None)
 
 
 @pytest.mark.parametrize("ndim", (1, 2))


### PR DESCRIPTION
# Description
This PR addresses a bug where SARkit is coercing all XDT metadata items to UTC; even in the rare circumstances where this is not correct, e.g. SIDD 3.0.0's `ExploitationFeatures/Collection/Information/LocalDateTime`:

<img width="684" height="104" alt="image" src="https://github.com/user-attachments/assets/5deae388-77aa-47e5-b2c0-d18f85a040b0" />

This can be illustrated by running the following script:

<details><summary>tmp.py</summary>
<p>

```python
import datetime

import lxml.etree

import sarkit.sidd as sksidd

wrapped_sidd = sksidd.ElementWrapper(lxml.etree.Element("{urn:SIDD:3.0.0}SIDD"))
dt_local = datetime.datetime.now()
dt_utc = dt_local.astimezone(tz=datetime.UTC)

print(f"{dt_utc=}\n{dt_local=}\n\n")

wrapped_sidd["ExploitationFeatures"].add("Collection")["Information"] = {
    "CollectionDateTime": dt_utc,
    "LocalDateTime": dt_local,
}
lxml.etree.dump(wrapped_sidd.elem.find(".//{*}Information"))

```

</p>
</details> 

## Main
**Notice the trailing "Z" added to LocalDateTime**
```console
$ pdm run python tmp.py 
dt_utc=datetime.datetime(2025, 8, 11, 18, 8, 25, 945621, tzinfo=datetime.timezone.utc)
dt_local=datetime.datetime(2025, 8, 11, 11, 8, 25, 945621)


<ns0:Information xmlns:ns0="urn:SIDD:3.0.0">
  <ns0:CollectionDateTime>2025-08-11T18:08:25.945621Z</ns0:CollectionDateTime>
  <ns0:LocalDateTime>2025-08-11T11:08:25.945621Z</ns0:LocalDateTime>
</ns0:Information>
```

## This branch
```console
$ pdm run python tmp.py 
dt_utc=datetime.datetime(2025, 8, 11, 18, 7, 54, 468427, tzinfo=datetime.timezone.utc)
dt_local=datetime.datetime(2025, 8, 11, 11, 7, 54, 468427)


<ns0:Information xmlns:ns0="urn:SIDD:3.0.0">
  <ns0:CollectionDateTime>2025-08-11T18:07:54.468427Z</ns0:CollectionDateTime>
  <ns0:LocalDateTime>2025-08-11T11:07:54.468427</ns0:LocalDateTime>
</ns0:Information>
```

# Background
CPHD and CRSD both declare XDT to be UTC:

<details><summary>CPHD v1.1.0</summary>

<img width="670" height="282" alt="image" src="https://github.com/user-attachments/assets/6271baf7-7761-43f7-8db8-52cad4b13eac" />

</details>

<details><summary>CRSD v1.0</summary>

<img width="603" height="246" alt="image-1" src="https://github.com/user-attachments/assets/00f6c120-2ee4-4d8a-a372-5875f0c0abee" />

</details>

SICD and SIDD are unfortunately more wishy-washy:

<details><summary>SICD v1.4.0</summary>

<img width="592" height="328" alt="image" src="https://github.com/user-attachments/assets/5a79bdfd-2123-41ea-ba13-83dadd480ff8" />

</details>

<details><summary>SIDD v3.0.0</summary>

<img width="634" height="278" alt="image-1" src="https://github.com/user-attachments/assets/6661c982-40a9-4972-833b-2671f0cffbbe" />

</details>

Of SICD's three XDT-typed fields, only `CalibrationDate` is not defined as UTC:

<img width="629" height="45" alt="image" src="https://github.com/user-attachments/assets/0e30b397-781a-42a2-b412-42cb8c2917cb" />

Of SIDD's four XDT-typed fields, only `LocalDateTime` is not defined as UTC.