### PR TITLE
SICD sensitivity API tweaks in preparation for SICD v1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - CLIs renamed from `<>-consistency` to `<>check`
 - Rearranged CRSD reference geometry API
+- Rearranged SICD sensitivity/error propagation API
 
 ### Removed
 - Several incomplete / NotImplemented APIs

--- a/sarkit/sicd/projection/__init__.py
+++ b/sarkit/sicd/projection/__init__.py
@@ -23,7 +23,6 @@ dataclasses with attributes named as similar as feasible to the IPDD.
    ProjectionSetsBi
    ScenePointRRdotParams
    ScenePointGpXyParams
-   SensitivityMatrices
 
 Type Aliases
 ------------
@@ -100,7 +99,7 @@ Adjustable Parameters
 .. autosummary::
    :toctree: generated/
 
-   compute_and_apply_offsets
+   apply_apos
 
 Precise R/Rdot to Constant HAE Surface Projection
 =================================================
@@ -121,21 +120,18 @@ Precise R/Rdot to DEM Surface Projection
 
 Projection Sensitivity Parameters
 =================================
-.. autosummary::
-   :toctree: generated/
-
-   compute_sensitivity_matrices
+Coming soon...
 
 Projection Error Propagation
 ============================
 .. autosummary::
    :toctree: generated/
 
-   compute_ecef_pv_covariance
+   compute_ecef_pv_transformation
 """
 
 from ._calc import (
-    compute_and_apply_offsets,
+    apply_apos,
     compute_coa_pos_vel,
     compute_coa_r_rdot,
     compute_coa_time,
@@ -153,7 +149,7 @@ from ._calc import (
     scene_to_image,
 )
 from ._errorprop import (
-    compute_ecef_pv_covariance,
+    compute_ecef_pv_transformation,
     compute_ric_basis_vectors,
 )
 from ._params import (
@@ -168,10 +164,6 @@ from ._params import (
     ScenePointGpXyParams,
     ScenePointRRdotParams,
 )
-from ._sensitivity import (
-    SensitivityMatrices,
-    compute_sensitivity_matrices,
-)
 
 __all__ = [
     "AdjustableParameterOffsets",
@@ -184,19 +176,17 @@ __all__ = [
     "ProjectionSetsMono",
     "ScenePointGpXyParams",
     "ScenePointRRdotParams",
-    "SensitivityMatrices",
-    "compute_and_apply_offsets",
+    "apply_apos",
     "compute_coa_pos_vel",
     "compute_coa_r_rdot",
     "compute_coa_time",
-    "compute_ecef_pv_covariance",
+    "compute_ecef_pv_transformation",
     "compute_gp_xy_parameters",
     "compute_projection_sets",
     "compute_pt_r_rdot_parameters",
     "compute_ric_basis_vectors",
     "compute_scp_coa_r_rdot",
     "compute_scp_coa_slant_plane_normal",
-    "compute_sensitivity_matrices",
     "image_grid_to_image_plane_point",
     "image_plane_point_to_image_grid",
     "r_rdot_to_constant_hae_surface",

--- a/sarkit/sicd/projection/_calc.py
+++ b/sarkit/sicd/projection/_calc.py
@@ -524,7 +524,7 @@ def r_rdot_from_plane(
     )
 
 
-def compute_and_apply_offsets(
+def apply_apos(
     proj_metadata: params.MetadataParams,
     init_proj_set: params.ProjectionSetsLike,
     apo_input_set: params.AdjustableParameterOffsets,
@@ -1112,7 +1112,7 @@ def scene_to_image(
         )
 
         if adjust_param_offsets is not None:
-            projection_sets = compute_and_apply_offsets(
+            projection_sets = apply_apos(
                 proj_metadata, projection_sets, adjust_param_offsets
             )
 

--- a/sarkit/sicd/projection/_derived.py
+++ b/sarkit/sicd/projection/_derived.py
@@ -17,7 +17,7 @@ def _get_projsets(sicd_xmltree, image_grid_locations):
 
     if params.AdjustableParameterOffsets.exists(sicd_xmltree):
         adjust_param_offsets = params.AdjustableParameterOffsets.from_xml(sicd_xmltree)
-        projection_sets = calc.compute_and_apply_offsets(
+        projection_sets = calc.apply_apos(
             proj_metadata, projection_sets, adjust_param_offsets
         )
     return proj_metadata, projection_sets

--- a/sarkit/sicd/projection/_errorprop.py
+++ b/sarkit/sicd/projection/_errorprop.py
@@ -63,29 +63,25 @@ def _compute_rici_rotation_matrix(p_ecef, v_ecef):
     )
 
 
-def compute_ecef_pv_covariance(c_pv, p_ecef, v_ecef, frame):
-    """Transform the input position and velocity covariance matrix to ECEF coordinates.
+def compute_ecef_pv_transformation(p_ecef, v_ecef, frame):
+    """Return the transformation matrix from ``frame`` to ECEF.
 
     Parameters
     ----------
-    c_pv : (6, 6) array_like
-        Position and velocity covariance matrix in ``frame`` coordinates
     p_ecef, v_ecef : (3,) array_like
         Position and velocity in ECEF coordinates
     frame : {'ECF', 'RICF', 'RICI'}
-        Name of ``c_pv`` coordinate frame
+        Name of coordinate frame
 
     Returns
     -------
     (6, 6) ndarray
-        ``c_pv`` transformed into ECEF coordinates
+        transformation matrix from ``frame`` to ECEF
     """
     if frame == "ECF":
-        return np.asarray(c_pv)
+        return np.eye(6)
     if frame == "RICF":
-        t = _compute_ricf_rotation_matrix(p_ecef, v_ecef)
-        return t @ c_pv @ t.T
+        return _compute_ricf_rotation_matrix(p_ecef, v_ecef)
     if frame == "RICI":
-        t = _compute_rici_rotation_matrix(p_ecef, v_ecef)
-        return t @ c_pv @ t.T
+        return _compute_rici_rotation_matrix(p_ecef, v_ecef)
     raise ValueError(frame)

--- a/tests/core/sicd/test_errorprop.py
+++ b/tests/core/sicd/test_errorprop.py
@@ -11,12 +11,8 @@ def test_compute_ric_basis_vectors():
 
 
 @pytest.mark.parametrize("frame", ("ECF", "RICF", "RICI"))
-def test_compute_ecef_pv_covariance(frame):
-    a = np.random.default_rng().random((6, 6))
-    c_pv = a @ a.T
-    c_pv_ecef = sicdproj.compute_ecef_pv_covariance(c_pv, [1, 2, 3], [4, 5, 6], frame)
+def test_compute_ecef_pv_transformation(frame):
+    t = sicdproj.compute_ecef_pv_transformation([1, 2, 3], [4, 5, 6], frame)
     if frame != "RICI":
-        assert np.linalg.eigvalsh(c_pv) == pytest.approx(np.linalg.eigvalsh(c_pv_ecef))
-    pos_eigvals = np.linalg.eigvalsh(c_pv[:3, :3])
-    pos_ecef_eigvals = np.linalg.eigvalsh(c_pv_ecef[:3, :3])
-    assert pos_eigvals == pytest.approx(pos_ecef_eigvals)
+        assert t @ t.T == pytest.approx(np.eye(6))
+    assert t[:3, :3] @ t[:3, :3].T == pytest.approx(np.eye(3))

--- a/tests/core/sicd/test_projection.py
+++ b/tests/core/sicd/test_projection.py
@@ -3,12 +3,12 @@ import dataclasses
 import functools
 import pathlib
 
-import lxml.builder
 import lxml.etree
 import numpy as np
 import pytest
 
 import sarkit.sicd.projection as sicdproj
+import sarkit.sicd.projection._sensitivity
 import sarkit.wgs84
 
 DATAPATH = pathlib.Path(__file__).parents[3] / "data"
@@ -443,7 +443,7 @@ def test_apo_mono(example_proj_metadata):
         delta_tr_SCP_COA=11.0,
     )
     proj_set = sicdproj.compute_projection_sets(meta, [0, 0])
-    adjust_proj_set = sicdproj.compute_and_apply_offsets(meta, proj_set, apos)
+    adjust_proj_set = sicdproj.apply_apos(meta, proj_set, apos)
 
     # Make sure things that were supposed to change did
     assert adjust_proj_set.t_COA == proj_set.t_COA
@@ -467,7 +467,7 @@ def test_apo_bi(example_proj_metadata_bi):
         delta_tr_SCP_COA=21.0,
     )
     proj_set = sicdproj.compute_projection_sets(meta, [0, 0])
-    adjust_proj_set = sicdproj.compute_and_apply_offsets(meta, proj_set, apos)
+    adjust_proj_set = sicdproj.apply_apos(meta, proj_set, apos)
 
     # Make sure things that were supposed to change did
     assert adjust_proj_set.t_COA == proj_set.t_COA
@@ -482,7 +482,9 @@ def test_apo_bi(example_proj_metadata_bi):
 
 
 def test_sensitivity_matrices(example_proj_metadata):
-    mats = sicdproj.compute_sensitivity_matrices(example_proj_metadata)
+    mats = sarkit.sicd.projection._sensitivity.compute_sensitivity_matrices(
+        example_proj_metadata
+    )
 
     # sensitivity when image plane is already slant should be nearly -identity due to relative orientation of slant and
     # image plane vectors


### PR DESCRIPTION
# Description
This PR aims to smooth out some of the API differences between `main` and `integration/sicd-1.5`, such that merging `integration/sicd-1.5` into `main` in the future will not cause any compatibility-breaking changes.

- renaming `compute_and_apply_offsets` -> `apply_apos`
- refactor `compute_ecef_pv_covariance` -> `compute_ecef_pv_transformation`
- hide _sensitivity methods from public API (for now)