### PR TITLE
ElementWrapper.__contains__ now raises KeyError for impossible keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `ElementWrapper.__contains__` now raises `KeyError` for impossible keys
 
 ## [1.0.1] - 2025-09-09
 

--- a/tests/core/xmlhelp/test_core.py
+++ b/tests/core/xmlhelp/test_core.py
@@ -25,6 +25,9 @@ def test_elementwrapper():
     with pytest.raises(KeyError, match="foo"):
         del wrapped_siddroot["foo"]
 
+    with pytest.raises(KeyError, match="foo"):
+        "foo" in wrapped_siddroot
+
     # Attribute KeyErrors
     with pytest.raises(KeyError, match="@fooattr"):
         wrapped_siddroot["@fooattr"] = "doesn't exist"
@@ -34,6 +37,9 @@ def test_elementwrapper():
 
     with pytest.raises(KeyError, match="@fooattr"):
         del wrapped_siddroot["@fooattr"]
+
+    with pytest.raises(KeyError, match="@fooattr"):
+        "@fooattr" in wrapped_siddroot
 
     # Add descendant of repeatable
     wrapped_siddroot["ProductProcessing"].add("ProcessingModule")["ModuleName"] = (


### PR DESCRIPTION
`ElementWrapper`'s `__getitem__`, `__setitem__`, and `__del__` already raise a `KeyError` if the key isn't schema-valid.  This extends that logic to the `__contains__` method.

This will allow code such as `"typo" in wrapper` to error out earlier with a more useful error message.