### PR TITLE
Additional ElementWrapper error checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Option to use SIDD v1.0/2.0 image angle convention in `sarkit.sidd.compute_angles`
 - Support for Python 3.14
 - `sarkit.wgs84.GM` constant
+- Additional error checking in Transcoders and ElementWrappers
 
 ### Changed
 - `jbpy` dependency updated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ test = [
     "nox>=2024.3.2",
 ]
 doc = [
-    "sphinx>=7.2.6",
+    "sphinx>=7.2.6,<9",  # v9 broke some autodoc features
     "numpydoc>=1.7.0",
     "sphinx-rtd-theme>=2.0.0",
     "sphinxcontrib-autoprogram>=0.1.9",

--- a/sarkit/sicd/_xml.py
+++ b/sarkit/sicd/_xml.py
@@ -153,6 +153,7 @@ class ImageCornersType(skxt.NdArrayType):
                 elem, ns + self.sub_tag, attrib={"index": label}
             )
             self.sub_type.set_elem(icp, coord)
+        self.parse_elem(elem)  # make sure result is parsable
 
 
 class XmlHelper(skxml.XmlHelper):

--- a/sarkit/sidd/_xml.py
+++ b/sarkit/sidd/_xml.py
@@ -214,6 +214,7 @@ class FilterCoefficientType(skxt.Type):
                 self.coef_y_name: str(coord[1]),
             }
             lxml.etree.SubElement(elem, ns + "Coef", attrib=attribs).text = str(coef)
+        self.parse_elem(elem)  # make sure result is parsable
 
 
 class IntListType(skxt.Type):
@@ -232,6 +233,7 @@ class IntListType(skxt.Type):
     ) -> None:
         """Sets ``elem`` node using the list of integers in ``val``."""
         elem.text = " ".join([str(entry) for entry in val])
+        self.parse_elem(elem)  # make sure result is parsable
 
 
 class LookupTableType(IntListType):
@@ -244,6 +246,7 @@ class LookupTableType(IntListType):
     ) -> None:
         super().set_elem(elem, val)
         elem.set("size", str(len(val)))
+        self.parse_elem(elem)  # make sure result is parsable
 
 
 class Lookup3TableType(skxt.Type):
@@ -266,6 +269,7 @@ class Lookup3TableType(skxt.Type):
         """Sets ``elem`` node using the sequence of integer-triplets in ``val``."""
         elem.text = " ".join(",".join(str(x) for x in triplet) for triplet in val)
         elem.set("size", str(len(val)))
+        self.parse_elem(elem)  # make sure result is parsable
 
 
 class ImageCornersType(skxt.NdArrayType):
@@ -321,6 +325,7 @@ class ImageCornersType(skxt.NdArrayType):
                 elem, icp_ns + self.sub_tag, attrib={"index": label}
             )
             self.sub_type.set_elem(icp, coord)
+        self.parse_elem(elem)  # make sure result is parsable
 
 
 class RangeAzimuthType(skxt.ArrayType):
@@ -428,6 +433,7 @@ class LUTInfoType(skxt.Type):
             subelem = lxml.etree.SubElement(elem, ns + "LUTValues")
             IntListType().set_elem(subelem, sub_val)
             subelem.set("lut", str(index + 1))
+        self.parse_elem(elem)  # make sure result is parsable
 
 
 class XmlHelper(skxml.XmlHelper):

--- a/sarkit/xmlhelp/_core.py
+++ b/sarkit/xmlhelp/_core.py
@@ -301,7 +301,9 @@ class ElementWrapper(collections.abc.MutableMapping):
             if isinstance(val, ElementWrapper):
                 return val.elem
             if transcoder is None:
-                return lxml.etree.Element(childdef.tag)
+                raise ValueError(
+                    f"can't initialize {childdef.tag} with value of '{val}'"
+                )
             return transcoder.make_elem(childdef.tag, val)
 
         for subelem in self.elem.findall("{*}" + localname):

--- a/tests/core/xmlhelp/test_core.py
+++ b/tests/core/xmlhelp/test_core.py
@@ -130,6 +130,18 @@ def test_elementwrapper():
         is None
     )
 
+    # repeatable fields must be initialized with a list
+    with pytest.raises(ValueError):
+        wrapped_siddroot["ExploitationFeatures"]["Product"] = {"North": 1}
+    wrapped_siddroot["ExploitationFeatures"]["Product"] = [{"North": 1}]
+
+    # primitive types can only be set with compatable types
+    assert isinstance(
+        wrapped_siddroot["ExploitationFeatures"]["Product"][0]["North"], float
+    )
+    with pytest.raises(ValueError):
+        wrapped_siddroot["ExploitationFeatures"]["Product"][0]["North"] = "string"
+
 
 def test_elementwrapper_tofromdict():
     root_ns = "urn:SIDD:3.0.0"


### PR DESCRIPTION
This adds additional error checking to the ElementWrappers and Transcoders to catch some common mistakes.

1. Repeatable nodes must now be set using an iterable of compatible types.
    * Passing a dictionary to an element expecting a list now raises an error.
    
        Previously this would silently fail (Collection expects a list):

        ```python
        ew["ExploitationFeatures"]["Collection"] = {"Information": {"SensorName": "sensor"}}
        ```

        resulting in:
        ```xml
        <ns0:SIDD xmlns:ns0="urn:SIDD:3.0.0">
          <ns0:ExploitationFeatures>
            <ns0:Collection/>
          </ns0:ExploitationFeatures>
        </ns0:SIDD>
        ```
        Now it results in a `ValueError`:
    
        ```
        ValueError: can't initialize {urn:SIDD:3.0.0}Collection with value of 'Information'
        ```

1. Transcoders now can only be set to values that can be parsed.
    * For example, previously it was possible to set a float field to a string.  Now that will raise an error.
        ```
        >>> ew["ErrorStatistics"]["CompositeSCP"]["Rg"] = 'not a number'
        ValueError: could not convert string to float: 'not a number'
        ```