### PR TITLE
Renamed consistency checker CLIs

### DIFF
--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -446,44 +446,44 @@ SARkit provides checkers that can be used to identify inconsistencies in SAR sta
      - Command
    * - CRSD
      - :py:class:`sarkit.verification.CrsdConsistency`
-     - :ref:`crsd-consistency-cli`
+     - :ref:`crsdcheck-cli`
    * - CPHD
      - :py:class:`sarkit.verification.CphdConsistency`
-     - :ref:`cphd-consistency-cli`
+     - :ref:`cphdcheck-cli`
    * - SICD
      - :py:class:`sarkit.verification.SicdConsistency`
-     - :ref:`sicd-consistency-cli`
+     - :ref:`sicdcheck-cli`
    * - SIDD
      - :py:class:`sarkit.verification.SiddConsistency`
-     - :ref:`sidd-consistency-cli`
+     - :ref:`siddcheck-cli`
 
 Each consistency checker provides a command line interface for checking SAR data/metadata files.
 When there are no inconsistencies, no output is produced.
 
 .. code-block:: shell-session
 
-   $ sicd-consistency good.sicd
+   $ sicdcheck good.sicd
    $
 
 Directly accessing URLs is supported if the `smart_open <https://github.com/piskvorky/smart_open>`_ package is installed.
 
 .. code-block:: shell-session
 
-   $ sicd-consistency https://www.example.com/good.sicd
+   $ sicdcheck https://www.example.com/good.sicd
    $
 
 The same command can be used to run a subset of the checks against the XML.
 
 .. code-block:: shell-session
 
-   $ sicd-consistency good.sicd.xml
+   $ sicdcheck good.sicd.xml
    $
 
 When a file is inconsistent, failed checks are printed.
 
 .. code-block:: shell-session
 
-   $ sicd-consistency bad.sicd
+   $ sicdcheck bad.sicd
    check_image_formation_timeline: Checks that the slow time span for data processed to form
    the image is within collect.
       [Error] Need: 0 <= TStartProc < TEndProc <= CollectDuration
@@ -502,7 +502,7 @@ For example:
 
 .. code-block:: shell-session
 
-   $ sicd-consistency good.sicd -vvv
+   $ sicdcheck good.sicd -vvv
    check_against_schema: Checks against schema.
       [Pass] Need: XML passes schema
       [Pass] Need: Schema available for checking xml whose root tag = {urn:SICD:1.2.1}SICD
@@ -518,10 +518,10 @@ SARkit provides command line utilities for inspecting SAR standards files.
    * - Format
      - Command
    * - CRSD
-     - :ref:`crsd-info-cli`
+     - :ref:`crsdinfo-cli`
    * - CPHD
-     - :ref:`cphd-info-cli`
+     - :ref:`cphdinfo-cli`
    * - SICD
-     - :ref:`sicd-info-cli`
+     - :ref:`sicdinfo-cli`
    * - SIDD
-     - :ref:`sidd-info-cli`
+     - :ref:`siddinfo-cli`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,10 +64,10 @@ xsdtypes-generation = [
 ]
 
 [project.scripts]
-cphd-consistency = "sarkit.verification._cphd_consistency:main"
-crsd-consistency = "sarkit.verification._crsd_consistency:main"
-sicd-consistency = "sarkit.verification._sicd_consistency:main"
-sidd-consistency = "sarkit.verification._sidd_consistency:main"
+cphdcheck = "sarkit.verification._cphdcheck:main"
+crsdcheck = "sarkit.verification._crsdcheck:main"
+sicdcheck = "sarkit.verification._sicdcheck:main"
+siddcheck = "sarkit.verification._siddcheck:main"
 cphdinfo = "sarkit.cphd._cphdinfo:main"
 crsdinfo = "sarkit.crsd._crsdinfo:main"
 sicdinfo = "sarkit.sicd._sicdinfo:main"

--- a/sarkit/cphd/__init__.py
+++ b/sarkit/cphd/__init__.py
@@ -72,7 +72,7 @@ Constants
 CLI Utililties
 ==============
 
-.. _cphd-info-cli:
+.. _cphdinfo-cli:
 
 .. autoprogram:: sarkit.cphd._cphdinfo:_parser()
    :prog: cphdinfo

--- a/sarkit/cphd/__init__.py
+++ b/sarkit/cphd/__init__.py
@@ -77,8 +77,8 @@ Constants
    * - ``SECTION_TERMINATOR``
      - Two-byte sequence that marks the end of the file header
 
-CLI Utililties
-==============
+CLI Utilities
+=============
 
 .. _cphdinfo-cli:
 

--- a/sarkit/crsd/__init__.py
+++ b/sarkit/crsd/__init__.py
@@ -91,8 +91,8 @@ Constants
    * - ``SECTION_TERMINATOR``
      - Two-byte sequence that marks the end of the file header
 
-CLI Utililties
-==============
+CLI Utilities
+=============
 
 .. _crsdinfo-cli:
 

--- a/sarkit/crsd/__init__.py
+++ b/sarkit/crsd/__init__.py
@@ -94,7 +94,7 @@ Constants
 CLI Utililties
 ==============
 
-.. _crsd-info-cli:
+.. _crsdinfo-cli:
 
 .. autoprogram:: sarkit.crsd._crsdinfo:_parser()
    :prog: crsdinfo

--- a/sarkit/sicd/__init__.py
+++ b/sarkit/sicd/__init__.py
@@ -86,7 +86,7 @@ Constants
 CLI Utililties
 ==============
 
-.. _sicd-info-cli:
+.. _sicdinfo-cli:
 
 .. autoprogram:: sarkit.sicd._sicdinfo:_parser()
    :prog: sicdinfo

--- a/sarkit/sicd/__init__.py
+++ b/sarkit/sicd/__init__.py
@@ -87,8 +87,8 @@ Constants
    * - ``ILOC_MAX``
      - maximum number of rows contained in a segmented SICD NITF image segment (99,999)
 
-CLI Utililties
-==============
+CLI Utilities
+=============
 
 .. _sicdinfo-cli:
 

--- a/sarkit/sidd/__init__.py
+++ b/sarkit/sidd/__init__.py
@@ -99,8 +99,8 @@ Constants
    * - ``ILOC_MAX``
      - maximum number of rows contained in a NITF image segment (99,999)
 
-CLI Utililties
-==============
+CLI Utilities
+=============
 
 .. _siddinfo-cli:
 

--- a/sarkit/sidd/__init__.py
+++ b/sarkit/sidd/__init__.py
@@ -102,7 +102,7 @@ Constants
 CLI Utililties
 ==============
 
-.. _sidd-info-cli:
+.. _siddinfo-cli:
 
 .. autoprogram:: sarkit.sidd._siddinfo:_parser()
    :prog: siddinfo

--- a/sarkit/verification/__init__.py
+++ b/sarkit/verification/__init__.py
@@ -51,32 +51,32 @@ Each of the consistency checkers has a corresponding entry point:
 
 .. code-block:: shell-session
 
-   $ cphd-consistency /path/to/file
-   $ crsd-consistency /path/to/file
-   $ sicd-consistency /path/to/file
-   $ sidd-consistency /path/to/file
+   $ cphdcheck /path/to/file
+   $ crsdcheck /path/to/file
+   $ sicdcheck /path/to/file
+   $ siddcheck /path/to/file
 
 The command line flags for each are given below:
 
-.. _cphd-consistency-cli:
+.. _cphdcheck-cli:
 
-.. autoprogram:: sarkit.verification._cphd_consistency:_parser()
-   :prog: cphd-consistency
+.. autoprogram:: sarkit.verification._cphdcheck:_parser()
+   :prog: cphdcheck
 
-.. _crsd-consistency-cli:
+.. _crsdcheck-cli:
 
-.. autoprogram:: sarkit.verification._crsd_consistency:_parser()
-   :prog: crsd-consistency
+.. autoprogram:: sarkit.verification._crsdcheck:_parser()
+   :prog: crsdcheck
 
-.. _sicd-consistency-cli:
+.. _sicdcheck-cli:
 
-.. autoprogram:: sarkit.verification._sicd_consistency:_parser()
-   :prog: sicd-consistency
+.. autoprogram:: sarkit.verification._sicdcheck:_parser()
+   :prog: sicdcheck
 
-.. _sidd-consistency-cli:
+.. _siddcheck-cli:
 
-.. autoprogram:: sarkit.verification._sidd_consistency:_parser()
-   :prog: sidd-consistency
+.. autoprogram:: sarkit.verification._siddcheck:_parser()
+   :prog: siddcheck
 """
 
 from ._cphd_consistency import (

--- a/sarkit/verification/_cphd_consistency.py
+++ b/sarkit/verification/_cphd_consistency.py
@@ -2,14 +2,12 @@
 Functionality for verifying CPHD files for internal consistency.
 """
 
-import argparse
 import collections
 import functools
 import itertools
 import logging
 import numbers
 import os
-import pathlib
 import re
 import struct
 from typing import Any, Optional
@@ -23,11 +21,6 @@ import sarkit.cphd as skcphd
 import sarkit.verification._consistency as con
 import sarkit.wgs84
 from sarkit import _constants
-
-try:
-    from smart_open import open
-except ImportError:
-    pass
 
 logger = logging.getLogger(__name__)
 
@@ -1982,42 +1975,3 @@ def calc_refgeom_parameters(xml, xmlhelp, pvps):
     return collections.namedtuple("refgeom_params", "refgeom monostat bistat")(
         refgeom, mono, bistat
     )
-
-
-def _parser():
-    parser = argparse.ArgumentParser(
-        description="Analyze a CPHD and display inconsistencies"
-    )
-    parser.add_argument("file_name", help="CPHD or CPHD XML to check")
-    parser.add_argument(
-        "--schema",
-        type=pathlib.Path,
-        help="Use a supplied schema file (attempts version-specific schema if omitted)",
-    )
-    parser.add_argument(
-        "--thorough",
-        action="store_true",
-        help=(
-            "Run checks that may seek/read through large portions of the file. "
-            "Ignored when file_name is XML"
-        ),
-    )
-    CphdConsistency.add_cli_args(parser)
-    return parser
-
-
-def main(args=None):
-    config = _parser().parse_args(args)
-    with open(config.file_name, "rb") as f:
-        cphd_con = CphdConsistency.from_file(
-            file=f,
-            schema=config.schema,
-            thorough=config.thorough,
-        )
-        return cphd_con.run_cli(config)
-
-
-if __name__ == "__main__":  # pragma: no cover
-    import sys
-
-    sys.exit(int(main()))

--- a/sarkit/verification/_cphdcheck.py
+++ b/sarkit/verification/_cphdcheck.py
@@ -1,0 +1,48 @@
+import argparse
+import pathlib
+
+from sarkit.verification._cphd_consistency import CphdConsistency
+
+try:
+    from smart_open import open
+except ImportError:
+    pass
+
+
+def _parser():
+    parser = argparse.ArgumentParser(
+        description="Analyze a CPHD and display inconsistencies"
+    )
+    parser.add_argument("file_name", help="CPHD or CPHD XML to check")
+    parser.add_argument(
+        "--schema",
+        type=pathlib.Path,
+        help="Use a supplied schema file (attempts version-specific schema if omitted)",
+    )
+    parser.add_argument(
+        "--thorough",
+        action="store_true",
+        help=(
+            "Run checks that may seek/read through large portions of the file. "
+            "Ignored when file_name is XML"
+        ),
+    )
+    CphdConsistency.add_cli_args(parser)
+    return parser
+
+
+def main(args=None):
+    config = _parser().parse_args(args)
+    with open(config.file_name, "rb") as f:
+        cphd_con = CphdConsistency.from_file(
+            file=f,
+            schema=config.schema,
+            thorough=config.thorough,
+        )
+        return cphd_con.run_cli(config)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import sys
+
+    sys.exit(int(main()))

--- a/sarkit/verification/_crsd_consistency.py
+++ b/sarkit/verification/_crsd_consistency.py
@@ -2,11 +2,9 @@
 Functionality for verifying CRSD files for internal consistency.
 """
 
-import argparse
 import functools
 import logging
 import os
-import pathlib
 import re
 from typing import Any, Optional
 
@@ -18,11 +16,6 @@ from lxml import etree
 import sarkit.crsd as skcrsd
 import sarkit.verification._consistency as con
 import sarkit.wgs84
-
-try:
-    from smart_open import open
-except ImportError:
-    pass
 
 logger = logging.getLogger(__name__)
 
@@ -2418,42 +2411,3 @@ class CrsdConsistency(con.ConsistencyChecker):
                     assert self.xmlhelp.load_elem(xml_val_node) == con.Approx(
                         geom[key], atol=1e-6, rtol=0
                     )
-
-
-def _parser():
-    parser = argparse.ArgumentParser(
-        description="Analyze a CRSD and display inconsistencies"
-    )
-    parser.add_argument("file_name", help="CRSD or CRSD XML to check")
-    parser.add_argument(
-        "--schema",
-        type=pathlib.Path,
-        help="Use a supplied schema file (attempts version-specific schema if omitted)",
-    )
-    parser.add_argument(
-        "--thorough",
-        action="store_true",
-        help=(
-            "Run checks that may seek/read through large portions of the file. "
-            "Ignored when file_name is XML"
-        ),
-    )
-    CrsdConsistency.add_cli_args(parser)
-    return parser
-
-
-def main(args=None):
-    config = _parser().parse_args(args)
-    with open(config.file_name, "rb") as f:
-        crsd_con = CrsdConsistency.from_file(
-            file=f,
-            schema=config.schema,
-            thorough=config.thorough,
-        )
-        return crsd_con.run_cli(config)
-
-
-if __name__ == "__main__":  # pragma: no cover
-    import sys
-
-    sys.exit(int(main()))

--- a/sarkit/verification/_crsdcheck.py
+++ b/sarkit/verification/_crsdcheck.py
@@ -1,0 +1,48 @@
+import argparse
+import pathlib
+
+from sarkit.verification._crsd_consistency import CrsdConsistency
+
+try:
+    from smart_open import open
+except ImportError:
+    pass
+
+
+def _parser():
+    parser = argparse.ArgumentParser(
+        description="Analyze a CRSD and display inconsistencies"
+    )
+    parser.add_argument("file_name", help="CRSD or CRSD XML to check")
+    parser.add_argument(
+        "--schema",
+        type=pathlib.Path,
+        help="Use a supplied schema file (attempts version-specific schema if omitted)",
+    )
+    parser.add_argument(
+        "--thorough",
+        action="store_true",
+        help=(
+            "Run checks that may seek/read through large portions of the file. "
+            "Ignored when file_name is XML"
+        ),
+    )
+    CrsdConsistency.add_cli_args(parser)
+    return parser
+
+
+def main(args=None):
+    config = _parser().parse_args(args)
+    with open(config.file_name, "rb") as f:
+        crsd_con = CrsdConsistency.from_file(
+            file=f,
+            schema=config.schema,
+            thorough=config.thorough,
+        )
+        return crsd_con.run_cli(config)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import sys
+
+    sys.exit(int(main()))

--- a/sarkit/verification/_sicd_consistency.py
+++ b/sarkit/verification/_sicd_consistency.py
@@ -2,13 +2,11 @@
 Functionality for verifying SICD files for internal consistency.
 """
 
-import argparse
 import copy
 import datetime
 import functools
 import logging
 import os
-import pathlib
 from typing import Any, Optional
 
 import numpy as np
@@ -23,11 +21,6 @@ import sarkit.sicd.projection as sicdproj
 import sarkit.verification._consistency as con
 import sarkit.wgs84
 from sarkit import _constants
-
-try:
-    from smart_open import open
-except ImportError:
-    pass
 
 logger = logging.getLogger(__name__)
 
@@ -1964,34 +1957,3 @@ class SicdConsistency(con.ConsistencyChecker):
             with self.precondition():
                 assert poly_node is not None
                 self._assert_poly_2d(poly_node, poly)
-
-
-def _parser():
-    parser = argparse.ArgumentParser(
-        description="Analyze a SICD and display inconsistencies"
-    )
-    parser.add_argument("file_name", help="SICD or SICD XML to check")
-    parser.add_argument(
-        "--schema",
-        type=pathlib.Path,
-        help="Use a supplied schema file (attempts version-specific schema if omitted)",
-    )
-    SicdConsistency.add_cli_args(parser)
-    return parser
-
-
-def main(args=None):
-    config = _parser().parse_args(args)
-    with open(config.file_name, "rb") as f:
-        sicd_con = SicdConsistency.from_file(
-            file=f,
-            schema=config.schema,
-        )
-    # file doesn't need to stay open once object is instantiated
-    return sicd_con.run_cli(config)
-
-
-if __name__ == "__main__":  # pragma: no cover
-    import sys
-
-    sys.exit(int(main()))

--- a/sarkit/verification/_sicdcheck.py
+++ b/sarkit/verification/_sicdcheck.py
@@ -1,0 +1,40 @@
+import argparse
+import pathlib
+
+from sarkit.verification._sicd_consistency import SicdConsistency
+
+try:
+    from smart_open import open
+except ImportError:
+    pass
+
+
+def _parser():
+    parser = argparse.ArgumentParser(
+        description="Analyze a SICD and display inconsistencies"
+    )
+    parser.add_argument("file_name", help="SICD or SICD XML to check")
+    parser.add_argument(
+        "--schema",
+        type=pathlib.Path,
+        help="Use a supplied schema file (attempts version-specific schema if omitted)",
+    )
+    SicdConsistency.add_cli_args(parser)
+    return parser
+
+
+def main(args=None):
+    config = _parser().parse_args(args)
+    with open(config.file_name, "rb") as f:
+        sicd_con = SicdConsistency.from_file(
+            file=f,
+            schema=config.schema,
+        )
+    # file doesn't need to stay open once object is instantiated
+    return sicd_con.run_cli(config)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import sys
+
+    sys.exit(int(main()))

--- a/sarkit/verification/_sidd_consistency.py
+++ b/sarkit/verification/_sidd_consistency.py
@@ -1,9 +1,7 @@
-import argparse
 import datetime
 import functools
 import itertools
 import os
-import pathlib
 import pprint
 import re
 from typing import Any, Optional
@@ -17,11 +15,6 @@ import shapely.geometry as shg
 import sarkit.sidd as sksidd
 import sarkit.verification._consistency as con
 from sarkit import wgs84
-
-try:
-    from smart_open import open
-except ImportError:
-    pass
 
 _PIXEL_INFO = {
     "MONO8I": {
@@ -1233,29 +1226,3 @@ def calc_geodata_imagecorners(sidd_xml):
     r_corner = np.array([-0.5, -0.5, n_rows - 0.5, n_rows - 0.5])
     c_corner = np.array([-0.5, n_cols - 0.5, n_cols - 0.5, -0.5])
     return sensor_coord_to_ecef(*rc_to_sensor_coord(r_corner, c_corner))
-
-
-def _parser():
-    parser = argparse.ArgumentParser(
-        description="Analyze a SIDD and display inconsistencies"
-    )
-    parser.add_argument("file_name", help="SIDD or SIDD XML to check")
-    parser.add_argument(
-        "--schema", type=pathlib.Path, help="Use a supplied schema file", default=None
-    )
-    SiddConsistency.add_cli_args(parser)
-    return parser
-
-
-def main(args=None):
-    config = _parser().parse_args(args)
-
-    with open(config.file_name, "rb") as file:
-        sidd_con = SiddConsistency.from_file(file, config.schema)
-    return sidd_con.run_cli(config)
-
-
-if __name__ == "__main__":  # pragma: no cover
-    import sys
-
-    sys.exit(int(main()))

--- a/sarkit/verification/_siddcheck.py
+++ b/sarkit/verification/_siddcheck.py
@@ -1,0 +1,35 @@
+import argparse
+import pathlib
+
+from sarkit.verification._sidd_consistency import SiddConsistency
+
+try:
+    from smart_open import open
+except ImportError:
+    pass
+
+
+def _parser():
+    parser = argparse.ArgumentParser(
+        description="Analyze a SIDD and display inconsistencies"
+    )
+    parser.add_argument("file_name", help="SIDD or SIDD XML to check")
+    parser.add_argument(
+        "--schema", type=pathlib.Path, help="Use a supplied schema file", default=None
+    )
+    SiddConsistency.add_cli_args(parser)
+    return parser
+
+
+def main(args=None):
+    config = _parser().parse_args(args)
+
+    with open(config.file_name, "rb") as file:
+        sidd_con = SiddConsistency.from_file(file, config.schema)
+    return sidd_con.run_cli(config)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import sys
+
+    sys.exit(int(main()))

--- a/tests/verification/test_cli.py
+++ b/tests/verification/test_cli.py
@@ -3,8 +3,6 @@ import subprocess
 import pytest
 
 
-@pytest.mark.parametrize(
-    "cmd", ("cphd-consistency", "crsd-consistency", "sicd-consistency")
-)
+@pytest.mark.parametrize("cmd", ("cphdcheck", "crsdcheck", "sicdcheck", "siddcheck"))
 def test_consistency_cli(cmd):
     subprocess.run([cmd, "-h"], check=True)

--- a/tests/verification/test_cphd_consistency.py
+++ b/tests/verification/test_cphd_consistency.py
@@ -9,7 +9,8 @@ import shapely.geometry as shg
 from lxml import etree
 
 import sarkit.cphd as skcphd
-from sarkit.verification._cphd_consistency import CphdConsistency, main
+from sarkit.verification._cphd_consistency import CphdConsistency
+from sarkit.verification._cphdcheck import main
 
 from . import testing
 

--- a/tests/verification/test_crsd_consistency.py
+++ b/tests/verification/test_crsd_consistency.py
@@ -12,7 +12,8 @@ from lxml import etree
 
 import sarkit.crsd as skcrsd
 import sarkit.wgs84
-from sarkit.verification._crsd_consistency import CrsdConsistency, main
+from sarkit.verification._crsd_consistency import CrsdConsistency
+from sarkit.verification._crsdcheck import main
 
 from . import testing
 

--- a/tests/verification/test_sicd_consistency.py
+++ b/tests/verification/test_sicd_consistency.py
@@ -8,7 +8,8 @@ import pytest
 from lxml import etree
 
 import sarkit.sicd as sksicd
-from sarkit.verification._sicd_consistency import SicdConsistency, main
+from sarkit.verification._sicd_consistency import SicdConsistency
+from sarkit.verification._sicdcheck import main
 
 from . import testing
 

--- a/tests/verification/test_sidd_consistency.py
+++ b/tests/verification/test_sidd_consistency.py
@@ -6,7 +6,8 @@ import lxml.builder
 import pytest
 from lxml import etree
 
-from sarkit.verification._sidd_consistency import SiddConsistency, main
+from sarkit.verification._sidd_consistency import SiddConsistency
+from sarkit.verification._siddcheck import main
 
 DATAPATH = pathlib.Path(__file__).parents[2] / "data"
 


### PR DESCRIPTION
This renames the command line consistency checkers from `<format>-consistency` to `<format>check`.  This removes the hyphen and provides a shorter name to go along with the `<format>info` utilities.

