### PR TITLE
Add SIDD v1.0/2.0 convention option in compute_angles; fix SIDD v2.0 ANG_MAG transcoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Option to use SIDD v1.0/2.0 image angle convention in `sarkit.sidd.compute_angles`
+
+### Fixed
+- SIDD v2.0 ANG_MAG types properly transcode to `AngleMagnitudeType`
+
 
 ## [1.3.0] - 2025-11-11
 

--- a/sarkit/sidd/_xml.py
+++ b/sarkit/sidd/_xml.py
@@ -498,6 +498,7 @@ class XsdHelper(skxml.XsdHelper):
         }
         sidd_2_and_3 = {
             "{urn:SFA:1.2.0}PointType": SfaPointType(),
+            "{urn:SICommon:1.0}AngleMagnitudeType": AngleMagnitudeType(),
             "{urn:SICommon:1.0}AngleZeroToExclusive360MagnitudeType": AngleMagnitudeType(),
             "{urn:SICommon:1.0}LatLonRestrictionType": LatLonType(),
             "{urn:SICommon:1.0}LatLonType": LatLonType(),

--- a/sarkit/sidd/calculations/exploitation_features.py
+++ b/sarkit/sidd/calculations/exploitation_features.py
@@ -10,7 +10,7 @@ import sarkit.wgs84
 
 @dataclasses.dataclass(kw_only=True)
 class Angles:
-    """Angles computed in SIDD 3.0.0 section 7."""
+    """Angles defined in SIDD Volume 1, ExploitationFeatures Calculations"""
 
     # Geometry
     Azimuth: float  # 7.5.1 - Azimuth Angle
@@ -36,8 +36,10 @@ def compute_angles(
     antenna_velocity_ecef: npt.ArrayLike,
     increasing_row_ecef: npt.ArrayLike,
     increasing_col_ecef: npt.ArrayLike,
+    *,
+    convention="3.0",
 ) -> Angles:
-    """Compute the angles defined in SIDD 3.0.0 section 7
+    """Compute the angles defined in SIDD Volume 1, ExploitationFeatures Calculations
 
     Parameters
     ----------
@@ -51,6 +53,11 @@ def compute_angles(
         Unit Vector in increasing rows, in ECEF coordinates.  (:math:`\\hat{r}`)
     increasing_col_ecef : array_like
         Unit Vector in increasing columns, in ECEF coordinates.  (:math:`\\hat{c}`)
+    convention : {'2.0', '3.0'}, optional
+        Which convention to use for image angles:
+
+        * '2.0': Counter-clockwise rotation from increasing row direction; angle range [-180, 180)
+        * '3.0': Clockwise rotation from increasing column direction; angle range [0, 360)
 
     Returns
     -------
@@ -63,11 +70,24 @@ def compute_angles(
     r_hat = np.asarray(increasing_row_ecef)
     c_hat = np.asarray(increasing_col_ecef)
 
+    # Section references throughout are from SIDD v3.0
     # Table 7-1 defines lambda as Latitude and phi as Longitude, but the angle calculations imply the opposite.
     phi, lam = np.deg2rad(sarkit.wgs84.cartesian_to_geodetic(P_o)[:2])
 
     def _unit(vec):
         return vec / np.linalg.norm(vec, axis=-1)
+
+    def compute_image_angle(vec):
+        """Compute angle between a vector and image row/col axes
+
+        Inferred from the document (see 'Image Angle' section)
+        """
+        if convention == "2.0":
+            return np.arctan2(np.dot(c_hat, vec), np.dot(r_hat, vec))
+        if convention == "3.0":
+            # note: r_hat/c_hat intentionally swapped
+            return np.arctan2(np.dot(r_hat, vec), np.dot(c_hat, vec)) % (2 * np.pi)
+        raise ValueError(f"Unrecognized {convention=}")
 
     # 7.2 - Slant Plane Definition
     X_s_hat = _unit(P_a - P_o)  # noqa: N806
@@ -83,7 +103,7 @@ def compute_angles(
         [-np.sin(phi) * np.cos(lam), -np.sin(phi) * np.sin(lam), np.cos(phi)]
     )
     N_prime = N_hat - np.dot(N_hat, z_hat) / np.dot(Z_s_hat, z_hat) * Z_s_hat  # noqa: N806
-    theta_N = np.arctan2(np.dot(r_hat, N_prime), np.dot(c_hat, N_prime))  # noqa: N806
+    theta_N = compute_image_angle(N_prime)  # noqa: N806
 
     # 7.6.4 - Up Direction
     Z_g_hat = U = np.array(  # noqa: N806
@@ -124,21 +144,21 @@ def compute_angles(
     # 7.6.1 - Shadow
     S = Z_g_hat - X_s_hat / np.dot(X_s_hat, Z_g_hat)  # noqa: N806
     S_prime = S - np.dot(S, z_hat) / np.dot(Z_s_hat, z_hat) * Z_s_hat  # noqa: N806
-    theta_S = np.arctan2(np.dot(r_hat, S_prime), np.dot(c_hat, S_prime))  # noqa: N806
+    theta_S = compute_image_angle(S_prime)  # noqa: N806
     magnitude_S = np.sqrt(np.dot(S_prime, S_prime))  # noqa: N806
 
     # 7.6.2 - Layover
     L = z_hat - Z_s_hat / np.dot(Z_s_hat, z_hat)  # noqa: N806
-    theta_L = np.arctan2(np.dot(r_hat, L), np.dot(c_hat, L))  # noqa: N806
+    theta_L = compute_image_angle(L)  # noqa: N806
     magnitude_L = np.sqrt(np.dot(L, L))  # noqa: N806
 
     # 7.6.5 - Multi-Path
     M = X_s_hat - np.dot(X_s_hat, z_hat) / np.dot(Z_s_hat, z_hat) * Z_s_hat  # noqa: N806
-    theta_M = np.arctan2(np.dot(r_hat, M), np.dot(c_hat, M))  # noqa: N806
+    theta_M = compute_image_angle(M)  # noqa: N806
 
     # 7.6.6 - Ground Track (Image Track) Angle
     T = V_a - np.dot(V_a, z_hat) * z_hat  # noqa: N806
-    theta_T = np.arctan2(np.dot(r_hat, T), np.dot(c_hat, T))  # noqa: N806
+    theta_T = compute_image_angle(T)  # noqa: N806
 
     return Angles(
         Azimuth=np.rad2deg(theta_a) % 360,
@@ -147,11 +167,11 @@ def compute_angles(
         Squint=np.rad2deg(Phi_g),
         Graze=np.rad2deg(Psi),
         Tilt=np.rad2deg(eta),
-        Shadow=np.rad2deg(theta_S) % 360,
+        Shadow=np.rad2deg(theta_S),
         ShadowMagnitude=magnitude_S,
-        Layover=np.rad2deg(theta_L) % 360,
+        Layover=np.rad2deg(theta_L),
         LayoverMagnitude=magnitude_L,
-        MultiPath=np.rad2deg(theta_M) % 360,
-        GroundTrack=np.rad2deg(theta_T) % 360,
-        North=np.rad2deg(theta_N) % 360,
+        MultiPath=np.rad2deg(theta_M),
+        GroundTrack=np.rad2deg(theta_T),
+        North=np.rad2deg(theta_N),
     )

--- a/tests/core/sidd/test_calculations.py
+++ b/tests/core/sidd/test_calculations.py
@@ -210,9 +210,15 @@ def test_coordinate_transform():
     np.testing.assert_almost_equal(pixel, pixel_rt)
 
 
-def test_angles():
-    sidd_xmlfile = DATAPATH / "example-sidd-3.0.0.xml"
-    sidd_xmltree = lxml.etree.parse(sidd_xmlfile)
+@pytest.mark.parametrize(
+    "siddxml, convention",
+    (
+        (DATAPATH / "example-sidd-2.0.0.xml", "2.0"),
+        (DATAPATH / "example-sidd-3.0.0.xml", "3.0"),
+    ),
+)
+def test_angles(siddxml, convention):
+    sidd_xmltree = lxml.etree.parse(siddxml)
     sidd_helper = sksidd.XmlHelper(sidd_xmltree)
 
     tcoa_poly = sidd_helper.load("./{*}Measurement/{*}PlaneProjection/{*}TimeCOAPoly")
@@ -230,6 +236,7 @@ def test_angles():
         sidd_helper.load(
             "./{*}Measurement/{*}PlaneProjection/{*}ProductPlane/{*}ColUnitVector"
         ),
+        convention=convention,
     )
     # Regression test against canned data
     col = "./{*}ExploitationFeatures/{*}Collection/"


### PR DESCRIPTION
# Description
This PR:
- adds the option of using SIDD v1.0/2.0 convention for image angles to `sarkit.sidd.compute_angles` (v1.0 and v2.0 have the same convention)

| v2.0 | v3.0 |
| ------ | ------ |
|  <img width="371" height="292" alt="image" src="https://github.com/user-attachments/assets/73729df3-cc51-4d4d-9da6-bc6f97aa8cbd" />     |  <img width="304" height="239" alt="image-1" src="https://github.com/user-attachments/assets/6a7fd816-c75b-4140-9eb8-5586dd07ecd3" />    |
|  <img width="469" height="172" alt="image" src="https://github.com/user-attachments/assets/c48f1b89-648d-40a9-aafc-a3ec635a12e1" />   |  <img width="495" height="99" alt="image-1" src="https://github.com/user-attachments/assets/8ca59651-85a7-457c-a3b6-b46f3c40591e" />    |

- fixes a bug where SIDD v2.0 ANG_MAG types were not being transcoded properly

In `main`:

```python
>>> import sarkit.sidd as sksidd
>>> import lxml.etree
>>> sksidd.XmlHelper(lxml.etree.parse("data/example-sidd-2.0.0.xml")).load(".//{*}Shadow")
Traceback (most recent call last):
LookupError: {urn:SIDD:2.0.0}ExploitationFeatures/{urn:SIDD:2.0.0}Collection/{urn:SIDD:2.0.0}Phenomenology/{urn:SIDD:2.0.0}Shadow is not transcodable
```

This branch:
```python
>>> import sarkit.sidd as sksidd
>>> import lxml.etree
>>> sksidd.XmlHelper(lxml.etree.parse("data/example-sidd-2.0.0.xml")).load(".//{*}Shadow")
array([5.22038580e-04, 1.73204516e+00])
```

With these changes, we are also able to de-duplicate some code from `_sidd_consistency.py`