### PR TITLE
Additional CPHD checks and unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Ability to read and write SIDD legend segments
+- Additional CPHD consistency checks and associated unit tests
 
 ### Changed
 - `jbpy` dependency updated

--- a/data/example-cphd-1.0.1.xml
+++ b/data/example-cphd-1.0.1.xml
@@ -151,7 +151,7 @@
   </SceneCoordinates>
   <Data>
     <SignalArrayFormat>CF8</SignalArrayFormat>
-    <NumBytesPVP>216</NumBytesPVP>
+    <NumBytesPVP>224</NumBytesPVP>
     <NumCPHDChannels>1</NumCPHDChannels>
     <Channel>
       <Identifier>1</Identifier>
@@ -355,6 +355,11 @@
       <Size>1</Size>
       <Format>F8</Format>
     </SCSS>
+    <SIGNAL>
+      <Offset>27</Offset>
+      <Size>1</Size>
+      <Format>I8</Format>
+    </SIGNAL>
   </PVP>
   <SupportArray>
     <AntGainPhase>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,6 +79,8 @@ def example_cphd(tmp_path_factory):
     srp = xmlhelp.load(".//{*}SRP/{*}ECF")
     pvps["SRPPos"] = srp
 
+    pvps["SIGNAL"] = 1
+
     tmp_cphd = (
         tmp_path_factory.mktemp("data") / good_cphd_xml_path.with_suffix(".cphd").name
     )


### PR DESCRIPTION
The purpose of this PR is to improve the CPHD consistency checking so I've added both consistency checks and unit tests.  In addition to checks and tests I added a `SIGNAL` PVP to the example xml so that I could check more signal related nodes.

<details>
<summary>Unit tests pass</summary>

```

$ pdm run nox
WARNING: Project requires a python version of >=3.11, The virtualenv is being created for you as it cannot be matched to the right version.
INFO: python.use_venv is on, creating a virtualenv for this project...
Virtualenv is created successfully at /home/vscuser/repos/sarkit-remote/.venv
[PdmUsageError]: Command 'nox' is not found in your PATH.
vscuser@dev-vm:~/repos/sarkit-remote$ git clean -xdf
Removing .pdm-python
Removing .venv/
vscuser@dev-vm:~/repos/sarkit-remote$ pdm install -dG :all
WARNING: Lockfile does not exist
Updating the lock file...
WARNING: Project requires a python version of >=3.11, The virtualenv is being created for you as it cannot be matched to the right version.
INFO: python.use_venv is on, creating a virtualenv for this project...
Virtualenv is created successfully at /home/vscuser/repos/sarkit-remote/.venv
Changes are written to pdm.lock.
  0:01:07 🔒 Lock successful.  
Synchronizing working set with resolved packages: 62 to add, 0 to update, 0 to remove

  ✔ Install argcomplete 3.6.3 successful
  ✔ Install alabaster 1.0.0 successful
  ✔ Install certifi 2025.10.5 successful
  ✔ Install attrs 25.4.0 successful
  ✔ Install aiosignal 1.4.0 successful
  ✔ Install dependency-groups 1.3.1 successful
  ✔ Install colorlog 6.10.1 successful
  ✔ Install aiohappyeyeballs 2.6.1 successful
  ✔ Install distlib 0.4.0 successful
  ✔ Install filelock 3.20.0 successful
  ✔ Install elementpath 5.0.4 successful
  ✔ Install docutils 0.21.2 successful
  ✔ Install idna 3.11 successful
  ✔ Install humanize 4.14.0 successful
  ✔ Install imagesize 1.4.1 successful
  ✔ Install iniconfig 2.3.0 successful
  ✔ Install jbpy 0.3.0 successful
  ✔ Install jinja2 3.1.6 successful
  ✔ Install babel 2.17.0 successful
  ✔ Install charset-normalizer 3.4.4 successful
  ✔ Install mypy-extensions 1.1.0 successful
  ✔ Install nox 2025.10.16 successful
  ✔ Install frozenlist 1.8.0 successful
  ✔ Install markupsafe 3.0.3 successful
  ✔ Install numpydoc 1.9.0 successful
  ✔ Install packaging 25.0 successful
  ✔ Install pathspec 0.12.1 successful
  ✔ Install platformdirs 4.5.0 successful
  ✔ Install pluggy 1.6.0 successful
  ✔ Install propcache 0.4.1 successful
  ✔ Install pygments 2.19.2 successful
  ✔ Install pytest 8.4.2 successful
  ✔ Install requests 2.32.5 successful
  ✔ Install roman-numerals-py 3.1.0 successful
  ✔ Install llvmlite 0.45.1 successful
  ✔ Install numba 0.62.1 successful
  ✔ Install mypy 1.18.2 successful
  ✔ Install smart-open 7.4.2 successful
  ✔ Install snowballstemmer 3.0.1 successful
  ✔ Install lxml 6.0.2 successful
  ✔ Install sphinx 8.2.3 successful
  ✔ Install sphinx-rtd-theme 3.0.2 successful
  ✔ Install sphinxcontrib-applehelp 2.0.0 successful
  ✔ Install sphinxcontrib-autoprogram 0.1.9 successful
  ✔ Install sphinxcontrib-devhelp 2.0.0 successful
  ✔ Install sphinxcontrib-htmlhelp 2.1.0 successful
  ✔ Install sphinxcontrib-jquery 4.1 successful
  ✔ Install sphinxcontrib-jsmath 1.0.1 successful
  ✔ Install sphinxcontrib-qthelp 2.0.0 successful
  ✔ Install typing-extensions 4.15.0 successful
  ✔ Install sphinxcontrib-serializinghtml 2.0.0 successful
  ✔ Install multidict 6.7.0 successful
  ✔ Install urllib3 2.5.0 successful
  ✔ Install xmlschema 4.2.0 successful
  ✔ Install virtualenv 20.35.4 successful
  ✔ Install shapely 2.1.2 successful
  ✔ Install numpy 2.3.4 successful
  ✔ Install aiohttp 3.13.2 successful
  ✔ Install wrapt 2.0.0 successful
  ✔ Install scipy 1.16.3 successful
  ✔ Install yarl 1.22.0 successful
  ✔ Install ruff 0.14.3 successful
  ✔ Install sarkit 1.2.1.dev4+g804050a successful

  0:01:13 🎉 All complete! 62/62
INFO: PDM 2.26.0 is installed, while 2.26.1 is available.
Please run `pdm self update` to upgrade.
Run `pdm config check_update false` to disable the check.
vscuser@dev-vm:~/repos/sarkit-remote$ pdm run nox
nox > Running session lint
nox > Creating virtual environment (virtualenv) using python in .nox/lint
nox > pdm sync --prod -G dev-lint -G all
INFO: Inside an active virtualenv /home/vscuser/repos/sarkit-remote/.nox/lint, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 9 to add, 0 to update, 0 to remove

  ✔ Install pathspec 0.12.1 successful
  ✔ Install jbpy 0.3.0 successful
  ✔ Install typing-extensions 4.15.0 successful
  ✔ Install mypy-extensions 1.1.0 successful
  ✔ Install shapely 2.1.2 successful
  ✔ Install mypy 1.18.2 successful
  ✔ Install lxml 6.0.2 successful
  ✔ Install ruff 0.14.3 successful
  ✔ Install numpy 2.3.4 successful
  ✔ Install sarkit 1.2.1.dev4+g804050a successful

  0:00:18 🎉 All complete! 9/9
INFO: PDM 2.26.0 is installed, while 2.26.1 is available.
Please run `pdm self update` to upgrade.
Run `pdm config check_update false` to disable the check.
nox > ruff check
All checks passed!
nox > ruff format --diff
103 files already formatted
nox > mypy /home/vscuser/repos/sarkit-remote/sarkit
Success: no issues found in 55 source files
nox > Session lint was successful in 34 seconds.
nox > Running session data
nox > Creating virtual environment (virtualenv) using python in .nox/data
nox > pdm sync --prod
INFO: Inside an active virtualenv /home/vscuser/repos/sarkit-remote/.nox/data, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 3 to add, 0 to update, 0 to remove

  ✔ Install jbpy 0.3.0 successful
  ✔ Install lxml 6.0.2 successful
  ✔ Install numpy 2.3.4 successful
  ✔ Install sarkit 1.2.1.dev4+g804050a successful

  0:00:07 🎉 All complete! 3/3
INFO: PDM 2.26.0 is installed, while 2.26.1 is available.
Please run `pdm self update` to upgrade.
Run `pdm config check_update false` to disable the check.
nox > python data/syntax_only/sicd/make_syntax_only_sicd_xmls.py --check
nox > python data/syntax_only/cphd/make_syntax_only_cphd_xmls.py --check
nox > python data/syntax_only/crsd/make_syntax_only_crsd_xmls.py --check
nox > python data/syntax_only/sidd/version1/make_syntax_only_sidd_xmls.py --check
nox > Session data was successful in 13 seconds.
nox > Running session xsdtypes
nox > Creating virtual environment (virtualenv) using python in .nox/xsdtypes
nox > pdm sync -G xsdtypes-generation
INFO: Inside an active virtualenv /home/vscuser/repos/sarkit-remote/.nox/xsdtypes, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 5 to add, 0 to update, 0 to remove

  ✔ Install jbpy 0.3.0 successful
  ✔ Install elementpath 5.0.4 successful
  ✔ Install xmlschema 4.2.0 successful
  ✔ Install lxml 6.0.2 successful
  ✔ Install numpy 2.3.4 successful
  ✔ Install sarkit 1.2.1.dev4+g804050a successful

  0:00:08 🎉 All complete! 5/5
INFO: PDM 2.26.0 is installed, while 2.26.1 is available.
Please run `pdm self update` to upgrade.
Run `pdm config check_update false` to disable the check.
nox > python generate_xsdtypes.py --check
nox > Session xsdtypes was successful in 17 seconds.
nox > Running session test
nox > Creating virtual environment (virtualenv) using python in .nox/test
nox > Session test was successful.
nox > Running session test_core
nox > Creating virtual environment (virtualenv) using python in .nox/test_core
nox > pdm sync --prod -G dev-test
INFO: Inside an active virtualenv /home/vscuser/repos/sarkit-remote/.nox/test_core, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 25 to add, 0 to update, 0 to remove

  ✔ Install certifi 2025.10.5 successful
  ✔ Install aiosignal 1.4.0 successful
  ✔ Install aiohappyeyeballs 2.6.1 successful
  ✔ Install frozenlist 1.8.0 successful
  ✔ Install jbpy 0.3.0 successful
  ✔ Install attrs 25.4.0 successful
  ✔ Install iniconfig 2.3.0 successful
  ✔ Install idna 3.11 successful
  ✔ Install packaging 25.0 successful
  ✔ Install pluggy 1.6.0 successful
  ✔ Install charset-normalizer 3.4.4 successful
  ✔ Install pytest 8.4.2 successful
  ✔ Install requests 2.32.5 successful
  ✔ Install smart-open 7.4.2 successful
  ✔ Install typing-extensions 4.15.0 successful
  ✔ Install pygments 2.19.2 successful
  ✔ Install urllib3 2.5.0 successful
  ✔ Install propcache 0.4.1 successful
  ✔ Install wrapt 2.0.0 successful
  ✔ Install lxml 6.0.2 successful
  ✔ Install multidict 6.7.0 successful
  ✔ Install scipy 1.16.3 successful
  ✔ Install yarl 1.22.0 successful
  ✔ Install numpy 2.3.4 successful
  ✔ Install aiohttp 3.13.2 successful
  ✔ Install sarkit 1.2.1.dev4+g804050a successful

  0:00:37 🎉 All complete! 25/25
INFO: PDM 2.26.0 is installed, while 2.26.1 is available.
Please run `pdm self update` to upgrade.
Run `pdm config check_update false` to disable the check.
nox > pytest tests/core
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.13.7, pytest-8.4.2, pluggy-1.6.0
rootdir: /home/vscuser/repos/sarkit-remote
configfile: pyproject.toml
collected 322 items                                                                                                                                                        

tests/core/cphd/test_cphdinfo.py .....                                                                                                                               [  1%]
tests/core/cphd/test_io.py .............................................................................................                                             [ 30%]
tests/core/cphd/test_refgeom.py ..                                                                                                                                   [ 31%]
tests/core/cphd/test_xml.py ......                                                                                                                                   [ 32%]
tests/core/crsd/test_computations.py ......                                                                                                                          [ 34%]
tests/core/crsd/test_crsdinfo.py .....                                                                                                                               [ 36%]
tests/core/crsd/test_io.py .......                                                                                                                                   [ 38%]
tests/core/crsd/test_xml.py .......                                                                                                                                  [ 40%]
tests/core/sicd/test_errorprop.py ....                                                                                                                               [ 41%]
tests/core/sicd/test_io.py ............                                                                                                                              [ 45%]
tests/core/sicd/test_projection.py ..................x....................................                                                                           [ 62%]
tests/core/sicd/test_sicd_projections.py ........x                                                                                                                   [ 65%]
tests/core/sicd/test_sicdinfo.py .....                                                                                                                               [ 67%]
tests/core/sicd/test_xml.py ....................                                                                                                                     [ 73%]
tests/core/sidd/test_calculations.py ...                                                                                                                             [ 74%]
tests/core/sidd/test_io.py ................                                                                                                                          [ 79%]
tests/core/sidd/test_siddinfo.py ......                                                                                                                              [ 81%]
tests/core/sidd/test_xml.py ...............................                                                                                                          [ 90%]
tests/core/test_iohelp.py ..                                                                                                                                         [ 91%]
tests/core/test_wgs84.py ......                                                                                                                                      [ 93%]
tests/core/xmlhelp/test_core.py ..                                                                                                                                   [ 93%]
tests/core/xmlhelp/test_transcoders.py ....................                                                                                                          [100%]

===================================================================== 320 passed, 2 xfailed in 56.72s ======================================================================
nox > Session test_core was successful in a minute.
nox > Running session test_processing
nox > Creating virtual environment (virtualenv) using python in .nox/test_processing
nox > pdm sync -G dev-test -G processing
INFO: Inside an active virtualenv /home/vscuser/repos/sarkit-remote/.nox/test_processing, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 27 to add, 0 to update, 0 to remove

  ✔ Install certifi 2025.10.5 successful
  ✔ Install attrs 25.4.0 successful
  ✔ Install aiosignal 1.4.0 successful
  ✔ Install aiohappyeyeballs 2.6.1 successful
  ✔ Install idna 3.11 successful
  ✔ Install iniconfig 2.3.0 successful
  ✔ Install jbpy 0.3.0 successful
  ✔ Install charset-normalizer 3.4.4 successful
  ✔ Install packaging 25.0 successful
  ✔ Install pluggy 1.6.0 successful
  ✔ Install frozenlist 1.8.0 successful
  ✔ Install propcache 0.4.1 successful
  ✔ Install pygments 2.19.2 successful
  ✔ Install requests 2.32.5 successful
  ✔ Install pytest 8.4.2 successful
  ✔ Install smart-open 7.4.2 successful
  ✔ Install typing-extensions 4.15.0 successful
  ✔ Install urllib3 2.5.0 successful
  ✔ Install llvmlite 0.45.1 successful
  ✔ Install numba 0.62.1 successful
  ✔ Install lxml 6.0.2 successful
  ✔ Install wrapt 2.0.0 successful
  ✔ Install multidict 6.7.0 successful
  ✔ Install numpy 2.3.4 successful
  ✔ Install yarl 1.22.0 successful
  ✔ Install scipy 1.16.3 successful
  ✔ Install aiohttp 3.13.2 successful
  ✔ Install sarkit 1.2.1.dev4+g804050a successful

  0:00:45 🎉 All complete! 27/27
INFO: PDM 2.26.0 is installed, while 2.26.1 is available.
Please run `pdm self update` to upgrade.
Run `pdm config check_update false` to disable the check.
nox > pytest tests/processing
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.13.7, pytest-8.4.2, pluggy-1.6.0
rootdir: /home/vscuser/repos/sarkit-remote
configfile: pyproject.toml
collected 6 items                                                                                                                                                          

tests/processing/test_deskew.py ...                                                                                                                                  [ 50%]
tests/processing/test_pixel_type.py ..                                                                                                                               [ 83%]
tests/processing/test_subimage.py .                                                                                                                                  [100%]

============================================================================ 6 passed in 6.79s =============================================================================
nox > Session test_processing was successful in 59 seconds.
nox > Running session test_verification
nox > Creating virtual environment (virtualenv) using python in .nox/test_verification
nox > pdm sync --prod -G dev-test -G verification
INFO: Inside an active virtualenv /home/vscuser/repos/sarkit-remote/.nox/test_verification, reusing it.
Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
Synchronizing working set with resolved packages: 26 to add, 0 to update, 0 to remove

  ✔ Install aiohappyeyeballs 2.6.1 successful
  ✔ Install attrs 25.4.0 successful
  ✔ Install aiosignal 1.4.0 successful
  ✔ Install certifi 2025.10.5 successful
  ✔ Install idna 3.11 successful
  ✔ Install jbpy 0.3.0 successful
  ✔ Install iniconfig 2.3.0 successful
  ✔ Install pluggy 1.6.0 successful
  ✔ Install packaging 25.0 successful
  ✔ Install pygments 2.19.2 successful
  ✔ Install pytest 8.4.2 successful
  ✔ Install requests 2.32.5 successful
  ✔ Install frozenlist 1.8.0 successful
  ✔ Install propcache 0.4.1 successful
  ✔ Install smart-open 7.4.2 successful
  ✔ Install typing-extensions 4.15.0 successful
  ✔ Install charset-normalizer 3.4.4 successful
  ✔ Install urllib3 2.5.0 successful
  ✔ Install shapely 2.1.2 successful
  ✔ Install wrapt 2.0.0 successful
  ✔ Install lxml 6.0.2 successful
  ✔ Install scipy 1.16.3 successful
  ✔ Install multidict 6.7.0 successful
  ✔ Install numpy 2.3.4 successful
  ✔ Install yarl 1.22.0 successful
  ✔ Install aiohttp 3.13.2 successful
  ✔ Install sarkit 1.2.1.dev4+g804050a successful

  0:00:38 🎉 All complete! 26/26
INFO: PDM 2.26.0 is installed, while 2.26.1 is available.
Please run `pdm self update` to upgrade.
Run `pdm config check_update false` to disable the check.
nox > pytest tests/verification
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.13.7, pytest-8.4.2, pluggy-1.6.0
rootdir: /home/vscuser/repos/sarkit-remote
configfile: pyproject.toml
collected 956 items                                                                                                                                                        

tests/verification/test_cli.py ....                                                                                                                                  [  0%]
tests/verification/test_consistency.py ..........                                                                                                                    [  1%]
tests/verification/test_cphd_consistency.py ........................................................................................................................ [ 14%]
................                                                                                                                                                     [ 15%]
tests/verification/test_crsd_consistency.py ........................................................................................................................ [ 28%]
..............................................................ssss......................................ss........................sssssssssssssssssssssssssssss..... [ 45%]
......sssss......ss.ss.ss......ssss................ss...........ssss....ssssssssssssssssssssssssssssssssssssss...................................................... [ 62%]
........ssss...........ss.ss.ss..ssss.....ss............s......................................................................                                      [ 75%]
tests/verification/test_sicd_consistency.py ........................................................................................................................ [ 88%]
.........................................................................                                                                                            [ 96%]
tests/verification/test_sidd_consistency.py ......................................                                                                                   [100%]

============================================================================= warnings summary =============================================================================
tests/verification/test_sicd_consistency.py::test_smoketest[xml_file4]
  /home/vscuser/repos/sarkit-remote/sarkit/verification/_sicd_consistency.py:36: RuntimeWarning: invalid value encountered in divide
    return vec / np.linalg.norm(vec, axis=axis, keepdims=True)

tests/verification/test_sicd_consistency.py::test_smoketest[xml_file6]
  /home/vscuser/repos/sarkit-remote/sarkit/sicd/_xml.py:454: RuntimeWarning: invalid value encountered in arccos
    dca_xmt = np.arccos(-rdot_xmt_scp / vxmt_m)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================== 845 passed, 111 skipped, 2 warnings in 30.58s ===============================================================
nox > Session test_verification was successful in a minute.
nox > Ran 7 sessions in 5 minutes:
nox > * lint: success, took 34 seconds
nox > * data: success, took 13 seconds
nox > * xsdtypes: success, took 17 seconds
nox > * test: success
nox > * test_core: success, took a minute
nox > * test_processing: success, took 59 seconds
nox > * test_verification: success, took a minute


```