### PR TITLE
optimize fromfile using readinto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- improved read performance
+- Improved read performance
 
 
 ## [1.1.0] - 2025-09-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- improved read performance
+
 
 ## [1.1.0] - 2025-09-29
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -58,6 +58,7 @@ def simple_open_read(filename, *args, **kwargs):
             self._file = builtins.open(filename, "rb")
 
             self.read = self._file.read
+            self.readinto = self._file.readinto
             self.readline = self._file.readline
             self.seek = self._file.seek
             self.tell = self._file.tell


### PR DESCRIPTION
This changes `_iohelper.fromfile` to use `readinto()`.  This eliminates the need for the extra buffer and generally has lower overhead.