### PR TITLE
Remove extraneous packages from test_core nox session env

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -15,7 +15,7 @@ nox.options.sessions = (
 
 @nox.session
 def docs(session):
-    session.run_install("pdm", "sync", "-G", "all", "-G", "doc", external=True)
+    session.run_install("pdm", "sync", "-G", "doc", external=True)
     session.run(
         "sphinx-build",
         "docs/source",
@@ -45,7 +45,7 @@ def format(session):
 
 @nox.session
 def lint(session):
-    session.run_install("pdm", "sync", "-G", "dev-lint", "-G", "all", external=True)
+    session.run_install("pdm", "sync", "-G", "dev-lint", external=True)
     session.run("ruff", "check")
     session.run(
         "ruff",
@@ -63,7 +63,7 @@ def test(session):
 
 @nox.session
 def test_core(session):
-    session.run_install("pdm", "sync", external=True)
+    session.run_install("pdm", "sync", "-G", "dev-test", external=True)
     session.run("pytest", "tests/core", "tests/verification")
 
 


### PR DESCRIPTION
# Description
While looking at some of the CI logs, I noticed that the `test_core` nox session was [installing `sphinx`](https://github.com/ValkyrieSystems/sarkit/actions/runs/21372445159/job/61520238184#step:5:77) (and other things) unnecessarily/unexpectedly. It looks like in #95, we inadvertently removed the `dev-test` specifier and are accidentally [installing ALL dependency groups](https://pdm-project.org/en/latest/usage/dependency/#select-a-subset-of-dependency-groups-to-install) during this stage. This PR restores it.

In addition, this PR removes two vestigial uses of the `all` group which is now empty.