### PR TITLE
update jbpy dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Ability to read and write SIDD legend segments
 
+### Changed
+- `jbpy` dependency updated
+
 ### Fixed
 - SICD consistency failure when optional ValidData polygon was omitted
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "jbpy==0.2.0",
+    "jbpy>=0.2.0, <0.4",
     "lxml>=5.1.0",
     "numpy>=1.25.0",
 ]
@@ -106,7 +106,6 @@ module = [
     "numba.*",
     "shapely.*",
     "smart_open.*",
-    "jbpy.*",
 ]
 ignore_missing_imports = true
 

--- a/sarkit/sicd/_io.py
+++ b/sarkit/sicd/_io.py
@@ -202,7 +202,7 @@ class NitfImSubheaderPart:
             iid2=image_header["IID2"].value,
             security=NitfSecurityFields._from_nitf_fields("IS", image_header),
             isorce=image_header["ISORCE"].value,
-            icom=[val.value for val in image_header.find_all("ICOM\\d+")],
+            icom=[val.value for val in image_header.find_all("ICOM\\d+")],  # type: ignore  # all ICOM should have value
         )
 
     def __post_init__(self):

--- a/sarkit/sidd/_io.py
+++ b/sarkit/sidd/_io.py
@@ -69,7 +69,7 @@ class NitfImSubheaderPart:
             tgtid=image_header["TGTID"].value,
             iid2=image_header["IID2"].value,
             security=NitfSecurityFields._from_nitf_fields("IS", image_header),
-            icom=[val.value for val in image_header.find_all("ICOM\\d+")],
+            icom=[val.value for val in image_header.find_all("ICOM\\d+")],  # type: ignore  # all ICOM should have value
         )
 
     def __post_init__(self):


### PR DESCRIPTION
# Description
This PR:
- updates `jbpy` dependency
- removes the `mypy` override as v0.3.0 declared typing support
- addressed `mypy` findings