### PR TITLE
Prepare v1.4.0 release

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,6 @@ jobs:
       uses: pdm-project/setup-pdm@v4
       with:
         python-version: 3.14
-        version: 2.26.2
     - name: Install dependencies
       run: |
         pdm lock -G :all
@@ -53,7 +52,6 @@ jobs:
       uses: pdm-project/setup-pdm@v4
       with:
         python-version: 3.11
-        version: 2.26.2
     - name: Install dependencies
       run: |
         pdm lock -G :all --strategy direct_minimal_versions
@@ -78,7 +76,6 @@ jobs:
       uses: pdm-project/setup-pdm@v4
       with:
         python-version: 3.14
-        version: 2.26.2
     - name: Install dependencies
       run: |
         pdm lock -G :all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [1.4.0] - 2026-01-26
+
 ### Added
 - Option to use SIDD v1.0/2.0 image angle convention in `sarkit.sidd.compute_angles`
 - Support for Python 3.14
@@ -208,7 +211,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Limited SICD Reading and Writing
 - Limited SIDD NITF Reading and Writing
 
-[unreleased]: https://github.com/ValkyrieSystems/sarkit/compare/v1.3.0...HEAD
+[unreleased]: https://github.com/ValkyrieSystems/sarkit/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/ValkyrieSystems/sarkit/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/ValkyrieSystems/sarkit/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/ValkyrieSystems/sarkit/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/ValkyrieSystems/sarkit/compare/v1.0.1...v1.1.0


### PR DESCRIPTION
# Description
This PR updates the CHANGELOG in advance of a v1.4.0 release.

Additionally, the PDM pinning from #102 is being removed as the [underlying issue has theoretically been resolved](https://github.com/pdm-project/pdm/issues/3724#issuecomment-3775859817).