### PR TITLE
Prepare v1.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+## [1.4.1] - 2026-02-06
+
+### Added
+- Extended `jbpy` version compatibility
+
+
 ## [1.4.0] - 2026-01-26
 
 ### Added
@@ -211,7 +217,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Limited SICD Reading and Writing
 - Limited SIDD NITF Reading and Writing
 
-[unreleased]: https://github.com/ValkyrieSystems/sarkit/compare/v1.4.0...HEAD
+[unreleased]: https://github.com/ValkyrieSystems/sarkit/compare/v1.4.1...HEAD
+[1.4.1]: https://github.com/ValkyrieSystems/sarkit/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/ValkyrieSystems/sarkit/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/ValkyrieSystems/sarkit/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/ValkyrieSystems/sarkit/compare/v1.1.0...v1.2.0


### PR DESCRIPTION
# Description
This PR prepares a  patch release (v1.4.1) to extend `jbpy` compatibility to include the newly-released `v0.6.0`