### PR TITLE
update jbpy to v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for Python 3.14
 - `sarkit.wgs84.GM` constant
 
+### Changed
+- `jbpy` dependency updated
+
 ### Fixed
 - SIDD v2.0 ANG_MAG types properly transcode to `AngleMagnitudeType`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "jbpy>=0.2.0, <0.5",
+    "jbpy>=0.5.1, <0.6",
     "lxml>=5.1.0",
     "numpy>=1.25.0",
     "shapely>=2.0.2",

--- a/sarkit/sidd/_io.py
+++ b/sarkit/sidd/_io.py
@@ -811,19 +811,18 @@ def jbp_from_nitf_metadata(metadata: NitfMetadata) -> jbpy.Jbp:
         xml_helper = sksidd.XmlHelper(imageinfo.xmltree)
 
         deseg = jbp["DataExtensionSegments"][desidx]
+        deseg.set_subheader(jbpy.des_subheader_factory("XML_DATA_CONTENT", 1))
         subhdr = deseg["subheader"]
-        subhdr["DESID"].value = "XML_DATA_CONTENT"
-        subhdr["DESVER"].value = 1
         imageinfo.de_subheader_part.security._set_nitf_fields("DES", subhdr)
         subhdr["DESSHL"].value = 773
-        subhdr["DESSHF"]["DESCRC"].value = 99999
-        subhdr["DESSHF"]["DESSHFT"].value = "XML"
-        subhdr["DESSHF"]["DESSHDT"].value = now_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
-        subhdr["DESSHF"]["DESSHRP"].value = imageinfo.de_subheader_part.desshrp
-        subhdr["DESSHF"]["DESSHSI"].value = siddconst.SPECIFICATION_IDENTIFIER
-        subhdr["DESSHF"]["DESSHSV"].value = siddconst.VERSION_INFO[xmlns]["version"]
-        subhdr["DESSHF"]["DESSHSD"].value = siddconst.VERSION_INFO[xmlns]["date"]
-        subhdr["DESSHF"]["DESSHTN"].value = xmlns
+        subhdr["DESCRC"].value = 99999
+        subhdr["DESSHFT"].value = "XML"
+        subhdr["DESSHDT"].value = now_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        subhdr["DESSHRP"].value = imageinfo.de_subheader_part.desshrp
+        subhdr["DESSHSI"].value = siddconst.SPECIFICATION_IDENTIFIER
+        subhdr["DESSHSV"].value = siddconst.VERSION_INFO[xmlns]["version"]
+        subhdr["DESSHSD"].value = siddconst.VERSION_INFO[xmlns]["date"]
+        subhdr["DESSHTN"].value = xmlns
 
         if xmlns == "urn:SIDD:1.0.0":
             corners_path = "{*}GeographicAndTarget/{*}GeographicCoverage/{*}Footprint"
@@ -833,10 +832,10 @@ def jbp_from_nitf_metadata(metadata: NitfMetadata) -> jbpy.Jbp:
         desshlpg = ""
         for icp_lat, icp_lon in itertools.chain(icp, [icp[0]]):
             desshlpg += f"{icp_lat:0=+12.8f}{icp_lon:0=+13.8f}"
-        subhdr["DESSHF"]["DESSHLPG"].value = desshlpg
-        subhdr["DESSHF"]["DESSHLI"].value = imageinfo.de_subheader_part.desshli
-        subhdr["DESSHF"]["DESSHLIN"].value = imageinfo.de_subheader_part.desshlin
-        subhdr["DESSHF"]["DESSHABS"].value = imageinfo.de_subheader_part.desshabs
+        subhdr["DESSHLPG"].value = desshlpg
+        subhdr["DESSHLI"].value = imageinfo.de_subheader_part.desshli
+        subhdr["DESSHLIN"].value = imageinfo.de_subheader_part.desshlin
+        subhdr["DESSHABS"].value = imageinfo.de_subheader_part.desshabs
 
         xml_bytes = lxml.etree.tostring(imageinfo.xmltree)
         deseg["DESDATA"].size = len(xml_bytes)
@@ -847,27 +846,26 @@ def jbp_from_nitf_metadata(metadata: NitfMetadata) -> jbpy.Jbp:
     # Product Support XML DES
     for prodinfo in metadata.product_support_xmls:
         deseg = jbp["DataExtensionSegments"][desidx]
+        deseg.set_subheader(jbpy.des_subheader_factory("XML_DATA_CONTENT", 1))
         subhdr = deseg["subheader"]
-        sidd_uh = jbp["DataExtensionSegments"][0]["subheader"]["DESSHF"]
+        sidd_uh = jbp["DataExtensionSegments"][0]["subheader"]
 
         xmlns = lxml.etree.QName(prodinfo.xmltree.getroot()).namespace or ""
 
-        subhdr["DESID"].value = "XML_DATA_CONTENT"
-        subhdr["DESVER"].value = 1
         prodinfo.de_subheader_part.security._set_nitf_fields("DES", subhdr)
         subhdr["DESSHL"].value = 773
-        subhdr["DESSHF"]["DESCRC"].value = 99999
-        subhdr["DESSHF"]["DESSHFT"].value = "XML"
-        subhdr["DESSHF"]["DESSHDT"].value = now_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
-        subhdr["DESSHF"]["DESSHRP"].value = prodinfo.de_subheader_part.desshrp
-        subhdr["DESSHF"]["DESSHSI"].value = sidd_uh["DESSHSI"].value
-        subhdr["DESSHF"]["DESSHSV"].value = "v" + sidd_uh["DESSHSV"].value
-        subhdr["DESSHF"]["DESSHSD"].value = sidd_uh["DESSHSD"].value
-        subhdr["DESSHF"]["DESSHTN"].value = xmlns
-        subhdr["DESSHF"]["DESSHLPG"].value = ""
-        subhdr["DESSHF"]["DESSHLI"].value = prodinfo.de_subheader_part.desshli
-        subhdr["DESSHF"]["DESSHLIN"].value = prodinfo.de_subheader_part.desshlin
-        subhdr["DESSHF"]["DESSHABS"].value = prodinfo.de_subheader_part.desshabs
+        subhdr["DESCRC"].value = 99999
+        subhdr["DESSHFT"].value = "XML"
+        subhdr["DESSHDT"].value = now_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        subhdr["DESSHRP"].value = prodinfo.de_subheader_part.desshrp
+        subhdr["DESSHSI"].value = sidd_uh["DESSHSI"].value
+        subhdr["DESSHSV"].value = "v" + sidd_uh["DESSHSV"].value
+        subhdr["DESSHSD"].value = sidd_uh["DESSHSD"].value
+        subhdr["DESSHTN"].value = xmlns
+        subhdr["DESSHLPG"].value = ""
+        subhdr["DESSHLI"].value = prodinfo.de_subheader_part.desshli
+        subhdr["DESSHLIN"].value = prodinfo.de_subheader_part.desshlin
+        subhdr["DESSHABS"].value = prodinfo.de_subheader_part.desshabs
 
         xml_bytes = lxml.etree.tostring(prodinfo.xmltree)
         deseg["DESDATA"].size = len(xml_bytes)
@@ -880,14 +878,17 @@ def jbp_from_nitf_metadata(metadata: NitfMetadata) -> jbpy.Jbp:
         deseg = jbp["DataExtensionSegments"][desidx]
 
         if sidd_ns == "urn:SIDD:1.0.0":
-            populate_sicd_xml_des_sidd1(deseg, sicd_xml_info.de_subheader_part)
+            xml_des_subheader = populate_sicd_xml_des_sidd1(
+                sicd_xml_info.de_subheader_part
+            )
         else:
-            sarkit.sicd._io._populate_de_segment(
-                deseg, sicd_xml_info.xmltree, sicd_xml_info.de_subheader_part
+            xml_des_subheader = sarkit.sicd._io._create_xml_des_subheader(
+                sicd_xml_info.xmltree, sicd_xml_info.de_subheader_part
             )
 
         xml_bytes = lxml.etree.tostring(sicd_xml_info.xmltree)
         deseg["DESDATA"].size = len(xml_bytes)
+        deseg.set_subheader(xml_des_subheader)
 
         desidx += 1
 
@@ -895,13 +896,12 @@ def jbp_from_nitf_metadata(metadata: NitfMetadata) -> jbpy.Jbp:
     return jbp
 
 
-def populate_sicd_xml_des_sidd1(deseg, de_subheader_part):
+def populate_sicd_xml_des_sidd1(de_subheader_part):
     """Populate SICD XML DES according to SIDD v1.0 volume 2, section 2.2.4"""
-    subhdr = deseg["subheader"]
-    subhdr["DESID"].value = "SICD_XML"
-    subhdr["DESVER"].value = 1
+    subhdr = jbpy.des_subheader_factory("SICD_XML", 1)
     de_subheader_part.security._set_nitf_fields("DES", subhdr)
     subhdr["DESSHL"].value = 0
+    return subhdr
 
 
 def _is_sidd_image_segment(segment, icat):

--- a/sarkit/verification/_sicd_consistency.py
+++ b/sarkit/verification/_sicd_consistency.py
@@ -151,7 +151,7 @@ def _compute_pfa_min_max_fx(xmlhelp):
 def _get_desdata_location(ntf):
     """Return the first SICD DES"""
     for deseg in ntf["DataExtensionSegments"]:
-        if deseg["subheader"]["DESSHF"]["DESSHTN"].value.startswith("urn:SICD"):
+        if deseg["subheader"]["DESSHTN"].encoded_value.startswith(b"urn:SICD"):
             return deseg["DESDATA"].get_offset(), deseg["DESDATA"].get_size()
     raise ValueError("Unable to find SICD DES")
 
@@ -401,15 +401,15 @@ class SicdConsistency(con.ConsistencyChecker):
                 with self.need("Valid image subheaders"):
                     assert idatim <= collect_start + datetime.timedelta(seconds=1)
                     assert idatim >= collect_start - datetime.timedelta(seconds=1)
-                    assert imhdr["PVTYPE"].value.rstrip() == pixel_info["pvtype"]
-                    assert imhdr["IREP"].value.rstrip() == "NODISPLY"
-                    assert imhdr["ICAT"].value.rstrip() == "SAR"
+                    assert imhdr["PVTYPE"].value == pixel_info["pvtype"]
+                    assert imhdr["IREP"].value == "NODISPLY"
+                    assert imhdr["ICAT"].value == "SAR"
                     assert imhdr["ABPP"].value == expected_nbpp
                     assert imhdr["PJUST"].value == "R"
                     assert imhdr["ICORDS"].value == "G"
                     assert imhdr["IC"].value in ["NC", "NM", "C7", "M7"]
                     assert imhdr["ISYNC"].value == 0
-                    assert imhdr["IMODE"].value.rstrip() == "P"
+                    assert imhdr["IMODE"].value == "P"
                     assert imhdr["NBPR"].value == 1
                     assert imhdr["NBPC"].value == 1
 
@@ -579,30 +579,28 @@ class SicdConsistency(con.ConsistencyChecker):
                 )
 
             with self.need("DESID == XML_DATA_CONTENT"):
-                assert des_header["DESID"].value.rstrip() == "XML_DATA_CONTENT"
+                assert des_header["DESID"].value == "XML_DATA_CONTENT"
 
             with self.need("DESSHFT == XML"):
-                assert des_header["DESSHF"]["DESSHFT"].value.rstrip() == "XML"
+                assert des_header["DESSHFT"].value == "XML"
 
             with self.need(
                 "DESSHSI == SICD Volume 1 Design & Implementation Description Document"
             ):
                 assert (
-                    des_header["DESSHF"]["DESSHSI"].value.rstrip()
+                    des_header["DESSHSI"].value
                     == "SICD Volume 1 Design & Implementation Description Document"
                 )
 
             instance_namespace = etree.QName(self.sicdroot).namespace
             with self.need("Consistent namespace"):
-                assert (
-                    des_header["DESSHF"]["DESSHTN"].value.rstrip() == instance_namespace
-                )
+                assert des_header["DESSHTN"].value == instance_namespace
 
             icp_nodes = self.xmlhelp.load("./{*}GeoData/{*}ImageCorners")
             icp_strs = [f"{lat:+012.8f}{lon:+013.8f}" for (lat, lon) in icp_nodes]
             icp_strs.append(icp_strs[0])
             with self.need("DESSHLPG consistent with image corners"):
-                assert des_header["DESSHF"]["DESSHLPG"].value == "".join(icp_strs)
+                assert des_header["DESSHLPG"].value == "".join(icp_strs)
 
     def check_grid_sign(self) -> None:
         """Grid signs match."""

--- a/sarkit/verification/_sidd_consistency.py
+++ b/sarkit/verification/_sidd_consistency.py
@@ -203,9 +203,9 @@ class SiddConsistency(con.ConsistencyChecker):
                 if not deseg["subheader"]["DESID"].value == "XML_DATA_CONTENT":
                     continue
                 desshtn = getattr(
-                    deseg["subheader"].get("DESSHF", {}).get("DESSHTN"), "value", ""
+                    deseg["subheader"].get("DESSHTN"), "encoded_value", b""
                 )
-                if not desshtn.startswith("urn:SIDD"):
+                if not desshtn.startswith(b"urn:SIDD"):
                     continue
                 file.seek(deseg["DESDATA"].get_offset())
                 xml_bytes = file.read(deseg["DESDATA"].size)
@@ -291,12 +291,12 @@ class SiddConsistency(con.ConsistencyChecker):
             def _de_segment_type(segment):
                 deseg_type = "OTHER"
                 if segment["subheader"]["DESID"].value == "XML_DATA_CONTENT":
-                    if segment["subheader"]["DESSHF"]["DESSHTN"].value.startswith(
-                        "urn:SIDD"
+                    if segment["subheader"]["DESSHTN"].encoded_value.startswith(
+                        b"urn:SIDD"
                     ):
                         deseg_type = "SIDD"
-                    if segment["subheader"]["DESSHF"]["DESSHTN"].value.startswith(
-                        "urn:SICD"
+                    if segment["subheader"]["DESSHTN"].encoded_value.startswith(
+                        b"urn:SICD"
                     ):
                         deseg_type = "SICD"
                     else:
@@ -331,17 +331,17 @@ class SiddConsistency(con.ConsistencyChecker):
                 with self.need("DESVER is 1"):
                     assert subhdr["DESVER"].value == 1
                 with self.need("DESCRC is not used"):
-                    assert subhdr["DESSHF"]["DESCRC"].value == 99999
+                    assert subhdr["DESCRC"].value == 99999
                 with self.need("DESSHFT is XML"):
-                    assert subhdr["DESSHF"]["DESSHFT"].value == "XML"
+                    assert subhdr["DESSHFT"].value == "XML"
                 with self.need("DESSHSI specifies SIDD standard"):
                     expected = (
                         "SIDD Volume 1 Design & Implementation Description Document"
                     )
-                    assert subhdr["DESSHF"]["DESSHSI"].value == expected
+                    assert subhdr["DESSHSI"].value == expected
 
                 actual = {
-                    name: subhdr["DESSHF"][name].value
+                    name: subhdr[name].value
                     for name in ("DESSHSV", "DESSHSD", "DESSHTN")
                 }
 
@@ -366,7 +366,7 @@ class SiddConsistency(con.ConsistencyChecker):
                 def _parse_ll_pair(string):
                     return float(string[:12]), float(string[12:])
 
-                desshlpg = subhdr["DESSHF"]["DESSHLPG"].value
+                desshlpg = subhdr["DESSHLPG"].value
                 actual = [
                     _parse_ll_pair(desshlpg[pair * 25 : (pair + 1) * 25])
                     for pair in range(5)
@@ -388,7 +388,7 @@ class SiddConsistency(con.ConsistencyChecker):
                     assert found, f"{actual=}\n{icp_ll=}"
 
                 with self.need("DESSHLPT is space-filled"):
-                    assert subhdr["DESSHF"]["DESSHLPT"].value == ""
+                    assert subhdr["DESSHLPT"].isnull()
 
     @staticmethod
     def _im_segment_type(segment):

--- a/tests/core/sicd/test_io.py
+++ b/tests/core/sicd/test_io.py
@@ -250,14 +250,12 @@ def test_nitfimagesegmentfields_from_header():
 
 
 def test_nitfdesegmentfields_from_header():
-    header = jbpy.core.DataExtensionSubheader("name")
-    header["DESID"].value = "XML_DATA_CONTENT"
-    header["DESVER"].value = 1
+    header = jbpy.des_subheader_factory("XML_DATA_CONTENT", 1)
     header["DESSHL"].value = 773
-    header["DESSHF"]["DESSHRP"].value = "desshrp"
-    header["DESSHF"]["DESSHLI"].value = "desshli"
-    header["DESSHF"]["DESSHLIN"].value = "desshlin"
-    header["DESSHF"]["DESSHABS"].value = "desshabs"
+    header["DESSHRP"].value = "desshrp"
+    header["DESSHLI"].value = "desshli"
+    header["DESSHLIN"].value = "desshlin"
+    header["DESSHABS"].value = "desshabs"
     # Data is unclassified.  These fields are filled for testing purposes only.
     header["DESCLAS"].value = "T"
     header["DESCLSY"].value = "US"
@@ -277,10 +275,10 @@ def test_nitfdesegmentfields_from_header():
     header["DESCTLN"].value = "ctln_h"
 
     fields = sksicd.NitfDeSubheaderPart._from_header(header)
-    assert fields.desshrp == header["DESSHF"]["DESSHRP"].value
-    assert fields.desshli == header["DESSHF"]["DESSHLI"].value
-    assert fields.desshlin == header["DESSHF"]["DESSHLIN"].value
-    assert fields.desshabs == header["DESSHF"]["DESSHABS"].value
+    assert fields.desshrp == header["DESSHRP"].value
+    assert fields.desshli == header["DESSHLI"].value
+    assert fields.desshlin == header["DESSHLIN"].value
+    assert fields.desshabs == header["DESSHABS"].value
     assert fields.security.clas == header["DESCLAS"].value
     assert fields.security.clsy == header["DESCLSY"].value
     assert fields.security.code == header["DESCODE"].value

--- a/tests/verification/test_sicd_consistency.py
+++ b/tests/verification/test_sicd_consistency.py
@@ -203,7 +203,7 @@ def test_check_des_subheader_desid(example_sicd_file):
 def test_check_des_subheader_desshft(example_sicd_file):
     sicdcon = SicdConsistency.from_file(example_sicd_file)
     des_header = sicdcon.ntf["DataExtensionSegments"][0]["subheader"]
-    des_header["DESSHF"]["DESSHFT"].value = "LXM"
+    des_header["DESSHFT"].value = "LXM"
 
     sicdcon.check("check_des_subheader")
     testing.assert_failures(sicdcon, "DESSHFT == XML")
@@ -212,7 +212,7 @@ def test_check_des_subheader_desshft(example_sicd_file):
 def test_check_des_subheader_desshsi(example_sicd_file):
     sicdcon = SicdConsistency.from_file(example_sicd_file)
     des_header = sicdcon.ntf["DataExtensionSegments"][0]["subheader"]
-    des_header["DESSHF"]["DESSHSI"].value = "SICD Volume 20"
+    des_header["DESSHSI"].value = "SICD Volume 20"
 
     sicdcon.check("check_des_subheader")
     testing.assert_failures(sicdcon, "DESSHSI == SICD Volume 1...")
@@ -221,7 +221,7 @@ def test_check_des_subheader_desshsi(example_sicd_file):
 def test_check_des_subheader_desshtn(example_sicd_file):
     sicdcon = SicdConsistency.from_file(example_sicd_file)
     des_header = sicdcon.ntf["DataExtensionSegments"][0]["subheader"]
-    des_header["DESSHF"]["DESSHTN"].value = "urn:SICD:10.20.10"
+    des_header["DESSHTN"].value = "urn:SICD:10.20.10"
 
     sicdcon.check("check_des_subheader")
     testing.assert_failures(sicdcon, "Consistent namespace")
@@ -230,7 +230,7 @@ def test_check_des_subheader_desshtn(example_sicd_file):
 def test_check_des_subheader_desshlpg(example_sicd_file):
     sicdcon = SicdConsistency.from_file(example_sicd_file)
     des_header = sicdcon.ntf["DataExtensionSegments"][0]["subheader"]
-    des_header["DESSHF"]["DESSHLPG"].value = "badcorners"
+    des_header["DESSHLPG"].value = "badcorners"
 
     sicdcon.check("check_des_subheader")
     testing.assert_failures(sicdcon, "DESSHLPG consistent with image corners")


### PR DESCRIPTION
# Description
This PR updates `jbpy` to v0.5.1. Three major changes are accommodated:

1. `DataExtensionSubheader` user-defined fields are no longer subfields a `DESSHF` field
1. creating a `DataExtensionSubheader` is now best done with a factory method (`jbpy.des_subheader_factory`)
1. Some fields of the `XML_DATA_CONTENT` DES subheader are nullable