### PR TITLE
Bugfix: replace SICD v1.4.0 schema with 2024-05-01 version 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [1.0.1] - 2025-09-09
+
 ### Fixed
 - Use most recent SICD v1.4.0 XML schema (dated 2024-05-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Use most recent SICD v1.4.0 XML schema (dated 2024-05-01)
+
 
 ## [1.0.0] - 2025-09-04
 
@@ -48,18 +51,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.0] - 2025-07-16
 
-## Added
+### Added
 - ElementWrapper classes for interacting with SAR XML
 - Improved handling of Compressed CRSD
 - Support for using `smart_open` to open remote files
 
-# Fixed
+### Fixed
 - SICD consistency checker's SegmentList checks
 
 
 ## [0.9.0] - 2025-07-01
 
-## Changed
+### Changed
 - Replaced built in NITF parsing with `jbpy`
 
 
@@ -86,7 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for python 3.13
 - SICD segmentation check to consistency checker
 
-## Fixed
+### Fixed
 - Writing CPHDs without support arrays
 - SICD projection to a DEM surface not iterating enough
 

--- a/generate_xsdtypes.py
+++ b/generate_xsdtypes.py
@@ -76,12 +76,6 @@ def make_typedef(typeobj: xmlschema.XsdType):
 def main(args=None):
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "output_dir",
-        nargs="?",
-        type=pathlib.Path,
-        default=pathlib.Path(__file__).parent,
-    )
-    parser.add_argument(
         "--check",
         action="store_true",
         help="Don't write the files, just return the status. Return code 0 means nothing would change.",

--- a/sarkit/sicd/_constants.py
+++ b/sarkit/sicd/_constants.py
@@ -37,7 +37,7 @@ VERSION_INFO: Final[dict[str, VersionInfoType]] = {
     "urn:SICD:1.4.0": {
         "version": "1.4.0",
         "date": "2023-10-26T00:00:00Z",
-        "schema": SCHEMA_DIR / "SICD_schema_V1.4.0_2023_10_26.xsd",
+        "schema": SCHEMA_DIR / "SICD_schema_V1.4.0_2024_05_01.xsd",
     },
 }
 

--- a/sarkit/sicd/_xml.py
+++ b/sarkit/sicd/_xml.py
@@ -249,7 +249,7 @@ class XsdHelper(skxml.XsdHelper):
             "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}BistaticAdjustableParameterOffsets/{urn:SICD:1.4.0}APOError": MtxType(
                 (16, 16)
             ),
-            "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}BistaticComponents/{urn:SICD:1.4.0}RadarSensor/{urn:SICD:1.4.0}TxRcvTimeFreq": MtxType(
+            "<UNNAMED>-{urn:SICD:1.4.0}BistaticComponentsErrorType/{urn:SICD:1.4.0}RadarSensor/{urn:SICD:1.4.0}TxRcvTimeFreq": MtxType(
                 (4, 4)
             ),
             "{urn:SICD:1.4.0}Matrix6x6Type": MtxType((6, 6)),

--- a/sarkit/sicd/schemas/SICD_schema_V1.4.0_2024_05_01.xsd
+++ b/sarkit/sicd/schemas/SICD_schema_V1.4.0_2024_05_01.xsd
@@ -943,6 +943,126 @@
       </xs:sequence>
    </xs:complexType>
 
+   <xs:complexType name="ComponentsErrorType">
+      <xs:sequence>
+         <xs:element name="PosVelErr">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="Frame" type="FrameType"/>
+                  <xs:element name="P1" type="NonNegativeDoubleType"/>
+                  <xs:element name="P2" type="NonNegativeDoubleType"/>
+                  <xs:element name="P3" type="NonNegativeDoubleType"/>
+                  <xs:element name="V1" type="NonNegativeDoubleType"/>
+                  <xs:element name="V2" type="NonNegativeDoubleType"/>
+                  <xs:element name="V3" type="NonNegativeDoubleType"/>
+                  <xs:element name="CorrCoefs" minOccurs="0">
+                     <xs:complexType>
+                        <xs:sequence>
+                           <xs:element name="P1P2" type="NegOneToOneType"/>
+                           <xs:element name="P1P3" type="NegOneToOneType"/>
+                           <xs:element name="P1V1" type="NegOneToOneType"/>
+                           <xs:element name="P1V2" type="NegOneToOneType"/>
+                           <xs:element name="P1V3" type="NegOneToOneType"/>
+                           <xs:element name="P2P3" type="NegOneToOneType"/>
+                           <xs:element name="P2V1" type="NegOneToOneType"/>
+                           <xs:element name="P2V2" type="NegOneToOneType"/>
+                           <xs:element name="P2V3" type="NegOneToOneType"/>
+                           <xs:element name="P3V1" type="NegOneToOneType"/>
+                           <xs:element name="P3V2" type="NegOneToOneType"/>
+                           <xs:element name="P3V3" type="NegOneToOneType"/>
+                           <xs:element name="V1V2" type="NegOneToOneType"/>
+                           <xs:element name="V1V3" type="NegOneToOneType"/>
+                           <xs:element name="V2V3" type="NegOneToOneType"/>
+                        </xs:sequence>
+                     </xs:complexType>
+                  </xs:element>
+                  <xs:element name="PositionDecorr" type="ErrorDecorrFuncType" minOccurs="0"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="RadarSensor">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="RangeBias" type="NonNegativeDoubleType"/>
+                  <xs:element name="ClockFreqSF" type="NonNegativeDoubleType" minOccurs="0"/>
+                  <xs:element name="TransmitFreqSF" type="NonNegativeDoubleType" minOccurs="0"/>
+                  <xs:element name="RangeBiasDecorr" type="ErrorDecorrFuncType" minOccurs="0"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="TropoError" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="TropoRangeVertical" type="NonNegativeDoubleType" minOccurs="0"/>
+                  <xs:element name="TropoRangeSlant" type="NonNegativeDoubleType" minOccurs="0"/>
+                  <xs:element name="TropoRangeDecorr" type="ErrorDecorrFuncType" minOccurs="0"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="IonoError" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="IonoRangeVertical" type="NonNegativeDoubleType" minOccurs="0"/>
+                  <xs:element name="IonoRangeRateVertical" type="NonNegativeDoubleType" minOccurs="0"/>
+                  <xs:element name="IonoRgRgRateCC" type="NegOneToOneType"/>
+                  <xs:element name="IonoRangeVertDecorr" type="ErrorDecorrFuncType" minOccurs="0"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="BistaticComponentsErrorType">
+      <xs:sequence>
+         <xs:element name="PosVelErr">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="TxFrame" type="FrameType"/>
+                  <xs:element name="TxPVCov" type="Matrix6x6Type"/>
+                  <xs:element name="RcvFrame" type="FrameType"/>
+                  <xs:element name="RcvPVCov" type="Matrix6x6Type"/>
+                  <xs:element name="TxRcvPVXCov" type="Matrix6x6Type"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="RadarSensor">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="TxRcvTimeFreq">
+                     <xs:complexType>
+                        <xs:complexContent>
+                           <xs:extension base="Matrix2DType">
+                              <xs:attribute name="size1" type="xs:int" fixed="4" use="required"/>
+                              <xs:attribute name="size2" type="xs:int" fixed="4" use="required"/>
+                           </xs:extension>
+                        </xs:complexContent>
+                     </xs:complexType>
+                  </xs:element>
+                  <xs:element name="TxRcvTimeFreqDecorr" minOccurs="0">
+                     <xs:complexType>
+                        <xs:sequence>
+                           <xs:element name="TxTimeDecorr" type="ErrorDecorrFuncType"/>
+                           <xs:element name="TxClockFreqDecorr" type="ErrorDecorrFuncType"/>
+                           <xs:element name="RcvTimeDecorr" type="ErrorDecorrFuncType"/>
+                           <xs:element name="RcvClockFreqDecorr" type="ErrorDecorrFuncType"/>
+                        </xs:sequence>
+                     </xs:complexType>
+                  </xs:element>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="AtmosphericError">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="TxSCP" type="NonNegativeDoubleType"/>
+                  <xs:element name="RcvSCP" type="NonNegativeDoubleType"/>
+                  <xs:element name="TxRcvCC" type="NegOneToOneType"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+
    <xs:simpleType name="FrameType">
       <xs:restriction base="xs:string">
          <xs:enumeration value="ECF"/>
@@ -951,6 +1071,22 @@
       </xs:restriction>
    </xs:simpleType>
 
+   <xs:complexType name="UnmodeledType">
+      <xs:sequence>
+         <xs:element name="Xrow" type="NonNegativeDoubleType"/>
+         <xs:element name="Ycol" type="NonNegativeDoubleType"/>
+         <xs:element name="XrowYcol" type="NegOneToOneType"/>
+         <xs:element name="UnmodeledDecorr" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="Xrow" type="ErrorDecorrFuncType"/>
+                  <xs:element name="Ycol" type="ErrorDecorrFuncType"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+
    <xs:complexType name="BistaticAdjustableParametersType">
       <xs:sequence>
          <xs:element name="APCPosSCPCOA" type="XYZType"/>
@@ -958,155 +1094,26 @@
          <xs:element name="TimeSCPCOA" type="xs:double"/>
          <xs:element name="ClockFreqSF" type="xs:double"/>
       </xs:sequence>
-  </xs:complexType>
+   </xs:complexType>
 
    <xs:complexType name="ErrorStatisticsType">
       <xs:sequence>
-         <xs:choice minOccurs="0">
-            <xs:element name="CompositeSCP" type="CompositeErrorType"/>
-            <xs:element name="BistaticCompositeSCP" type="BistaticCompositeErrorType"/>
-        </xs:choice>
-         <xs:choice minOccurs="0">
-            <xs:element name="Components">
-               <xs:complexType>
-                  <xs:sequence>
-                     <xs:element name="PosVelErr">
-                        <xs:complexType>
-                           <xs:sequence>
-                              <xs:element name="Frame" type="FrameType"/>
-                              <xs:element name="P1" type="NonNegativeDoubleType"/>
-                              <xs:element name="P2" type="NonNegativeDoubleType"/>
-                              <xs:element name="P3" type="NonNegativeDoubleType"/>
-                              <xs:element name="V1" type="NonNegativeDoubleType"/>
-                              <xs:element name="V2" type="NonNegativeDoubleType"/>
-                              <xs:element name="V3" type="NonNegativeDoubleType"/>
-                              <xs:element name="CorrCoefs" minOccurs="0">
-                                 <xs:complexType>
-                                    <xs:sequence>
-                                       <xs:element name="P1P2" type="NegOneToOneType"/>
-                                       <xs:element name="P1P3" type="NegOneToOneType"/>
-                                       <xs:element name="P1V1" type="NegOneToOneType"/>
-                                       <xs:element name="P1V2" type="NegOneToOneType"/>
-                                       <xs:element name="P1V3" type="NegOneToOneType"/>
-                                       <xs:element name="P2P3" type="NegOneToOneType"/>
-                                       <xs:element name="P2V1" type="NegOneToOneType"/>
-                                       <xs:element name="P2V2" type="NegOneToOneType"/>
-                                       <xs:element name="P2V3" type="NegOneToOneType"/>
-                                       <xs:element name="P3V1" type="NegOneToOneType"/>
-                                       <xs:element name="P3V2" type="NegOneToOneType"/>
-                                       <xs:element name="P3V3" type="NegOneToOneType"/>
-                                       <xs:element name="V1V2" type="NegOneToOneType"/>
-                                       <xs:element name="V1V3" type="NegOneToOneType"/>
-                                       <xs:element name="V2V3" type="NegOneToOneType"/>
-                                    </xs:sequence>
-                                 </xs:complexType>
-                              </xs:element>
-                              <xs:element name="PositionDecorr" type="ErrorDecorrFuncType" minOccurs="0"/>
-                           </xs:sequence>
-                        </xs:complexType>
-                     </xs:element>
-                     <xs:element name="RadarSensor">
-                        <xs:complexType>
-                           <xs:sequence>
-                              <xs:element name="RangeBias" type="NonNegativeDoubleType"/>
-                              <xs:element name="ClockFreqSF" type="NonNegativeDoubleType" minOccurs="0"/>
-                              <xs:element name="TransmitFreqSF" type="NonNegativeDoubleType" minOccurs="0"/>
-                              <xs:element name="RangeBiasDecorr" type="ErrorDecorrFuncType" minOccurs="0"/>
-                           </xs:sequence>
-                        </xs:complexType>
-                     </xs:element>
-                     <xs:element name="TropoError" minOccurs="0">
-                        <xs:complexType>
-                           <xs:sequence>
-                              <xs:element name="TropoRangeVertical" type="NonNegativeDoubleType" minOccurs="0"/>
-                              <xs:element name="TropoRangeSlant" type="NonNegativeDoubleType" minOccurs="0"/>
-                              <xs:element name="TropoRangeDecorr" type="ErrorDecorrFuncType" minOccurs="0"/>
-                           </xs:sequence>
-                        </xs:complexType>
-                     </xs:element>
-                     <xs:element name="IonoError" minOccurs="0">
-                        <xs:complexType>
-                           <xs:sequence>
-                              <xs:element name="IonoRangeVertical" type="NonNegativeDoubleType" minOccurs="0"/>
-                              <xs:element name="IonoRangeRateVertical" type="NonNegativeDoubleType" minOccurs="0"/>
-                              <xs:element name="IonoRgRgRateCC" type="NegOneToOneType"/>
-                              <xs:element name="IonoRangeVertDecorr" type="ErrorDecorrFuncType" minOccurs="0"/>
-                           </xs:sequence>
-                        </xs:complexType>
-                     </xs:element>
-                  </xs:sequence>
-               </xs:complexType>
-            </xs:element>
-            <xs:element name="BistaticComponents">
-               <xs:complexType>
-                  <xs:sequence>
-                     <xs:element name="PosVelErr">
-                        <xs:complexType>
-                           <xs:sequence>
-                              <xs:element name="TxFrame" type="FrameType"/>
-                              <xs:element name="TxPVCov" type="Matrix6x6Type"/>
-                              <xs:element name="RcvFrame" type="FrameType"/>
-                              <xs:element name="RcvPVCov" type="Matrix6x6Type"/>
-                              <xs:element name="TxRcvPVXCov" type="Matrix6x6Type"/>
-                           </xs:sequence>
-                        </xs:complexType>
-                     </xs:element>
-                     <xs:element name="RadarSensor">
-                        <xs:complexType>
-                           <xs:sequence>
-                              <xs:element name="TxRcvTimeFreq">
-                                 <xs:complexType>
-                                    <xs:complexContent>
-                                       <xs:extension base="Matrix2DType">
-                                          <xs:attribute name="size1" type="xs:int" fixed="4" use="required"/>
-                                          <xs:attribute name="size2" type="xs:int" fixed="4" use="required"/>
-                                       </xs:extension>
-                                    </xs:complexContent>
-                                 </xs:complexType>
-                              </xs:element>
-                              <xs:element name="TxRcvTimeFreqDecorr" minOccurs="0">
-                                 <xs:complexType>
-                                    <xs:sequence>
-                                       <xs:element name="TxTimeDecorr" type="ErrorDecorrFuncType"/>
-                                       <xs:element name="TxClockFreqDecorr" type="ErrorDecorrFuncType"/>
-                                       <xs:element name="RcvTimeDecorr" type="ErrorDecorrFuncType"/>
-                                       <xs:element name="RcvClockFreqDecorr" type="ErrorDecorrFuncType"/>
-                                    </xs:sequence>
-                                 </xs:complexType>
-                              </xs:element>
-                           </xs:sequence>
-                        </xs:complexType>
-                     </xs:element>
-                     <xs:element name="AtmosphericError">
-                        <xs:complexType>
-                           <xs:sequence>
-                              <xs:element name="TxSCP" type="NonNegativeDoubleType"/>
-                              <xs:element name="RcvSCP" type="NonNegativeDoubleType"/>
-                              <xs:element name="TxRcvCC" type="NegOneToOneType"/>
-                           </xs:sequence>
-                        </xs:complexType>
-                     </xs:element>
-                  </xs:sequence>
-               </xs:complexType>
-            </xs:element>
-         </xs:choice>
-         <xs:element name="Unmodeled" minOccurs="0">
-            <xs:complexType>
-               <xs:sequence>
-                  <xs:element name="Xrow" type="NonNegativeDoubleType"/>
-                  <xs:element name="Ycol" type="NonNegativeDoubleType"/>
-                  <xs:element name="XrowYcol" type="NegOneToOneType"/>
-                  <xs:element name="UnmodeledDecorr" minOccurs="0">
-                     <xs:complexType>
-                        <xs:sequence>
-                           <xs:element name="Xrow" type="ErrorDecorrFuncType"/>
-                           <xs:element name="Ycol" type="ErrorDecorrFuncType"/>
-                        </xs:sequence>
-                     </xs:complexType>
-                  </xs:element>
+         <xs:choice minOccurs="0">  <!-- This choice must be consistent with the following choice -->
+            <xs:sequence>
+               <xs:element name="CompositeSCP" type="CompositeErrorType" minOccurs="0"/>
+               <xs:sequence minOccurs="0">
+                  <xs:element name="Components" type="ComponentsErrorType"/>
+                  <xs:element name="Unmodeled" type="UnmodeledType" minOccurs="0"/>
                </xs:sequence>
-            </xs:complexType>
-         </xs:element>
+            </xs:sequence>
+            <xs:sequence>
+               <xs:element name="BistaticCompositeSCP" type="BistaticCompositeErrorType" minOccurs="0"/>
+               <xs:sequence minOccurs="0">
+                  <xs:element name="BistaticComponents" type="BistaticComponentsErrorType"/>
+                  <xs:element name="Unmodeled" type="UnmodeledType" minOccurs="0"/>
+               </xs:sequence>
+            </xs:sequence>
+         </xs:choice>
          <xs:element name="AdditionalParms" minOccurs="0">
             <xs:complexType>
                <xs:sequence>
@@ -1114,7 +1121,7 @@
                </xs:sequence>
             </xs:complexType>
          </xs:element>
-         <xs:choice>
+         <xs:choice minOccurs="0">  <!-- This choice must be consistent with the previous choice -->
             <xs:element name="AdjustableParameterOffsets">
                <xs:complexType>
                   <xs:sequence>

--- a/sarkit/sicd/xsdtypes/SICD_schema_V1.4.0_2024_05_01.json
+++ b/sarkit/sicd/xsdtypes/SICD_schema_V1.4.0_2024_05_01.json
@@ -18,6 +18,114 @@
     ],
     "text_typename": null
   },
+  "<UNNAMED>-{urn:SICD:1.4.0}BistaticComponentsErrorType/{urn:SICD:1.4.0}AtmosphericError": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}TxSCP",
+        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}RcvSCP",
+        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}TxRcvCC",
+        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.4.0}BistaticComponentsErrorType/{urn:SICD:1.4.0}PosVelErr": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}TxFrame",
+        "typename": "{urn:SICD:1.4.0}FrameType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}TxPVCov",
+        "typename": "{urn:SICD:1.4.0}Matrix6x6Type"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}RcvFrame",
+        "typename": "{urn:SICD:1.4.0}FrameType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}RcvPVCov",
+        "typename": "{urn:SICD:1.4.0}Matrix6x6Type"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}TxRcvPVXCov",
+        "typename": "{urn:SICD:1.4.0}Matrix6x6Type"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.4.0}BistaticComponentsErrorType/{urn:SICD:1.4.0}RadarSensor": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}TxRcvTimeFreq",
+        "typename": "<UNNAMED>-{urn:SICD:1.4.0}BistaticComponentsErrorType/{urn:SICD:1.4.0}RadarSensor/{urn:SICD:1.4.0}TxRcvTimeFreq"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}TxRcvTimeFreqDecorr",
+        "typename": "<UNNAMED>-{urn:SICD:1.4.0}BistaticComponentsErrorType/{urn:SICD:1.4.0}RadarSensor/{urn:SICD:1.4.0}TxRcvTimeFreqDecorr"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.4.0}BistaticComponentsErrorType/{urn:SICD:1.4.0}RadarSensor/{urn:SICD:1.4.0}TxRcvTimeFreq": {
+    "attributes": [
+      "size1",
+      "size2"
+    ],
+    "children": [
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.4.0}Entry",
+        "typename": "{urn:SICD:1.4.0}MatrixEntry2DType"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.4.0}BistaticComponentsErrorType/{urn:SICD:1.4.0}RadarSensor/{urn:SICD:1.4.0}TxRcvTimeFreqDecorr": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}TxTimeDecorr",
+        "typename": "{urn:SICD:1.4.0}ErrorDecorrFuncType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}TxClockFreqDecorr",
+        "typename": "{urn:SICD:1.4.0}ErrorDecorrFuncType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}RcvTimeDecorr",
+        "typename": "{urn:SICD:1.4.0}ErrorDecorrFuncType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}RcvClockFreqDecorr",
+        "typename": "{urn:SICD:1.4.0}ErrorDecorrFuncType"
+      }
+    ],
+    "text_typename": null
+  },
   "<UNNAMED>-{urn:SICD:1.4.0}CollectionInfoType/{urn:SICD:1.4.0}CollectType": {
     "attributes": [],
     "children": [],
@@ -43,6 +151,211 @@
     "attributes": [],
     "children": [],
     "text_typename": "{http://www.w3.org/2001/XMLSchema}string"
+  },
+  "<UNNAMED>-{urn:SICD:1.4.0}ComponentsErrorType/{urn:SICD:1.4.0}IonoError": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}IonoRangeVertical",
+        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}IonoRangeRateVertical",
+        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}IonoRgRgRateCC",
+        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}IonoRangeVertDecorr",
+        "typename": "{urn:SICD:1.4.0}ErrorDecorrFuncType"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.4.0}ComponentsErrorType/{urn:SICD:1.4.0}PosVelErr": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}Frame",
+        "typename": "{urn:SICD:1.4.0}FrameType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}P1",
+        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}P2",
+        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}P3",
+        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}V1",
+        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}V2",
+        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}V3",
+        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}CorrCoefs",
+        "typename": "<UNNAMED>-{urn:SICD:1.4.0}ComponentsErrorType/{urn:SICD:1.4.0}PosVelErr/{urn:SICD:1.4.0}CorrCoefs"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}PositionDecorr",
+        "typename": "{urn:SICD:1.4.0}ErrorDecorrFuncType"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.4.0}ComponentsErrorType/{urn:SICD:1.4.0}PosVelErr/{urn:SICD:1.4.0}CorrCoefs": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}P1P2",
+        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}P1P3",
+        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}P1V1",
+        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}P1V2",
+        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}P1V3",
+        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}P2P3",
+        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}P2V1",
+        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}P2V2",
+        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}P2V3",
+        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}P3V1",
+        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}P3V2",
+        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}P3V3",
+        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}V1V2",
+        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}V1V3",
+        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}V2V3",
+        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.4.0}ComponentsErrorType/{urn:SICD:1.4.0}RadarSensor": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}RangeBias",
+        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}ClockFreqSF",
+        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}TransmitFreqSF",
+        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}RangeBiasDecorr",
+        "typename": "{urn:SICD:1.4.0}ErrorDecorrFuncType"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.4.0}ComponentsErrorType/{urn:SICD:1.4.0}TropoError": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}TropoRangeVertical",
+        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}TropoRangeSlant",
+        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}TropoRangeDecorr",
+        "typename": "{urn:SICD:1.4.0}ErrorDecorrFuncType"
+      }
+    ],
+    "text_typename": null
   },
   "<UNNAMED>-{urn:SICD:1.4.0}DirParamType/{urn:SICD:1.4.0}Sgn": {
     "attributes": [],
@@ -182,408 +495,6 @@
         "repeat": true,
         "tag": "{urn:SICD:1.4.0}Entry",
         "typename": "{urn:SICD:1.4.0}MatrixEntry2DType"
-      }
-    ],
-    "text_typename": null
-  },
-  "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}BistaticComponents": {
-    "attributes": [],
-    "children": [
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}PosVelErr",
-        "typename": "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}BistaticComponents/{urn:SICD:1.4.0}PosVelErr"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}RadarSensor",
-        "typename": "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}BistaticComponents/{urn:SICD:1.4.0}RadarSensor"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}AtmosphericError",
-        "typename": "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}BistaticComponents/{urn:SICD:1.4.0}AtmosphericError"
-      }
-    ],
-    "text_typename": null
-  },
-  "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}BistaticComponents/{urn:SICD:1.4.0}AtmosphericError": {
-    "attributes": [],
-    "children": [
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}TxSCP",
-        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}RcvSCP",
-        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}TxRcvCC",
-        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
-      }
-    ],
-    "text_typename": null
-  },
-  "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}BistaticComponents/{urn:SICD:1.4.0}PosVelErr": {
-    "attributes": [],
-    "children": [
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}TxFrame",
-        "typename": "{urn:SICD:1.4.0}FrameType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}TxPVCov",
-        "typename": "{urn:SICD:1.4.0}Matrix6x6Type"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}RcvFrame",
-        "typename": "{urn:SICD:1.4.0}FrameType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}RcvPVCov",
-        "typename": "{urn:SICD:1.4.0}Matrix6x6Type"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}TxRcvPVXCov",
-        "typename": "{urn:SICD:1.4.0}Matrix6x6Type"
-      }
-    ],
-    "text_typename": null
-  },
-  "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}BistaticComponents/{urn:SICD:1.4.0}RadarSensor": {
-    "attributes": [],
-    "children": [
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}TxRcvTimeFreq",
-        "typename": "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}BistaticComponents/{urn:SICD:1.4.0}RadarSensor/{urn:SICD:1.4.0}TxRcvTimeFreq"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}TxRcvTimeFreqDecorr",
-        "typename": "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}BistaticComponents/{urn:SICD:1.4.0}RadarSensor/{urn:SICD:1.4.0}TxRcvTimeFreqDecorr"
-      }
-    ],
-    "text_typename": null
-  },
-  "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}BistaticComponents/{urn:SICD:1.4.0}RadarSensor/{urn:SICD:1.4.0}TxRcvTimeFreq": {
-    "attributes": [
-      "size1",
-      "size2"
-    ],
-    "children": [
-      {
-        "repeat": true,
-        "tag": "{urn:SICD:1.4.0}Entry",
-        "typename": "{urn:SICD:1.4.0}MatrixEntry2DType"
-      }
-    ],
-    "text_typename": null
-  },
-  "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}BistaticComponents/{urn:SICD:1.4.0}RadarSensor/{urn:SICD:1.4.0}TxRcvTimeFreqDecorr": {
-    "attributes": [],
-    "children": [
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}TxTimeDecorr",
-        "typename": "{urn:SICD:1.4.0}ErrorDecorrFuncType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}TxClockFreqDecorr",
-        "typename": "{urn:SICD:1.4.0}ErrorDecorrFuncType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}RcvTimeDecorr",
-        "typename": "{urn:SICD:1.4.0}ErrorDecorrFuncType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}RcvClockFreqDecorr",
-        "typename": "{urn:SICD:1.4.0}ErrorDecorrFuncType"
-      }
-    ],
-    "text_typename": null
-  },
-  "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}Components": {
-    "attributes": [],
-    "children": [
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}PosVelErr",
-        "typename": "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}Components/{urn:SICD:1.4.0}PosVelErr"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}RadarSensor",
-        "typename": "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}Components/{urn:SICD:1.4.0}RadarSensor"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}TropoError",
-        "typename": "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}Components/{urn:SICD:1.4.0}TropoError"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}IonoError",
-        "typename": "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}Components/{urn:SICD:1.4.0}IonoError"
-      }
-    ],
-    "text_typename": null
-  },
-  "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}Components/{urn:SICD:1.4.0}IonoError": {
-    "attributes": [],
-    "children": [
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}IonoRangeVertical",
-        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}IonoRangeRateVertical",
-        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}IonoRgRgRateCC",
-        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}IonoRangeVertDecorr",
-        "typename": "{urn:SICD:1.4.0}ErrorDecorrFuncType"
-      }
-    ],
-    "text_typename": null
-  },
-  "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}Components/{urn:SICD:1.4.0}PosVelErr": {
-    "attributes": [],
-    "children": [
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}Frame",
-        "typename": "{urn:SICD:1.4.0}FrameType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}P1",
-        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}P2",
-        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}P3",
-        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}V1",
-        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}V2",
-        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}V3",
-        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}CorrCoefs",
-        "typename": "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}Components/{urn:SICD:1.4.0}PosVelErr/{urn:SICD:1.4.0}CorrCoefs"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}PositionDecorr",
-        "typename": "{urn:SICD:1.4.0}ErrorDecorrFuncType"
-      }
-    ],
-    "text_typename": null
-  },
-  "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}Components/{urn:SICD:1.4.0}PosVelErr/{urn:SICD:1.4.0}CorrCoefs": {
-    "attributes": [],
-    "children": [
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}P1P2",
-        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}P1P3",
-        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}P1V1",
-        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}P1V2",
-        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}P1V3",
-        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}P2P3",
-        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}P2V1",
-        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}P2V2",
-        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}P2V3",
-        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}P3V1",
-        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}P3V2",
-        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}P3V3",
-        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}V1V2",
-        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}V1V3",
-        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}V2V3",
-        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
-      }
-    ],
-    "text_typename": null
-  },
-  "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}Components/{urn:SICD:1.4.0}RadarSensor": {
-    "attributes": [],
-    "children": [
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}RangeBias",
-        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}ClockFreqSF",
-        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}TransmitFreqSF",
-        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}RangeBiasDecorr",
-        "typename": "{urn:SICD:1.4.0}ErrorDecorrFuncType"
-      }
-    ],
-    "text_typename": null
-  },
-  "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}Components/{urn:SICD:1.4.0}TropoError": {
-    "attributes": [],
-    "children": [
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}TropoRangeVertical",
-        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}TropoRangeSlant",
-        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}TropoRangeDecorr",
-        "typename": "{urn:SICD:1.4.0}ErrorDecorrFuncType"
-      }
-    ],
-    "text_typename": null
-  },
-  "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}Unmodeled": {
-    "attributes": [],
-    "children": [
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}Xrow",
-        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}Ycol",
-        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}XrowYcol",
-        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}UnmodeledDecorr",
-        "typename": "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}Unmodeled/{urn:SICD:1.4.0}UnmodeledDecorr"
-      }
-    ],
-    "text_typename": null
-  },
-  "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}Unmodeled/{urn:SICD:1.4.0}UnmodeledDecorr": {
-    "attributes": [],
-    "children": [
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}Xrow",
-        "typename": "{urn:SICD:1.4.0}ErrorDecorrFuncType"
-      },
-      {
-        "repeat": false,
-        "tag": "{urn:SICD:1.4.0}Ycol",
-        "typename": "{urn:SICD:1.4.0}ErrorDecorrFuncType"
       }
     ],
     "text_typename": null
@@ -1580,6 +1491,22 @@
     ],
     "text_typename": null
   },
+  "<UNNAMED>-{urn:SICD:1.4.0}UnmodeledType/{urn:SICD:1.4.0}UnmodeledDecorr": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}Xrow",
+        "typename": "{urn:SICD:1.4.0}ErrorDecorrFuncType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}Ycol",
+        "typename": "{urn:SICD:1.4.0}ErrorDecorrFuncType"
+      }
+    ],
+    "text_typename": null
+  },
   "{http://www.w3.org/2001/XMLSchema}boolean": {
     "attributes": [],
     "children": [],
@@ -1723,6 +1650,27 @@
     ],
     "text_typename": null
   },
+  "{urn:SICD:1.4.0}BistaticComponentsErrorType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}PosVelErr",
+        "typename": "<UNNAMED>-{urn:SICD:1.4.0}BistaticComponentsErrorType/{urn:SICD:1.4.0}PosVelErr"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}RadarSensor",
+        "typename": "<UNNAMED>-{urn:SICD:1.4.0}BistaticComponentsErrorType/{urn:SICD:1.4.0}RadarSensor"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}AtmosphericError",
+        "typename": "<UNNAMED>-{urn:SICD:1.4.0}BistaticComponentsErrorType/{urn:SICD:1.4.0}AtmosphericError"
+      }
+    ],
+    "text_typename": null
+  },
   "{urn:SICD:1.4.0}BistaticCompositeErrorType": {
     "attributes": [],
     "children": [
@@ -1807,6 +1755,32 @@
         "repeat": false,
         "tag": "{urn:SICD:1.4.0}Imag",
         "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.4.0}ComponentsErrorType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}PosVelErr",
+        "typename": "<UNNAMED>-{urn:SICD:1.4.0}ComponentsErrorType/{urn:SICD:1.4.0}PosVelErr"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}RadarSensor",
+        "typename": "<UNNAMED>-{urn:SICD:1.4.0}ComponentsErrorType/{urn:SICD:1.4.0}RadarSensor"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}TropoError",
+        "typename": "<UNNAMED>-{urn:SICD:1.4.0}ComponentsErrorType/{urn:SICD:1.4.0}TropoError"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}IonoError",
+        "typename": "<UNNAMED>-{urn:SICD:1.4.0}ComponentsErrorType/{urn:SICD:1.4.0}IonoError"
       }
     ],
     "text_typename": null
@@ -1924,23 +1898,28 @@
       },
       {
         "repeat": false,
+        "tag": "{urn:SICD:1.4.0}Components",
+        "typename": "{urn:SICD:1.4.0}ComponentsErrorType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}Unmodeled",
+        "typename": "{urn:SICD:1.4.0}UnmodeledType"
+      },
+      {
+        "repeat": false,
         "tag": "{urn:SICD:1.4.0}BistaticCompositeSCP",
         "typename": "{urn:SICD:1.4.0}BistaticCompositeErrorType"
       },
       {
         "repeat": false,
-        "tag": "{urn:SICD:1.4.0}Components",
-        "typename": "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}Components"
-      },
-      {
-        "repeat": false,
         "tag": "{urn:SICD:1.4.0}BistaticComponents",
-        "typename": "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}BistaticComponents"
+        "typename": "{urn:SICD:1.4.0}BistaticComponentsErrorType"
       },
       {
         "repeat": false,
         "tag": "{urn:SICD:1.4.0}Unmodeled",
-        "typename": "<UNNAMED>-{urn:SICD:1.4.0}ErrorStatisticsType/{urn:SICD:1.4.0}Unmodeled"
+        "typename": "{urn:SICD:1.4.0}UnmodeledType"
       },
       {
         "repeat": false,
@@ -2854,6 +2833,32 @@
         "repeat": false,
         "tag": "{urn:SICD:1.4.0}IPP",
         "typename": "<UNNAMED>-{urn:SICD:1.4.0}TimelineType/{urn:SICD:1.4.0}IPP"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.4.0}UnmodeledType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}Xrow",
+        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}Ycol",
+        "typename": "{urn:SICD:1.4.0}NonNegativeDoubleType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}XrowYcol",
+        "typename": "{urn:SICD:1.4.0}NegOneToOneType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.4.0}UnmodeledDecorr",
+        "typename": "<UNNAMED>-{urn:SICD:1.4.0}UnmodeledType/{urn:SICD:1.4.0}UnmodeledDecorr"
       }
     ],
     "text_typename": null


### PR DESCRIPTION
# Description
This PR replaces the deprecated SICD v1.4.0 schema (dated 2023-10-26) with the most recent version that superseded it on 2024-05-01.

See this entry from the SICD v1.4.0 vol 1 revision history:

<img width="483" height="84" alt="image" src="https://github.com/user-attachments/assets/e4b77809-2c69-41bf-96da-5587ec709d45" />


## Miscellaneous
- fix header levels in CHANGELOG.md
- remove unused `output_dir` arg from `generate_xsdtypes.py`