### PR TITLE
Handle PVP/PPP sets with pad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - SICD consistency failure when optional ValidData polygon was omitted
+- Handling of CPHD and CRSD with padded PVP/PPP sets
 
 
 ## [1.2.0] - 2025-10-13

--- a/tests/verification/test_crsd_consistency.py
+++ b/tests/verification/test_crsd_consistency.py
@@ -1645,6 +1645,10 @@ def test_numbytesppp(crsd_con):
     nbppp = crsd_con.crsdroot.find("{*}Data/{*}Transmit/{*}NumBytesPPP")
     nbppp.text = str(int(nbppp.text) + 1)
     crsd_con.check("check_numbytesppp")
+    assert not crsd_con.failures()
+
+    nbppp.text = str(int(nbppp.text) - 2)
+    crsd_con.check("check_numbytesppp")
     assert crsd_con.failures()
 
 
@@ -1687,6 +1691,10 @@ def test_numbytespvp(crsd_con):
         pytest.skip("test not applicable with CRSDtx")
     nbpvp = crsd_con.crsdroot.find("{*}Data/{*}Receive/{*}NumBytesPVP")
     nbpvp.text = str(int(nbpvp.text) + 1)
+    crsd_con.check("check_numbytespvp")
+    assert not crsd_con.failures()
+
+    nbpvp.text = str(int(nbpvp.text) - 2)
     crsd_con.check("check_numbytespvp")
     assert crsd_con.failures()
 


### PR DESCRIPTION
`NumBytesPVP` / `NumBytesPPP` is allowed to be larger than what is strictly necessary to contain all of the PxP fields.  This fixes the custom dtype to account for this scenario.