### PR TITLE
CPHD: additional consistency checks for fields added in v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Additional CPHD consistency checks for optional antenna fields introduced in v1.1.0
+
 
 ## [1.6.0] - 2026-03-30
 

--- a/data/example-cphd-1.1.0.xml
+++ b/data/example-cphd-1.1.0.xml
@@ -1,9 +1,8 @@
-<CPHD xmlns="http://api.nsgreg.nga.mil/schema/cphd/1.0.1">
+<CPHD xmlns="http://api.nsgreg.nga.mil/schema/cphd/1.1.0">
   <CollectionID>
-    <CollectorName>SyntheticCollector</CollectorName>
-    <IlluminatorName>SyntheticIlluminator</IlluminatorName>
+    <CollectorName>Synthetic</CollectorName>
     <CoreName>SyntheticCore</CoreName>
-    <CollectType>BISTATIC</CollectType>
+    <CollectType>MONOSTATIC</CollectType>
     <RadarMode>
       <ModeType>SPOTLIGHT</ModeType>
     </RadarMode>
@@ -14,17 +13,17 @@
     <DomainType>FX</DomainType>
     <SGN>-1</SGN>
     <Timeline>
-      <CollectionStart>2026-03-31T17:16:19Z</CollectionStart>
+      <CollectionStart>2022-12-05T18:41:24.051402Z</CollectionStart>
       <TxTime1>0.0</TxTime1>
-      <TxTime2>0.9411737916915772</TxTime2>
+      <TxTime2>3.4554951665729656</TxTime2>
     </Timeline>
     <FxBand>
-      <FxMin>7957112451.471448</FxMin>
-      <FxMax>8042887548.528551</FxMax>
+      <FxMin>9933296178.095</FxMin>
+      <FxMax>10066703821.904999</FxMax>
     </FxBand>
     <TOASwath>
-      <TOAMin>-1.628324838674996e-06</TOAMin>
-      <TOAMax>1.628324838674996e-06</TOAMax>
+      <TOAMin>-2.933147262895803e-06</TOAMin>
+      <TOAMax>2.933147262895803e-06</TOAMax>
     </TOASwath>
     <TropoParameters>
       <N0>320.3</N0>
@@ -35,179 +34,129 @@
     <EarthModel>WGS_84</EarthModel>
     <IARP>
       <ECF>
-        <X>-2505550.4775087754</X>
-        <Y>-4659700.31181321</Y>
-        <Z>3550427.2120698043</Z>
+        <X>6378137.0</X>
+        <Y>0.0</Y>
+        <Z>0.0</Z>
       </ECF>
       <LLH>
-        <Lat>34.043085000000005</Lat>
-        <Lon>-118.267202</Lon>
-        <HAE>35.0</HAE>
+        <Lat>0.0</Lat>
+        <Lon>0.0</Lon>
+        <HAE>0.0</HAE>
       </LLH>
     </IARP>
     <ReferenceSurface>
       <Planar>
         <uIAX>
-          <X>0.0922974580898881</X>
-          <Y>0.5743207475170493</Y>
-          <Z>0.8134106332436204</Z>
+          <X>0.0</X>
+          <Y>-0.17364817766693033</Y>
+          <Z>-0.9848077530122081</Z>
         </uIAX>
         <uIAY>
-          <X>-0.9151436500251293</X>
-          <Y>0.37086802534759045</Y>
-          <Z>-0.15801584534347057</Z>
+          <X>0.0</X>
+          <Y>0.9848077530122081</Y>
+          <Z>-0.17364817766693033</Z>
         </uIAY>
       </Planar>
     </ReferenceSurface>
     <ImageArea>
       <X1Y1>
-        <X>-375.0</X>
-        <Y>-750.0</Y>
+        <X>-500.0</X>
+        <Y>-500.0</Y>
       </X1Y1>
       <X2Y2>
-        <X>375.0</X>
-        <Y>750.0</Y>
+        <X>500.0</X>
+        <Y>500.0</Y>
       </X2Y2>
       <Polygon size="4">
         <Vertex index="1">
-          <X>-375.0</X>
-          <Y>-750.0</Y>
+          <X>-500.0</X>
+          <Y>-500.0</Y>
         </Vertex>
         <Vertex index="2">
-          <X>-375.0</X>
-          <Y>750.0</Y>
+          <X>-500.0</X>
+          <Y>500.0</Y>
         </Vertex>
         <Vertex index="3">
-          <X>375.0</X>
-          <Y>750.0</Y>
+          <X>500.0</X>
+          <Y>500.0</Y>
         </Vertex>
         <Vertex index="4">
-          <X>375.0</X>
-          <Y>-750.0</Y>
+          <X>500.0</X>
+          <Y>-500.0</Y>
         </Vertex>
       </Polygon>
     </ImageArea>
     <ImageAreaCornerPoints>
       <IACP index="1">
-        <Lat>34.04105541648031</Lat>
-        <Lon>-118.25845453209043</Lon>
+        <Lat>0.00523836089566673</Lat>
+        <Lon>-0.003643385217052057</Lon>
       </IACP>
       <IACP index="2">
-        <Lat>34.03847674026072</Lat>
-        <Lon>-118.2744003820634</Lon>
+        <Lat>0.003667939784508838</Lat>
+        <Lon>0.0052032933282355155</Lon>
       </IACP>
       <IACP index="3">
-        <Lat>34.04511396045249</Lat>
-        <Lon>-118.27594988461296</Lon>
+        <Lat>-0.00523836089566673</Lat>
+        <Lon>0.003643385217052057</Lon>
       </IACP>
       <IACP index="4">
-        <Lat>34.04769283477876</Lat>
-        <Lon>-118.26000283923808</Lon>
+        <Lat>-0.003667939784508838</Lat>
+        <Lon>-0.0052032933282355155</Lon>
       </IACP>
     </ImageAreaCornerPoints>
+    <ExtendedArea>
+      <X1Y1>
+        <X>-1500.0</X>
+        <Y>-1500.0</Y>
+      </X1Y1>
+      <X2Y2>
+        <X>1500.0</X>
+        <Y>1500.0</Y>
+      </X2Y2>
+      <Polygon size="4">
+        <Vertex index="1">
+          <X>-1500.0</X>
+          <Y>-1500.0</Y>
+        </Vertex>
+        <Vertex index="2">
+          <X>-1500.0</X>
+          <Y>1500.0</Y>
+        </Vertex>
+        <Vertex index="3">
+          <X>1500.0</X>
+          <Y>1500.0</Y>
+        </Vertex>
+        <Vertex index="4">
+          <X>1500.0</X>
+          <Y>-1500.0</Y>
+        </Vertex>
+      </Polygon>
+    </ExtendedArea>
     <ImageGrid>
       <IARPLocation>
-        <Line>229.0</Line>
-        <Sample>469.0</Sample>
+        <Line>650.0</Line>
+        <Sample>750.0</Sample>
       </IARPLocation>
       <IAXExtent>
-        <LineSpacing>1.6345857121693614</LineSpacing>
+        <LineSpacing>0.7698004349651958</LineSpacing>
         <FirstLine>0</FirstLine>
-        <NumLines>459</NumLines>
+        <NumLines>1301</NumLines>
       </IAXExtent>
       <IAYExtent>
-        <SampleSpacing>1.6006554269427937</SampleSpacing>
+        <SampleSpacing>0.6664110897495725</SampleSpacing>
         <FirstSample>0</FirstSample>
-        <NumSamples>939</NumSamples>
+        <NumSamples>1501</NumSamples>
       </IAYExtent>
-      <SegmentList>
-        <NumSegments>3</NumSegments>
-        <Segment>
-          <Identifier>Segment_0000_0000</Identifier>
-          <StartLine>0</StartLine>
-          <StartSample>0</StartSample>
-          <EndLine>152</EndLine>
-          <EndSample>938</EndSample>
-          <SegmentPolygon size="4">
-            <SV index="1">
-              <Line>0.0</Line>
-              <Sample>938.0</Sample>
-            </SV>
-            <SV index="2">
-              <Line>152.0</Line>
-              <Sample>938.0</Sample>
-            </SV>
-            <SV index="3">
-              <Line>152.0</Line>
-              <Sample>0.0</Sample>
-            </SV>
-            <SV index="4">
-              <Line>0.0</Line>
-              <Sample>0.0</Sample>
-            </SV>
-          </SegmentPolygon>
-        </Segment>
-        <Segment>
-          <Identifier>Segment_0001_0000</Identifier>
-          <StartLine>153</StartLine>
-          <StartSample>0</StartSample>
-          <EndLine>305</EndLine>
-          <EndSample>938</EndSample>
-          <SegmentPolygon size="4">
-            <SV index="1">
-              <Line>153.0</Line>
-              <Sample>938.0</Sample>
-            </SV>
-            <SV index="2">
-              <Line>305.0</Line>
-              <Sample>938.0</Sample>
-            </SV>
-            <SV index="3">
-              <Line>305.0</Line>
-              <Sample>0.0</Sample>
-            </SV>
-            <SV index="4">
-              <Line>153.0</Line>
-              <Sample>0.0</Sample>
-            </SV>
-          </SegmentPolygon>
-        </Segment>
-        <Segment>
-          <Identifier>Segment_0002_0000</Identifier>
-          <StartLine>306</StartLine>
-          <StartSample>0</StartSample>
-          <EndLine>458</EndLine>
-          <EndSample>938</EndSample>
-          <SegmentPolygon size="4">
-            <SV index="1">
-              <Line>306.0</Line>
-              <Sample>938.0</Sample>
-            </SV>
-            <SV index="2">
-              <Line>458.0</Line>
-              <Sample>938.0</Sample>
-            </SV>
-            <SV index="3">
-              <Line>458.0</Line>
-              <Sample>0.0</Sample>
-            </SV>
-            <SV index="4">
-              <Line>306.0</Line>
-              <Sample>0.0</Sample>
-            </SV>
-          </SegmentPolygon>
-        </Segment>
-      </SegmentList>
     </ImageGrid>
   </SceneCoordinates>
   <Data>
     <SignalArrayFormat>CF8</SignalArrayFormat>
-    <NumBytesPVP>224</NumBytesPVP>
+    <NumBytesPVP>352</NumBytesPVP>
     <NumCPHDChannels>1</NumCPHDChannels>
     <Channel>
       <Identifier>1</Identifier>
-      <NumVectors>1667</NumVectors>
-      <NumSamples>350</NumSamples>
+      <NumVectors>2081</NumVectors>
+      <NumSamples>979</NumSamples>
       <SignalArrayByteOffset>0</SignalArrayByteOffset>
       <PVPArrayByteOffset>0</PVPArrayByteOffset>
     </Channel>
@@ -248,7 +197,7 @@
     <SRPFixedCPHD>true</SRPFixedCPHD>
     <Parameters>
       <Identifier>1</Identifier>
-      <RefVectorIndex>833</RefVectorIndex>
+      <RefVectorIndex>1040</RefVectorIndex>
       <FXFixed>true</FXFixed>
       <TOAFixed>true</TOAFixed>
       <SRPFixed>true</SRPFixed>
@@ -256,39 +205,49 @@
       <Polarization>
         <TxPol>V</TxPol>
         <RcvPol>V</RcvPol>
+        <TxPolRef>
+          <AmpH>0.15595041814031432</AmpH>
+          <AmpV>0.9877648845154707</AmpV>
+          <PhaseV>0.0</PhaseV>
+        </TxPolRef>
+        <RcvPolRef>
+          <AmpH>0.1559148176398521</AmpH>
+          <AmpV>0.9877705045405697</AmpV>
+          <PhaseV>0.0</PhaseV>
+        </RcvPolRef>
       </Polarization>
-      <FxC>8000000000.0</FxC>
-      <FxBW>85775097.05710316</FxBW>
-      <TOASaved>3.256649677349992e-06</TOASaved>
+      <FxC>10000000000.0</FxC>
+      <FxBW>133407643.80999947</FxBW>
+      <TOASaved>5.866294525791606e-06</TOASaved>
       <DwellTimes>
         <CODId>1</CODId>
         <DwellId>1</DwellId>
       </DwellTimes>
       <ImageArea>
         <X1Y1>
-          <X>-375.0</X>
-          <Y>-750.0</Y>
+          <X>-500.0</X>
+          <Y>-500.0</Y>
         </X1Y1>
         <X2Y2>
-          <X>375.0</X>
-          <Y>750.0</Y>
+          <X>500.0</X>
+          <Y>500.0</Y>
         </X2Y2>
         <Polygon size="4">
           <Vertex index="1">
-            <X>-375.0</X>
-            <Y>-750.0</Y>
+            <X>-500.0</X>
+            <Y>-500.0</Y>
           </Vertex>
           <Vertex index="2">
-            <X>-375.0</X>
-            <Y>750.0</Y>
+            <X>-500.0</X>
+            <Y>500.0</Y>
           </Vertex>
           <Vertex index="3">
-            <X>375.0</X>
-            <Y>750.0</Y>
+            <X>500.0</X>
+            <Y>500.0</Y>
           </Vertex>
           <Vertex index="4">
-            <X>375.0</X>
-            <Y>-750.0</Y>
+            <X>500.0</X>
+            <Y>-500.0</Y>
           </Vertex>
         </Polygon>
       </ImageArea>
@@ -303,11 +262,21 @@
         <RcvId>rcv_id#1</RcvId>
       </TxRcv>
       <TgtRefLevel>
-        <PTRef>0.999961256980896</PTRef>
+        <PTRef>1.0001673698425293</PTRef>
       </TgtRefLevel>
       <NoiseLevel>
         <PNRef>1.0</PNRef>
         <BNRef>1.0</BNRef>
+        <FxNoiseProfile>
+          <Point>
+            <Fx>1.0</Fx>
+            <PN>2.0</PN>
+          </Point>
+          <Point>
+            <Fx>3.0</Fx>
+            <PN>.0</PN>
+          </Point>
+        </FxNoiseProfile>
       </NoiseLevel>
     </Parameters>
   </Channel>
@@ -328,17 +297,17 @@
       <Format>X=F8;Y=F8;Z=F8;</Format>
     </TxVel>
     <RcvTime>
-      <Offset>16</Offset>
+      <Offset>24</Offset>
       <Size>1</Size>
       <Format>F8</Format>
     </RcvTime>
     <RcvPos>
-      <Offset>17</Offset>
+      <Offset>25</Offset>
       <Size>3</Size>
       <Format>X=F8;Y=F8;Z=F8;</Format>
     </RcvPos>
     <RcvVel>
-      <Offset>20</Offset>
+      <Offset>28</Offset>
       <Size>3</Size>
       <Format>X=F8;Y=F8;Z=F8;</Format>
     </RcvVel>
@@ -348,17 +317,17 @@
       <Format>X=F8;Y=F8;Z=F8;</Format>
     </SRPPos>
     <aFDOP>
-      <Offset>24</Offset>
+      <Offset>32</Offset>
       <Size>1</Size>
       <Format>F8</Format>
     </aFDOP>
     <aFRR1>
-      <Offset>25</Offset>
+      <Offset>33</Offset>
       <Size>1</Size>
       <Format>F8</Format>
     </aFRR1>
     <aFRR2>
-      <Offset>26</Offset>
+      <Offset>34</Offset>
       <Size>1</Size>
       <Format>F8</Format>
     </aFRR2>
@@ -383,7 +352,7 @@
       <Format>F8</Format>
     </TOA2>
     <TDTropoSRP>
-      <Offset>23</Offset>
+      <Offset>31</Offset>
       <Size>1</Size>
       <Format>F8</Format>
     </TDTropoSRP>
@@ -398,19 +367,53 @@
       <Format>F8</Format>
     </SCSS>
     <SIGNAL>
-      <Offset>27</Offset>
+      <Offset>35</Offset>
       <Size>1</Size>
       <Format>I8</Format>
     </SIGNAL>
+    <TxAntenna>
+      <TxACX>
+        <Offset>16</Offset>
+        <Size>3</Size>
+        <Format>X=F8;Y=F8;Z=F8;</Format>
+      </TxACX>
+      <TxACY>
+        <Offset>19</Offset>
+        <Size>3</Size>
+        <Format>X=F8;Y=F8;Z=F8;</Format>
+      </TxACY>
+      <TxEB>
+        <Offset>22</Offset>
+        <Size>2</Size>
+        <Format>DCX=F8;DCY=F8;</Format>
+      </TxEB>
+    </TxAntenna>
+    <RcvAntenna>
+      <RcvACX>
+        <Offset>36</Offset>
+        <Size>3</Size>
+        <Format>X=F8;Y=F8;Z=F8;</Format>
+      </RcvACX>
+      <RcvACY>
+        <Offset>39</Offset>
+        <Size>3</Size>
+        <Format>X=F8;Y=F8;Z=F8;</Format>
+      </RcvACY>
+      <RcvEB>
+        <Offset>42</Offset>
+        <Size>2</Size>
+        <Format>DCX=F8;DCY=F8;</Format>
+      </RcvEB>
+    </RcvAntenna>
   </PVP>
   <SupportArray>
     <AntGainPhase>
       <Identifier>transmit_array</Identifier>
       <ElementFormat>Gain=F4;Phase=F4;</ElementFormat>
-      <X0>-0.003150531791024802</X0>
-      <Y0>-0.003150531791024802</Y0>
-      <XSS>0.00031505317910248017</XSS>
-      <YSS>0.00031505317910248017</YSS>
+      <X0>-0.0007686867111526051</X0>
+      <Y0>-0.0007686867111526051</Y0>
+      <XSS>7.686867111526052e-05</XSS>
+      <YSS>7.686867111526052e-05</YSS>
     </AntGainPhase>
     <AntGainPhase>
       <Identifier>transmit_element</Identifier>
@@ -423,10 +426,10 @@
     <AntGainPhase>
       <Identifier>receive_array</Identifier>
       <ElementFormat>Gain=F4;Phase=F4;</ElementFormat>
-      <X0>-0.0033901726285369828</X0>
-      <Y0>-0.0033901726285369828</Y0>
-      <XSS>0.0003390172628536983</XSS>
-      <YSS>0.0003390172628536983</YSS>
+      <X0>-0.0007686867111526051</X0>
+      <Y0>-0.0007686867111526051</Y0>
+      <XSS>7.686867111526052e-05</XSS>
+      <YSS>7.686867111526052e-05</YSS>
     </AntGainPhase>
     <AntGainPhase>
       <Identifier>receive_element</Identifier>
@@ -442,23 +445,23 @@
     <CODTime>
       <Identifier>1</Identifier>
       <CODTimePoly order1="0" order2="0">
-        <Coef exponent1="0" exponent2="0">0.42063913243504203</Coef>
+        <Coef exponent1="0" exponent2="0">1.6781983940603595</Coef>
       </CODTimePoly>
     </CODTime>
     <NumDwellTimes>1</NumDwellTimes>
     <DwellTime>
       <Identifier>1</Identifier>
       <DwellTimePoly order1="0" order2="0">
-        <Coef exponent1="0" exponent2="0">0.6412791563731501</Coef>
+        <Coef exponent1="0" exponent2="0">3.156398206329848</Coef>
       </DwellTimePoly>
     </DwellTime>
   </Dwell>
   <ReferenceGeometry>
     <SRP>
       <ECF>
-        <X>-2505550.4775087754</X>
-        <Y>-4659700.31181321</Y>
-        <Z>3550427.2120698043</Z>
+        <X>6378137.0</X>
+        <Y>0.0</Y>
+        <Z>0.0</Z>
       </ECF>
       <IAC>
         <X>0.0</X>
@@ -466,59 +469,31 @@
         <Z>0.0</Z>
       </IAC>
     </SRP>
-    <ReferenceTime>0.4726434211577197</ReferenceTime>
-    <SRPCODTime>0.42063913243504203</SRPCODTime>
-    <SRPDwellTime>0.6412791563731501</SRPDwellTime>
-    <Bistatic>
-      <AzimuthAngle>168.9553649370711</AzimuthAngle>
-      <AzimuthAngleRate>-0.9829228838479771</AzimuthAngleRate>
-      <BistaticAngle>27.134278307960717</BistaticAngle>
-      <BistaticAngleRate>-0.1505089314231526</BistaticAngleRate>
-      <GrazeAngle>49.26267390494474</GrazeAngle>
-      <TwistAngle>-2.896515936363246</TwistAngle>
-      <SlopeAngle>49.32568838706529</SlopeAngle>
-      <LayoverAngle>172.77568013789437</LayoverAngle>
-      <TxPlatform>
-        <Time>0.4705868958457886</Time>
-        <Pos>
-          <X>-2584442.3830194646</X>
-          <Y>-5267302.919543751</Y>
-          <Z>3481862.0320100184</Z>
-        </Pos>
-        <Vel>
-          <X>6116.066383763933</X>
-          <Y>31.002674710486488</Y>
-          <Z>4586.566085063514</Z>
-        </Vel>
-        <SideOfTrack>L</SideOfTrack>
-        <SlantRange>616527.408630542</SlantRange>
-        <GroundRange>406256.4918927849</GroundRange>
-        <DopplerConeAngle>80.0324054698787</DopplerConeAngle>
-        <GrazeAngle>45.00715170562433</GrazeAngle>
-        <IncidenceAngle>44.99284829437567</IncidenceAngle>
-        <AzimuthAngle>149.95159171545907</AzimuthAngle>
-      </TxPlatform>
-      <RcvPlatform>
-        <Time>0.47455935606008914</Time>
-        <Pos>
-          <X>-2830760.0320586013</X>
-          <Y>-5129927.225490715</Y>
-          <Z>3495314.3390491814</Z>
-        </Pos>
-        <Vel>
-          <X>5139.221547825472</X>
-          <Y>-4837.554748010545</Y>
-          <Z>-2937.7993559739416</Z>
-        </Vel>
-        <SideOfTrack>L</SideOfTrack>
-        <SlantRange>574379.6945312008</SlantRange>
-        <GroundRange>343772.7632838354</GroundRange>
-        <DopplerConeAngle>100.03756148701356</DopplerConeAngle>
-        <GrazeAngle>49.99042219492481</GrazeAngle>
-        <IncidenceAngle>40.00957780507519</IncidenceAngle>
-        <AzimuthAngle>189.93879140949124</AzimuthAngle>
-      </RcvPlatform>
-    </Bistatic>
+    <ReferenceTime>1.7334217951373574</ReferenceTime>
+    <SRPCODTime>1.6781983940603595</SRPCODTime>
+    <SRPDwellTime>3.156398206329848</SRPDwellTime>
+    <Monostatic>
+      <ARPPos>
+        <X>7228728.214968013</X>
+        <Y>255419.41247283682</Y>
+        <Z>1450830.0590822883</Z>
+      </ARPPos>
+      <ARPVel>
+        <X>340.088818546394</X>
+        <Y>-7332.832996723746</Y>
+        <Z>-403.588079745125</Z>
+      </ARPVel>
+      <SideOfTrack>L</SideOfTrack>
+      <SlantRange>1701073.881871521</SlantRange>
+      <GroundRange>1282241.7333399511</GroundRange>
+      <DopplerConeAngle>80.01129358437885</DopplerConeAngle>
+      <GrazeAngle>30.002110889655366</GrazeAngle>
+      <IncidenceAngle>59.99788911034463</IncidenceAngle>
+      <AzimuthAngle>9.984637878914404</AzimuthAngle>
+      <TwistAngle>8.97088903146688</TwistAngle>
+      <SlopeAngle>31.19452907650451</SlopeAngle>
+      <LayoverAngle>352.4633580087539</LayoverAngle>
+    </Monostatic>
   </ReferenceGeometry>
   <Antenna>
     <NumACFs>2</NumACFs>
@@ -528,54 +503,54 @@
       <Identifier>transmit</Identifier>
       <XAxisPoly>
         <X order1="5">
-          <Coef exponent1="0">0.7888410615628246</Coef>
-          <Coef exponent1="1">0.0020557559651799397</Coef>
-          <Coef exponent1="2">-5.578477382569012e-05</Coef>
-          <Coef exponent1="3">-3.560387492524295e-07</Coef>
-          <Coef exponent1="4">4.3640050535757796e-09</Coef>
-          <Coef exponent1="5">5.811430093287692e-11</Coef>
+          <Coef exponent1="0">0.1398298626200596</Coef>
+          <Coef exponent1="1">-0.002759434120305412</Coef>
+          <Coef exponent1="2">-2.642141233211328e-06</Coef>
+          <Coef exponent1="3">1.4412928975132546e-08</Coef>
+          <Coef exponent1="4">4.910682797619282e-11</Coef>
+          <Coef exponent1="5">-1.1406011989724555e-13</Coef>
         </X>
         <Y order1="5">
-          <Coef exponent1="0">-0.17474212517728493</Coef>
-          <Coef exponent1="1">0.012009152522968592</Coef>
-          <Coef exponent1="2">3.85979705985416e-05</Coef>
-          <Coef exponent1="3">-7.195547867712815e-07</Coef>
-          <Coef exponent1="4">-6.445513762870639e-09</Coef>
-          <Coef exponent1="5">5.361591800387376e-11</Coef>
+          <Coef exponent1="0">-0.985103968766331</Coef>
+          <Coef exponent1="1">-0.000720229999813326</Coef>
+          <Coef exponent1="2">8.692990993728007e-06</Coef>
+          <Coef exponent1="3">1.74194134614338e-08</Coef>
+          <Coef exponent1="4">-7.019526602081124e-11</Coef>
+          <Coef exponent1="5">-3.138341997107139e-13</Coef>
         </Y>
         <Z order1="5">
-          <Coef exponent1="0">0.5892325256475242</Coef>
-          <Coef exponent1="1">0.0008092562694701483</Coef>
-          <Coef exponent1="2">-4.039216037258948e-05</Coef>
-          <Coef exponent1="3">-2.733050961647074e-07</Coef>
-          <Coef exponent1="4">3.2411835043048667e-09</Coef>
-          <Coef exponent1="5">4.249391313233596e-11</Coef>
+          <Coef exponent1="0">0.10008886172036295</Coef>
+          <Coef exponent1="1">-0.0032336279155612555</Coef>
+          <Coef exponent1="2">-3.6150726160461875e-06</Coef>
+          <Coef exponent1="3">2.4227194540266762e-08</Coef>
+          <Coef exponent1="4">6.853549014106076e-11</Coef>
+          <Coef exponent1="5">-1.9455706113121084e-13</Coef>
         </Z>
       </XAxisPoly>
       <YAxisPoly>
         <X order1="5">
-          <Coef exponent1="0">0.6001460060372003</Coef>
-          <Coef exponent1="1">-0.000579458519200739</Coef>
-          <Coef exponent1="2">-2.046839663112088e-07</Coef>
-          <Coef exponent1="3">3.338204035308585e-09</Coef>
-          <Coef exponent1="4">-4.1270795095821745e-12</Coef>
-          <Coef exponent1="5">1.4981757438512756e-14</Coef>
+          <Coef exponent1="0">-0.8552353560719915</Coef>
+          <Coef exponent1="1">-0.00010473716447760117</Coef>
+          <Coef exponent1="2">1.0612386361416289e-06</Coef>
+          <Coef exponent1="3">1.219198878977556e-10</Coef>
+          <Coef exponent1="4">-6.534256171555903e-13</Coef>
+          <Coef exponent1="5">3.2519400278010645e-16</Coef>
         </X>
         <Y order1="5">
-          <Coef exponent1="0">0.012328528284148365</Coef>
-          <Coef exponent1="1">0.00012836022112771813</Coef>
-          <Coef exponent1="2">-4.532693317101969e-06</Coef>
-          <Coef exponent1="3">-1.3670676544796797e-09</Coef>
-          <Coef exponent1="4">2.298023071483263e-11</Coef>
-          <Coef exponent1="5">3.691350088529422e-14</Coef>
+          <Coef exponent1="0">-0.06921308838843146</Coef>
+          <Coef exponent1="1">0.0007378752611914464</Coef>
+          <Coef exponent1="2">7.399077245060788e-08</Coef>
+          <Coef exponent1="3">-1.0525875572605681e-09</Coef>
+          <Coef exponent1="4">-3.378821622814598e-14</Coef>
+          <Coef exponent1="5">7.62417875002352e-16</Coef>
         </Y>
         <Z order1="5">
-          <Coef exponent1="0">-0.7997954606197403</Coef>
-          <Coef exponent1="1">-0.00043283219321634144</Coef>
-          <Coef exponent1="2">1.1387212265808047e-07</Coef>
-          <Coef exponent1="3">1.8430716109405648e-09</Coef>
-          <Coef exponent1="4">6.450627294362346e-12</Coef>
-          <Coef exponent1="5">4.385140628520597e-14</Coef>
+          <Coef exponent1="0">0.5135971515888192</Coef>
+          <Coef exponent1="1">-7.496984818402987e-05</Coef>
+          <Coef exponent1="2">1.23093518380827e-06</Coef>
+          <Coef exponent1="3">3.5096979204331667e-10</Coef>
+          <Coef exponent1="4">-2.0820927565561895e-12</Coef>
+          <Coef exponent1="5">-5.491378062886501e-16</Coef>
         </Z>
       </YAxisPoly>
     </AntCoordFrame>
@@ -583,54 +558,54 @@
       <Identifier>receive</Identifier>
       <XAxisPoly>
         <X order1="5">
-          <Coef exponent1="0">0.7794513282801113</Coef>
-          <Coef exponent1="1">0.007329785231690633</Coef>
-          <Coef exponent1="2">-8.382044146831157e-05</Coef>
-          <Coef exponent1="3">-2.7473081904434877e-07</Coef>
-          <Coef exponent1="4">1.0856368167470684e-08</Coef>
-          <Coef exponent1="5">-1.6098449928591864e-11</Coef>
+          <Coef exponent1="0">0.1398298626200596</Coef>
+          <Coef exponent1="1">-0.002759434120305412</Coef>
+          <Coef exponent1="2">-2.642141233211328e-06</Coef>
+          <Coef exponent1="3">1.4412928975132546e-08</Coef>
+          <Coef exponent1="4">4.910682797619282e-11</Coef>
+          <Coef exponent1="5">-1.1406011989724555e-13</Coef>
         </X>
         <Y order1="5">
-          <Coef exponent1="0">-0.5028901110335532</Coef>
-          <Coef exponent1="1">0.01090027224949486</Coef>
-          <Coef exponent1="2">2.0439377765715443e-05</Coef>
-          <Coef exponent1="3">-9.987391968762466e-07</Coef>
-          <Coef exponent1="4">1.1585998664882605e-09</Coef>
-          <Coef exponent1="5">1.208449626937155e-10</Coef>
+          <Coef exponent1="0">-0.985103968766331</Coef>
+          <Coef exponent1="1">-0.000720229999813326</Coef>
+          <Coef exponent1="2">8.692990993728007e-06</Coef>
+          <Coef exponent1="3">1.74194134614338e-08</Coef>
+          <Coef exponent1="4">-7.019526602081124e-11</Coef>
+          <Coef exponent1="5">-3.138341997107139e-13</Coef>
         </Y>
         <Z order1="5">
-          <Coef exponent1="0">-0.37357350423581803</Coef>
-          <Coef exponent1="1">0.000619882594392314</Coef>
-          <Coef exponent1="2">2.904449859989372e-05</Coef>
-          <Coef exponent1="3">-2.287894973545195e-07</Coef>
-          <Coef exponent1="4">-2.731671934462511e-09</Coef>
-          <Coef exponent1="5">4.003367067512183e-11</Coef>
+          <Coef exponent1="0">0.10008886172036295</Coef>
+          <Coef exponent1="1">-0.0032336279155612555</Coef>
+          <Coef exponent1="2">-3.6150726160461875e-06</Coef>
+          <Coef exponent1="3">2.4227194540266762e-08</Coef>
+          <Coef exponent1="4">6.853549014106076e-11</Coef>
+          <Coef exponent1="5">-1.9455706113121084e-13</Coef>
         </Z>
       </XAxisPoly>
       <YAxisPoly>
         <X order1="5">
-          <Coef exponent1="0">-0.25758533306987264</Coef>
-          <Coef exponent1="1">-0.0005150118502789343</Coef>
-          <Coef exponent1="2">-2.919437099321424e-06</Coef>
-          <Coef exponent1="3">3.6454988231878407e-09</Coef>
-          <Coef exponent1="4">1.8924810371442558e-11</Coef>
-          <Coef exponent1="5">-3.4260244685182435e-14</Coef>
+          <Coef exponent1="0">-0.8552353560719915</Coef>
+          <Coef exponent1="1">-0.00010473716447760117</Coef>
+          <Coef exponent1="2">1.0612386361416289e-06</Coef>
+          <Coef exponent1="3">1.219198878977556e-10</Coef>
+          <Coef exponent1="4">-6.534256171555903e-13</Coef>
+          <Coef exponent1="5">3.2519400278010645e-16</Coef>
         </X>
         <Y order1="5">
-          <Coef exponent1="0">0.28630922499790407</Coef>
-          <Coef exponent1="1">0.0003322777923065895</Coef>
-          <Coef exponent1="2">-3.2798597942397965e-06</Coef>
-          <Coef exponent1="3">-1.5988572030677872e-09</Coef>
-          <Coef exponent1="4">1.6936017303163103e-11</Coef>
-          <Coef exponent1="5">9.972752557527912e-15</Coef>
+          <Coef exponent1="0">-0.06921308838843146</Coef>
+          <Coef exponent1="1">0.0007378752611914464</Coef>
+          <Coef exponent1="2">7.399077245060788e-08</Coef>
+          <Coef exponent1="3">-1.0525875572605681e-09</Coef>
+          <Coef exponent1="4">-3.378821622814598e-14</Coef>
+          <Coef exponent1="5">7.62417875002352e-16</Coef>
         </Y>
         <Z order1="5">
-          <Coef exponent1="0">-0.9228633831008691</Coef>
-          <Coef exponent1="1">0.0002468336054506791</Coef>
-          <Coef exponent1="2">3.3847202571619725e-08</Coef>
-          <Coef exponent1="3">-1.0561873137616833e-09</Coef>
-          <Coef exponent1="4">7.517716089954157e-12</Coef>
-          <Coef exponent1="5">3.886710354369731e-15</Coef>
+          <Coef exponent1="0">0.5135971515888192</Coef>
+          <Coef exponent1="1">-7.496984818402987e-05</Coef>
+          <Coef exponent1="2">1.23093518380827e-06</Coef>
+          <Coef exponent1="3">3.5096979204331667e-10</Coef>
+          <Coef exponent1="4">-2.0820927565561895e-12</Coef>
+          <Coef exponent1="5">-5.491378062886501e-16</Coef>
         </Z>
       </YAxisPoly>
     </AntCoordFrame>
@@ -654,11 +629,16 @@
     </AntPhaseCenter>
     <AntPattern>
       <Identifier>transmit</Identifier>
-      <FreqZero>8000000000.0</FreqZero>
+      <FreqZero>10000000000.0</FreqZero>
       <MLFreqDilation>false</MLFreqDilation>
       <GainBSPoly order1="0">
         <Coef exponent1="0">0.0</Coef>
       </GainBSPoly>
+      <AntPolRef>
+        <AmpX>0.0</AmpX>
+        <AmpY>1.0</AmpY>
+        <PhaseY>0.0</PhaseY>
+      </AntPolRef>
       <EB>
         <DCXPoly order1="0">
           <Coef exponent1="0">0.0</Coef>
@@ -670,15 +650,15 @@
       <Array>
         <GainPoly order1="8" order2="8">
           <Coef exponent1="0" exponent2="0">0.0</Coef>
-          <Coef exponent1="0" exponent2="1">6.739029013725276e-13</Coef>
-          <Coef exponent1="0" exponent2="2">-1536462.6524849327</Coef>
-          <Coef exponent1="0" exponent2="3">-1.0165188097826342e-06</Coef>
-          <Coef exponent1="0" exponent2="4">-48505289670.759346</Coef>
-          <Coef exponent1="0" exponent2="5">0.18477208190289895</Coef>
-          <Coef exponent1="0" exponent2="6">-888457251560972.4</Coef>
-          <Coef exponent1="0" exponent2="7">6563.484839851887</Coef>
-          <Coef exponent1="0" exponent2="8">-5.5957736958970606e+20</Coef>
-          <Coef exponent1="1" exponent2="0">6.739029013725276e-13</Coef>
+          <Coef exponent1="0" exponent2="1">-4.143077701293506e-12</Coef>
+          <Coef exponent1="0" exponent2="2">-25810177.686242383</Coef>
+          <Coef exponent1="0" exponent2="3">-0.00014382609695309318</Coef>
+          <Coef exponent1="0" exponent2="4">-13687592749336.885</Coef>
+          <Coef exponent1="0" exponent2="5">292.1994786744385</Coef>
+          <Coef exponent1="0" exponent2="6">-4.211564877440521e+18</Coef>
+          <Coef exponent1="0" exponent2="7">-1442527537.8580344</Coef>
+          <Coef exponent1="0" exponent2="8">-4.4559066869820204e+25</Coef>
+          <Coef exponent1="1" exponent2="0">-4.143077701293506e-12</Coef>
           <Coef exponent1="1" exponent2="1">0.0</Coef>
           <Coef exponent1="1" exponent2="2">0.0</Coef>
           <Coef exponent1="1" exponent2="3">0.0</Coef>
@@ -687,7 +667,7 @@
           <Coef exponent1="1" exponent2="6">0.0</Coef>
           <Coef exponent1="1" exponent2="7">0.0</Coef>
           <Coef exponent1="1" exponent2="8">0.0</Coef>
-          <Coef exponent1="2" exponent2="0">-1536462.6524849327</Coef>
+          <Coef exponent1="2" exponent2="0">-25810177.686242383</Coef>
           <Coef exponent1="2" exponent2="1">0.0</Coef>
           <Coef exponent1="2" exponent2="2">0.0</Coef>
           <Coef exponent1="2" exponent2="3">0.0</Coef>
@@ -696,7 +676,7 @@
           <Coef exponent1="2" exponent2="6">0.0</Coef>
           <Coef exponent1="2" exponent2="7">0.0</Coef>
           <Coef exponent1="2" exponent2="8">0.0</Coef>
-          <Coef exponent1="3" exponent2="0">-1.0165188097826342e-06</Coef>
+          <Coef exponent1="3" exponent2="0">-0.00014382609695309318</Coef>
           <Coef exponent1="3" exponent2="1">0.0</Coef>
           <Coef exponent1="3" exponent2="2">0.0</Coef>
           <Coef exponent1="3" exponent2="3">0.0</Coef>
@@ -705,7 +685,7 @@
           <Coef exponent1="3" exponent2="6">0.0</Coef>
           <Coef exponent1="3" exponent2="7">0.0</Coef>
           <Coef exponent1="3" exponent2="8">0.0</Coef>
-          <Coef exponent1="4" exponent2="0">-48505289670.759346</Coef>
+          <Coef exponent1="4" exponent2="0">-13687592749336.885</Coef>
           <Coef exponent1="4" exponent2="1">0.0</Coef>
           <Coef exponent1="4" exponent2="2">0.0</Coef>
           <Coef exponent1="4" exponent2="3">0.0</Coef>
@@ -714,7 +694,7 @@
           <Coef exponent1="4" exponent2="6">0.0</Coef>
           <Coef exponent1="4" exponent2="7">0.0</Coef>
           <Coef exponent1="4" exponent2="8">0.0</Coef>
-          <Coef exponent1="5" exponent2="0">0.18477208190289895</Coef>
+          <Coef exponent1="5" exponent2="0">292.1994786744385</Coef>
           <Coef exponent1="5" exponent2="1">0.0</Coef>
           <Coef exponent1="5" exponent2="2">0.0</Coef>
           <Coef exponent1="5" exponent2="3">0.0</Coef>
@@ -723,7 +703,7 @@
           <Coef exponent1="5" exponent2="6">0.0</Coef>
           <Coef exponent1="5" exponent2="7">0.0</Coef>
           <Coef exponent1="5" exponent2="8">0.0</Coef>
-          <Coef exponent1="6" exponent2="0">-888457251560972.4</Coef>
+          <Coef exponent1="6" exponent2="0">-4.211564877440521e+18</Coef>
           <Coef exponent1="6" exponent2="1">0.0</Coef>
           <Coef exponent1="6" exponent2="2">0.0</Coef>
           <Coef exponent1="6" exponent2="3">0.0</Coef>
@@ -732,7 +712,7 @@
           <Coef exponent1="6" exponent2="6">0.0</Coef>
           <Coef exponent1="6" exponent2="7">0.0</Coef>
           <Coef exponent1="6" exponent2="8">0.0</Coef>
-          <Coef exponent1="7" exponent2="0">6563.484839851887</Coef>
+          <Coef exponent1="7" exponent2="0">-1442527537.8580344</Coef>
           <Coef exponent1="7" exponent2="1">0.0</Coef>
           <Coef exponent1="7" exponent2="2">0.0</Coef>
           <Coef exponent1="7" exponent2="3">0.0</Coef>
@@ -741,7 +721,7 @@
           <Coef exponent1="7" exponent2="6">0.0</Coef>
           <Coef exponent1="7" exponent2="7">0.0</Coef>
           <Coef exponent1="7" exponent2="8">0.0</Coef>
-          <Coef exponent1="8" exponent2="0">-5.5957736958970606e+20</Coef>
+          <Coef exponent1="8" exponent2="0">-4.4559066869820204e+25</Coef>
           <Coef exponent1="8" exponent2="1">0.0</Coef>
           <Coef exponent1="8" exponent2="2">0.0</Coef>
           <Coef exponent1="8" exponent2="3">0.0</Coef>
@@ -754,6 +734,7 @@
         <PhasePoly order1="0" order2="0">
           <Coef exponent1="0" exponent2="0">0.0</Coef>
         </PhasePoly>
+        <AntGPId>transmit_array</AntGPId>
       </Array>
       <Element>
         <GainPoly order1="0" order2="0">
@@ -762,20 +743,26 @@
         <PhasePoly order1="0" order2="0">
           <Coef exponent1="0" exponent2="0">0.0</Coef>
         </PhasePoly>
+        <AntGPId>transmit_element</AntGPId>
       </Element>
       <GainPhaseArray>
-        <Freq>8000000000.0</Freq>
+        <Freq>10000000000.0</Freq>
         <ArrayId>transmit_array</ArrayId>
         <ElementId>transmit_element</ElementId>
       </GainPhaseArray>
     </AntPattern>
     <AntPattern>
       <Identifier>receive</Identifier>
-      <FreqZero>8000000000.0</FreqZero>
+      <FreqZero>10000000000.0</FreqZero>
       <MLFreqDilation>false</MLFreqDilation>
       <GainBSPoly order1="0">
         <Coef exponent1="0">0.0</Coef>
       </GainBSPoly>
+      <AntPolRef>
+        <AmpX>0.0</AmpX>
+        <AmpY>1.0</AmpY>
+        <PhaseY>0.0</PhaseY>
+      </AntPolRef>
       <EB>
         <DCXPoly order1="0">
           <Coef exponent1="0">0.0</Coef>
@@ -787,15 +774,15 @@
       <Array>
         <GainPoly order1="8" order2="8">
           <Coef exponent1="0" exponent2="0">0.0</Coef>
-          <Coef exponent1="0" exponent2="1">-5.323267677938582e-12</Coef>
-          <Coef exponent1="0" exponent2="2">-1326924.19915182</Coef>
-          <Coef exponent1="0" exponent2="3">-1.9969107465396037e-06</Coef>
-          <Coef exponent1="0" exponent2="4">-36177396945.46189</Coef>
-          <Coef exponent1="0" exponent2="5">-0.04757345815600436</Coef>
-          <Coef exponent1="0" exponent2="6">-572280377879537.5</Coef>
-          <Coef exponent1="0" exponent2="7">-31906.261251931344</Coef>
-          <Coef exponent1="0" exponent2="8">-3.112838344667953e+20</Coef>
-          <Coef exponent1="1" exponent2="0">-5.323267677938582e-12</Coef>
+          <Coef exponent1="0" exponent2="1">-4.143077701293506e-12</Coef>
+          <Coef exponent1="0" exponent2="2">-25810177.686242383</Coef>
+          <Coef exponent1="0" exponent2="3">-0.00014382609695309318</Coef>
+          <Coef exponent1="0" exponent2="4">-13687592749336.885</Coef>
+          <Coef exponent1="0" exponent2="5">292.1994786744385</Coef>
+          <Coef exponent1="0" exponent2="6">-4.211564877440521e+18</Coef>
+          <Coef exponent1="0" exponent2="7">-1442527537.8580344</Coef>
+          <Coef exponent1="0" exponent2="8">-4.4559066869820204e+25</Coef>
+          <Coef exponent1="1" exponent2="0">-4.143077701293506e-12</Coef>
           <Coef exponent1="1" exponent2="1">0.0</Coef>
           <Coef exponent1="1" exponent2="2">0.0</Coef>
           <Coef exponent1="1" exponent2="3">0.0</Coef>
@@ -804,7 +791,7 @@
           <Coef exponent1="1" exponent2="6">0.0</Coef>
           <Coef exponent1="1" exponent2="7">0.0</Coef>
           <Coef exponent1="1" exponent2="8">0.0</Coef>
-          <Coef exponent1="2" exponent2="0">-1326924.19915182</Coef>
+          <Coef exponent1="2" exponent2="0">-25810177.686242383</Coef>
           <Coef exponent1="2" exponent2="1">0.0</Coef>
           <Coef exponent1="2" exponent2="2">0.0</Coef>
           <Coef exponent1="2" exponent2="3">0.0</Coef>
@@ -813,7 +800,7 @@
           <Coef exponent1="2" exponent2="6">0.0</Coef>
           <Coef exponent1="2" exponent2="7">0.0</Coef>
           <Coef exponent1="2" exponent2="8">0.0</Coef>
-          <Coef exponent1="3" exponent2="0">-1.9969107465396037e-06</Coef>
+          <Coef exponent1="3" exponent2="0">-0.00014382609695309318</Coef>
           <Coef exponent1="3" exponent2="1">0.0</Coef>
           <Coef exponent1="3" exponent2="2">0.0</Coef>
           <Coef exponent1="3" exponent2="3">0.0</Coef>
@@ -822,7 +809,7 @@
           <Coef exponent1="3" exponent2="6">0.0</Coef>
           <Coef exponent1="3" exponent2="7">0.0</Coef>
           <Coef exponent1="3" exponent2="8">0.0</Coef>
-          <Coef exponent1="4" exponent2="0">-36177396945.46189</Coef>
+          <Coef exponent1="4" exponent2="0">-13687592749336.885</Coef>
           <Coef exponent1="4" exponent2="1">0.0</Coef>
           <Coef exponent1="4" exponent2="2">0.0</Coef>
           <Coef exponent1="4" exponent2="3">0.0</Coef>
@@ -831,7 +818,7 @@
           <Coef exponent1="4" exponent2="6">0.0</Coef>
           <Coef exponent1="4" exponent2="7">0.0</Coef>
           <Coef exponent1="4" exponent2="8">0.0</Coef>
-          <Coef exponent1="5" exponent2="0">-0.04757345815600436</Coef>
+          <Coef exponent1="5" exponent2="0">292.1994786744385</Coef>
           <Coef exponent1="5" exponent2="1">0.0</Coef>
           <Coef exponent1="5" exponent2="2">0.0</Coef>
           <Coef exponent1="5" exponent2="3">0.0</Coef>
@@ -840,7 +827,7 @@
           <Coef exponent1="5" exponent2="6">0.0</Coef>
           <Coef exponent1="5" exponent2="7">0.0</Coef>
           <Coef exponent1="5" exponent2="8">0.0</Coef>
-          <Coef exponent1="6" exponent2="0">-572280377879537.5</Coef>
+          <Coef exponent1="6" exponent2="0">-4.211564877440521e+18</Coef>
           <Coef exponent1="6" exponent2="1">0.0</Coef>
           <Coef exponent1="6" exponent2="2">0.0</Coef>
           <Coef exponent1="6" exponent2="3">0.0</Coef>
@@ -849,7 +836,7 @@
           <Coef exponent1="6" exponent2="6">0.0</Coef>
           <Coef exponent1="6" exponent2="7">0.0</Coef>
           <Coef exponent1="6" exponent2="8">0.0</Coef>
-          <Coef exponent1="7" exponent2="0">-31906.261251931344</Coef>
+          <Coef exponent1="7" exponent2="0">-1442527537.8580344</Coef>
           <Coef exponent1="7" exponent2="1">0.0</Coef>
           <Coef exponent1="7" exponent2="2">0.0</Coef>
           <Coef exponent1="7" exponent2="3">0.0</Coef>
@@ -858,7 +845,7 @@
           <Coef exponent1="7" exponent2="6">0.0</Coef>
           <Coef exponent1="7" exponent2="7">0.0</Coef>
           <Coef exponent1="7" exponent2="8">0.0</Coef>
-          <Coef exponent1="8" exponent2="0">-3.112838344667953e+20</Coef>
+          <Coef exponent1="8" exponent2="0">-4.4559066869820204e+25</Coef>
           <Coef exponent1="8" exponent2="1">0.0</Coef>
           <Coef exponent1="8" exponent2="2">0.0</Coef>
           <Coef exponent1="8" exponent2="3">0.0</Coef>
@@ -871,6 +858,7 @@
         <PhasePoly order1="0" order2="0">
           <Coef exponent1="0" exponent2="0">0.0</Coef>
         </PhasePoly>
+        <AntGPId>receive_array</AntGPId>
       </Array>
       <Element>
         <GainPoly order1="0" order2="0">
@@ -879,9 +867,10 @@
         <PhasePoly order1="0" order2="0">
           <Coef exponent1="0" exponent2="0">0.0</Coef>
         </PhasePoly>
+        <AntGPId>receive_element</AntGPId>
       </Element>
       <GainPhaseArray>
-        <Freq>8000000000.0</Freq>
+        <Freq>10000000000.0</Freq>
         <ArrayId>receive_array</ArrayId>
         <ElementId>receive_element</ElementId>
       </GainPhaseArray>
@@ -891,35 +880,58 @@
     <NumTxWFs>1</NumTxWFs>
     <TxWFParameters>
       <Identifier>txwf_id#1</Identifier>
-      <PulseLength>5.718339803806877e-07</PulseLength>
-      <RFBandwidth>85775097.05710316</RFBandwidth>
-      <FreqCenter>8000000000.0</FreqCenter>
-      <LFMRate>150000000000000.0</LFMRate>
+      <PulseLength>1.3499904374914016e-05</PulseLength>
+      <RFBandwidth>337497609.3728504</RFBandwidth>
+      <FreqCenter>10000000000.0</FreqCenter>
+      <LFMRate>371357935.0</LFMRate>
       <Polarization>V</Polarization>
+      <Power>0.0</Power>
     </TxWFParameters>
     <NumRcvs>1</NumRcvs>
     <RcvParameters>
       <Identifier>rcv_id#1</Identifier>
-      <WindowLength>3.82848365773068e-06</WindowLength>
-      <SampleRate>102930116.46852379</SampleRate>
-      <IFFilterBW>94352606.76281348</IFFilterBW>
-      <FreqCenter>8000000000.0</FreqCenter>
-      <LFMRate>0.05</LFMRate>
+      <WindowLength>2.5878502230492327e-05</WindowLength>
+      <SampleRate>371357935.6673492</SampleRate>
+      <IFFilterBW>340411441.0284035</IFFilterBW>
+      <FreqCenter>10154732473.19473</FreqCenter>
+      <LFMRate>371357935.0</LFMRate>
       <Polarization>V</Polarization>
+      <PathGain>1.0</PathGain>
     </RcvParameters>
   </TxRcv>
   <ProductInfo>
     <CreationInfo>
-      <Application>Valkyrie Systems Sage | sar_common_kit 2.1.3.0</Application>
-      <DateTime>2026-03-31T17:16:19Z</DateTime>
+      <Application>Valkyrie Systems Sage | sar_common_kit 1.9.0.0</Application>
+      <DateTime>2022-12-05T18:41:24.396396Z</DateTime>
     </CreationInfo>
   </ProductInfo>
   <GeoInfo name="synthetic_targets">
     <GeoInfo name="target0">
-      <Desc name="ecef">[-2504864.1197712747, -4659978.462832459, 3550545.723953865]</Desc>
+      <Desc name="ecef">[6378137.0, -405.5797876726389, 579.2279653395692]</Desc>
     </GeoInfo>
     <GeoInfo name="target1">
-      <Desc name="ecef">[-2506236.835246276, -4659422.160793961, 3550308.7001857436]</Desc>
+      <Desc name="ecef">[6378137.0, 86.82408883346518, 492.403876506104]</Desc>
+    </GeoInfo>
+    <GeoInfo name="target2">
+      <Desc name="ecef">[6378137.0, 579.2279653395692, 405.5797876726388]</Desc>
+    </GeoInfo>
+    <GeoInfo name="target3">
+      <Desc name="ecef">[6378137.0, -492.40387650610404, 86.8240888334652]</Desc>
+    </GeoInfo>
+    <GeoInfo name="target4">
+      <Desc name="ecef">[6378137.0, 0.0, 0.0]</Desc>
+    </GeoInfo>
+    <GeoInfo name="target5">
+      <Desc name="ecef">[6378137.0, 492.40387650610404, -86.8240888334652]</Desc>
+    </GeoInfo>
+    <GeoInfo name="target6">
+      <Desc name="ecef">[6378137.0, -579.2279653395692, -405.5797876726388]</Desc>
+    </GeoInfo>
+    <GeoInfo name="target7">
+      <Desc name="ecef">[6378137.0, -86.82408883346518, -492.403876506104]</Desc>
+    </GeoInfo>
+    <GeoInfo name="target8">
+      <Desc name="ecef">[6378137.0, 405.5797876726389, -579.2279653395692]</Desc>
     </GeoInfo>
   </GeoInfo>
 </CPHD>

--- a/sarkit/cphd/_io.py
+++ b/sarkit/cphd/_io.py
@@ -359,7 +359,7 @@ class Reader:
 
         import sarkit.cphd as skcphd
         import lxml.etree
-        meta = skcphd.Metadata(xmltree=lxml.etree.parse("data/example-cphd-1.0.1.xml"))
+        meta = skcphd.Metadata(xmltree=lxml.etree.parse("data/example-cphd-1.1.0.xml"))
 
         file = pathlib.Path(tmpdir.name) / "foo"
         with file.open("wb") as f, skcphd.Writer(f, meta) as w:
@@ -680,7 +680,7 @@ class Writer:
 
         >>> import lxml.etree
 
-        >>> xmltree = lxml.etree.parse("data/example-cphd-1.0.1.xml")
+        >>> xmltree = lxml.etree.parse("data/example-cphd-1.1.0.xml")
         >>> first_channel = xmltree.find("{*}Data/{*}Channel")
         >>> ch_id = first_channel.findtext("{*}Identifier")
         >>> num_v = int(first_channel.findtext("{*}NumVectors"))

--- a/sarkit/verification/__init__.py
+++ b/sarkit/verification/__init__.py
@@ -26,7 +26,7 @@ Consistency objects should be instantiated using ``from_parts`` when data compon
 
    >>> import sarkit.verification as skver
 
-   >>> with open("data/example-cphd-1.0.1.xml", "r") as f:
+   >>> with open("data/example-cphd-1.1.0.xml", "r") as f:
    ...     con = skver.CphdConsistency.from_file(f)
    >>> con.check()
    >>> bool(con.passes())
@@ -35,7 +35,7 @@ Consistency objects should be instantiated using ``from_parts`` when data compon
    False
 
    >>> import lxml.etree
-   >>> cphd_xmltree = lxml.etree.parse("data/example-cphd-1.0.1.xml")
+   >>> cphd_xmltree = lxml.etree.parse("data/example-cphd-1.1.0.xml")
    >>> con = skver.CphdConsistency.from_parts(cphd_xmltree)
    >>> con.check()
    >>> bool(con.passes())

--- a/sarkit/verification/_cphd_consistency.py
+++ b/sarkit/verification/_cphd_consistency.py
@@ -172,7 +172,7 @@ class CphdConsistency(con.ConsistencyChecker):
             import sarkit.cphd as skcphd
             import lxml.etree
             meta = skcphd.Metadata(
-                xmltree=lxml.etree.parse("data/example-cphd-1.0.1.xml"),
+                xmltree=lxml.etree.parse("data/example-cphd-1.1.0.xml"),
             )
             file = tmppath / "example.cphd"
             with file.open("wb") as f, skcphd.Writer(f, meta) as w:
@@ -187,7 +187,7 @@ class CphdConsistency(con.ConsistencyChecker):
 
             >>> import sarkit.verification as skver
 
-            >>> with open("data/example-cphd-1.0.1.xml", "r") as f:
+            >>> with open("data/example-cphd-1.1.0.xml", "r") as f:
             ...     con = skver.CphdConsistency.from_file(f)
             >>> con.check()
             >>> bool(con.passes())
@@ -275,7 +275,7 @@ class CphdConsistency(con.ConsistencyChecker):
 
             >>> import lxml.etree
             >>> import sarkit.verification as skver
-            >>> cphd_xmltree = lxml.etree.parse("data/example-cphd-1.0.1.xml")
+            >>> cphd_xmltree = lxml.etree.parse("data/example-cphd-1.1.0.xml")
             >>> con = skver.CphdConsistency.from_parts(cphd_xmltree)
             >>> con.check()
             >>> bool(con.passes())
@@ -634,6 +634,66 @@ class CphdConsistency(con.ConsistencyChecker):
                         is not None
                     )
 
+    def check_antenna_useacfpvp(self):
+        """UseACFPVP only included when PVP TxAntenna & RcvAntenna are included."""
+        with self.precondition():
+            assert (
+                self.cphdroot.find("{*}Antenna/{*}AntCoordFrame/{*}UseACFPVP")
+                is not None
+            )
+            with self.need(
+                "UseACFPVP only included when PVP TxAntenna & RcvAntenna are included"
+            ):
+                assert self.cphdroot.find("{*}PVP/{*}TxAntenna") is not None
+                assert self.cphdroot.find("{*}PVP/{*}RcvAntenna") is not None
+
+    def check_antenna_useebpvp(self):
+        """UseEBPVP only included when PVP TxAntenna & RcvAntenna are included."""
+        with self.precondition():
+            assert (
+                self.cphdroot.find("{*}Antenna/{*}AntPattern/{*}EB/{*}UseEBPVP")
+                is not None
+            )
+            with self.need(
+                "UseEBPVP only included when PVP TxAntenna & RcvAntenna are included"
+            ):
+                assert self.cphdroot.find("{*}PVP/{*}TxAntenna") is not None
+                assert self.cphdroot.find("{*}PVP/{*}RcvAntenna") is not None
+
+    def check_antenna_ebfreqshiftsf(self):
+        """AntPattern/EBFreqShiftSF only included for EBFreqShift = true"""
+        ebfreqshiftsf_elems = self.cphdroot.findall(
+            "{*}Antenna/{*}AntPattern/{*}EBFreqShiftSF"
+        )
+        with self.precondition():
+            assert ebfreqshiftsf_elems
+            for elem in ebfreqshiftsf_elems:
+                apat = elem.getparent()
+                apat_id = apat.findtext("{*}Identifier")
+                ebfs_elem = apat.find("{*}EBFreqShift")
+                with self.need(
+                    f"EBFreqShiftSF only included for EBFreqShift = true for APAT_ID={apat_id}"
+                ):
+                    assert ebfs_elem is not None
+                    assert self.xmlhelp.load_elem(ebfs_elem) is True
+
+    def check_antenna_mlfreqdilationsf(self):
+        """AntPattern/MLFreqDilationSF only included for MLFreqDilation = true"""
+        mlfreqdilationsf_elems = self.cphdroot.findall(
+            "{*}Antenna/{*}AntPattern/{*}MLFreqDilationSF"
+        )
+        with self.precondition():
+            assert mlfreqdilationsf_elems
+            for elem in mlfreqdilationsf_elems:
+                apat = elem.getparent()
+                apat_id = apat.findtext("{*}Identifier")
+                mlfd_elem = apat.find("{*}MLFreqDilation")
+                with self.need(
+                    f"MLFreqDilationSF only included for MLFreqDilation = true for APAT_ID={apat_id}"
+                ):
+                    assert mlfd_elem is not None
+                    assert self.xmlhelp.load_elem(mlfd_elem) is True
+
     def check_antenna_arrayid_elementid_exist(self):
         """Check that used gain phase arrays exist"""
         array_id_nodes = self.cphdroot.findall(
@@ -803,6 +863,54 @@ class CphdConsistency(con.ConsistencyChecker):
                         assert all(
                             set_finiteness.max(axis=-1) == set_finiteness.min(axis=-1)
                         )
+
+    @per_channel
+    def check_tx_acxy(self, channel_id, channel_node):
+        """TxACX and TxACY PVPs are orthonormal"""
+        with self.precondition():
+            pvp = self._get_channel_pvps(channel_id)
+            assert {"TxACX", "TxACY"}.issubset(pvp.dtype.names)
+            with self.need("TxACX is unit length"):
+                assert np.linalg.norm(pvp["TxACX"], axis=-1) == con.Approx(1.0)
+            with self.need("TxACY is unit length"):
+                assert np.linalg.norm(pvp["TxACY"], axis=-1) == con.Approx(1.0)
+            with self.need("TxACX and TxACY are orthogonal"):
+                assert np.vecdot(pvp["TxACX"], pvp["TxACY"]) == con.Approx(
+                    0.0, atol=1e-6
+                )
+
+    @per_channel
+    def check_txeb(self, channel_id, channel_node):
+        """TxEB composed of valid direction cosines"""
+        with self.precondition():
+            pvp = self._get_channel_pvps(channel_id)
+            assert "TxEB" in pvp.dtype.names
+            with self.need("TxEB is less than unit length"):
+                assert np.linalg.norm(pvp["TxEB"], axis=-1) <= con.Approx(1.0)
+
+    @per_channel
+    def check_rcv_acxy(self, channel_id, channel_node):
+        """RcvACX and RcvACY PVPs are orthonormal"""
+        with self.precondition():
+            pvp = self._get_channel_pvps(channel_id)
+            assert {"RcvACX", "RcvACY"}.issubset(pvp.dtype.names)
+            with self.need("RcvACX is unit length"):
+                assert np.linalg.norm(pvp["RcvACX"], axis=-1) == con.Approx(1.0)
+            with self.need("RcvACY is unit length"):
+                assert np.linalg.norm(pvp["RcvACY"], axis=-1) == con.Approx(1.0)
+            with self.need("RcvACX and RcvACY are orthogonal"):
+                assert np.vecdot(pvp["RcvACX"], pvp["RcvACY"]) == con.Approx(
+                    0.0, atol=1e-6
+                )
+
+    @per_channel
+    def check_rcveb(self, channel_id, channel_node):
+        """RcvEB composed of valid direction cosines"""
+        with self.precondition():
+            pvp = self._get_channel_pvps(channel_id)
+            assert "RcvEB" in pvp.dtype.names
+            with self.need("RcvEB is less than unit length"):
+                assert np.linalg.norm(pvp["RcvEB"], axis=-1) <= con.Approx(1.0)
 
     @per_channel
     def check_channel_fxfixed(self, channel_id, channel_node):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from sarkit import _constants
 
 DATAPATH = pathlib.Path(__file__).parents[1] / "data"
 
-good_cphd_xml_path = DATAPATH / "example-cphd-1.0.1.xml"
+good_cphd_xml_path = DATAPATH / "example-cphd-1.1.0.xml"
 good_crsd_xml_path = DATAPATH / "example-crsd-1.0.xml"
 good_sicd_xml_path = DATAPATH / "example-sicd-1.2.1.xml"
 good_sidd_xml_path = DATAPATH / "example-sidd-3.0.0.xml"
@@ -80,6 +80,22 @@ def example_cphd(tmp_path_factory):
     pvps["SRPPos"] = srp
 
     pvps["SIGNAL"] = 1
+
+    def unit(x):
+        return x / np.linalg.norm(x, axis=-1, keepdims=True)
+
+    tx_acz = unit(srp - pvps["TxPos"])
+    tx_acx = unit(np.cross(pvps["TxVel"], tx_acz))
+    tx_acy = unit(np.cross(tx_acz, tx_acx))
+    rcv_acz = unit(srp - pvps["RcvPos"])
+    rcv_acx = unit(np.cross(pvps["RcvVel"], rcv_acz))
+    rcv_acy = unit(np.cross(rcv_acz, rcv_acx))
+    pvps["TxACX"] = tx_acx
+    pvps["TxACY"] = tx_acy
+    pvps["TxEB"] = 0
+    pvps["RcvACX"] = rcv_acx
+    pvps["RcvACY"] = rcv_acy
+    pvps["RcvEB"] = 0
 
     tmp_cphd = (
         tmp_path_factory.mktemp("data") / good_cphd_xml_path.with_suffix(".cphd").name

--- a/tests/core/cphd/test_io.py
+++ b/tests/core/cphd/test_io.py
@@ -62,7 +62,7 @@ def _last_field(structured_dtype):
 
 
 def test_get_pvp_dtype():
-    etree = lxml.etree.parse(DATAPATH / "example-cphd-1.0.1.xml")
+    etree = lxml.etree.parse(DATAPATH / "example-cphd-1.1.0.xml")
     num_bytes_pvp = int(etree.find("./{*}Data/{*}NumBytesPVP").text)
     pvp_dtype = skcphd.get_pvp_dtype(etree)
 
@@ -109,9 +109,13 @@ def _random_support_array(cphd_xmltree, sa_id):
     )
 
 
+@pytest.mark.parametrize(
+    "basis_xml",
+    (DATAPATH / "example-cphd-1.0.1.xml", DATAPATH / "example-cphd-1.1.0.xml"),
+)
 @pytest.mark.parametrize("with_support_block", (True, False))
-def test_roundtrip(tmp_path, with_support_block):
-    basis_etree = lxml.etree.parse(DATAPATH / "example-cphd-1.0.1.xml")
+def test_roundtrip(tmp_path, with_support_block, basis_xml):
+    basis_etree = lxml.etree.parse(basis_xml)
     basis_version = lxml.etree.QName(basis_etree.getroot()).namespace
     schema = lxml.etree.XMLSchema(file=skcphd.VERSION_INFO[basis_version]["schema"])
     schema.assertValid(basis_etree)
@@ -223,7 +227,7 @@ def test_roundtrip(tmp_path, with_support_block):
 
 
 def test_roundtrip_compressed(tmp_path):
-    basis_etree = lxml.etree.parse(DATAPATH / "example-cphd-1.0.1.xml")
+    basis_etree = lxml.etree.parse(DATAPATH / "example-cphd-1.1.0.xml")
     basis_version = lxml.etree.QName(basis_etree.getroot()).namespace
     assert basis_etree.find("{*}Data/{*}SignalCompressionID") is None
     channel_ids = [
@@ -273,7 +277,7 @@ def test_roundtrip_compressed(tmp_path):
 @pytest.mark.parametrize("is_masked", (True, False))
 @pytest.mark.parametrize("nodata_in_xml", (True, False))
 def test_write_support_array(is_masked, nodata_in_xml, tmp_path):
-    basis_etree = lxml.etree.parse(DATAPATH / "example-cphd-1.0.1.xml")
+    basis_etree = lxml.etree.parse(DATAPATH / "example-cphd-1.1.0.xml")
     elem_ns = lxml.etree.QName(basis_etree.getroot()).namespace
     em = lxml.builder.ElementMaker(namespace=elem_ns, nsmap={None: elem_ns})
     sa_id = str(uuid.uuid4())

--- a/tests/core/cphd/test_scenecoords.py
+++ b/tests/core/cphd/test_scenecoords.py
@@ -66,7 +66,7 @@ def test_hae_llh_tofrom_iac():
 
 
 def get_planar_xmltree():
-    return lxml.etree.parse(DATAPATH / "example-cphd-1.0.1.xml")
+    return lxml.etree.parse(DATAPATH / "example-cphd-1.1.0.xml")
 
 
 def get_hae_xmltree():

--- a/tests/verification/test_cphd_consistency.py
+++ b/tests/verification/test_cphd_consistency.py
@@ -4,6 +4,7 @@ import unittest.mock
 
 import lxml.builder
 import numpy as np
+import numpy.lib.recfunctions as rfn
 import pytest
 import shapely.affinity
 import shapely.geometry as shg
@@ -19,7 +20,7 @@ from . import testing
 
 DATAPATH = pathlib.Path(__file__).parents[2] / "data"
 
-good_cphd_xml_path = DATAPATH / "example-cphd-1.0.1.xml"
+good_cphd_xml_path = DATAPATH / "example-cphd-1.1.0.xml"
 
 
 @pytest.fixture(scope="session")
@@ -324,7 +325,7 @@ def test_check_pvp_set_finiteness(example_cphd_file):
 
 
 def test_txrcv_lfmrate():
-    cphd_con = CphdConsistency.from_file(str(good_cphd_xml_path))
+    cphd_con = CphdConsistency.from_file(str(DATAPATH / "example-cphd-1.0.1.xml"))
     cphd_con.cphdroot.find("./{*}TxRcv/{*}TxWFParameters/{*}LFMRate").text = "0.0"
     cphd_con.check("check_txrcv_lfmrate")
     testing.assert_failures(
@@ -1738,3 +1739,113 @@ def test_smart_open_contract(example_cphd, monkeypatch):
     monkeypatch.setattr(sarkit.verification._cphdcheck, "open", mock_open)
     assert not main([str(example_cphd), "--thorough"])
     mock_open.assert_called_once_with(str(example_cphd), "rb")
+
+
+@pytest.mark.parametrize("txrcv", ["Tx", "Rcv"])
+@pytest.mark.parametrize("axis", ["X", "Y"])
+def test_txrcv_acxy_not_unit(cphd_con_from_file, axis, txrcv):
+    cphd_con = cphd_con_from_file
+    ch_id = cphd_con.cphdroot.findtext(".//{*}RefChId")
+    pvp = cphd_con._get_channel_pvps(ch_id)
+    pvp[f"{txrcv}AC{axis}"][0] *= 3
+    cphd_con.check(f"check_{txrcv.lower()}_acxy", allow_prefix=True)
+    testing.assert_failures(cphd_con, f"{txrcv}AC{axis} is unit length")
+
+
+@pytest.mark.parametrize("txrcv", ["Tx", "Rcv"])
+def test_txrcv_acxy_not_ortho(cphd_con_from_file, txrcv):
+    cphd_con = cphd_con_from_file
+    ch_id = cphd_con.cphdroot.findtext(".//{*}RefChId")
+    pvp = cphd_con._get_channel_pvps(ch_id)
+    pvp[f"{txrcv}ACX"][0] = pvp[f"{txrcv}ACY"][0]
+    cphd_con.check(f"check_{txrcv.lower()}_acxy", allow_prefix=True)
+    testing.assert_failures(cphd_con, "are orthogonal")
+
+
+def test_txrcv_antenna_pvps_not_present(cphd_con_from_file):
+    cphd_con = cphd_con_from_file
+    remove_nodes(*cphd_con.cphdroot.findall("{*}PVP/{*}TxAntenna"))
+    remove_nodes(*cphd_con.cphdroot.findall("{*}PVP/{*}RcvAntenna"))
+    ch_id = cphd_con.cphdroot.findtext(".//{*}RefChId")
+    pvp = cphd_con._get_channel_pvps(ch_id)
+    cphd_con.pvps[ch_id] = rfn.drop_fields(
+        pvp, ("TxACX", "TxACY", "TxEB", "RcvACX", "RcvACY", "RcvEB")
+    )
+    cphd_con.check(
+        ["check_tx_acxy", "check_txeb", "check_rcv_acxy", "check_rcveb"],
+        allow_prefix=True,
+    )
+    assert not cphd_con.failures()
+    assert cphd_con.skips()
+
+
+@pytest.mark.parametrize("txrcv", ["Tx", "Rcv"])
+def test_txrcv_eb(cphd_con_from_file, txrcv):
+    cphd_con = cphd_con_from_file
+    ch_id = cphd_con.cphdroot.findtext(".//{*}RefChId")
+    pvp = cphd_con._get_channel_pvps(ch_id)
+    pvp[f"{txrcv}EB"][0] = [0.8, 0.8]
+    cphd_con.check(f"check_{txrcv.lower()}eb", allow_prefix=True)
+    testing.assert_failures(cphd_con, "unit length")
+
+
+def test_check_antenna_useacfpvp(cphd_con):
+    ew = skcphd.ElementWrapper(cphd_con.cphdroot)
+    assert all(x in ew["PVP"] for x in ("TxAntenna", "RcvAntenna"))
+    ew["Antenna"]["AntCoordFrame"][0]["UseACFPVP"] = True
+    cphd_con.check("check_antenna_useacfpvp")
+    assert cphd_con.passes() and not cphd_con.failures()
+    del ew["PVP"]["TxAntenna"]
+    cphd_con.check("check_antenna_useacfpvp")
+    testing.assert_failures(cphd_con, "UseACFPVP only included")
+
+
+def test_check_antenna_useebpvp(cphd_con):
+    ew = skcphd.ElementWrapper(cphd_con.cphdroot)
+    assert all(x in ew["PVP"] for x in ("TxAntenna", "RcvAntenna"))
+    ew["Antenna"]["AntPattern"][0]["EB"]["UseEBPVP"] = True
+    cphd_con.check("check_antenna_useebpvp")
+    assert cphd_con.passes() and not cphd_con.failures()
+    del ew["PVP"]["TxAntenna"]
+    cphd_con.check("check_antenna_useebpvp")
+    testing.assert_failures(cphd_con, "UseEBPVP only included")
+
+
+def test_check_antenna_ebfreqshiftsf(cphd_con):
+    remove_nodes(*cphd_con.cphdroot.findall("{*}Antenna/{*}AntPattern/{*}EBFreqShift"))
+    ew = skcphd.ElementWrapper(cphd_con.cphdroot)
+    apat_ew = ew["Antenna"]["AntPattern"][0]
+    apat_ew["EBFreqShiftSF"] = {"DCXSF": 0.0, "DCYSF": 0.0}
+    cphd_con.check("check_antenna_ebfreqshiftsf")
+    testing.assert_failures(
+        cphd_con, "EBFreqShiftSF only included for EBFreqShift = true"
+    )
+    apat_ew["EBFreqShift"] = False
+    cphd_con.check("check_antenna_ebfreqshiftsf")
+    testing.assert_failures(
+        cphd_con, "EBFreqShiftSF only included for EBFreqShift = true"
+    )
+    apat_ew["EBFreqShift"] = True
+    cphd_con.check("check_antenna_ebfreqshiftsf")
+    assert cphd_con.passes() and not cphd_con.failures()
+
+
+def test_check_antenna_mlfreqdilationsf(cphd_con):
+    remove_nodes(
+        *cphd_con.cphdroot.findall("{*}Antenna/{*}AntPattern/{*}MLFreqDilation")
+    )
+    ew = skcphd.ElementWrapper(cphd_con.cphdroot)
+    apat_ew = ew["Antenna"]["AntPattern"][0]
+    apat_ew["MLFreqDilationSF"] = {"DCXSF": 0.0, "DCYSF": 0.0}
+    cphd_con.check("check_antenna_mlfreqdilationsf")
+    testing.assert_failures(
+        cphd_con, "MLFreqDilationSF only included for MLFreqDilation = true"
+    )
+    apat_ew["MLFreqDilation"] = False
+    cphd_con.check("check_antenna_mlfreqdilationsf")
+    testing.assert_failures(
+        cphd_con, "MLFreqDilationSF only included for MLFreqDilation = true"
+    )
+    apat_ew["MLFreqDilation"] = True
+    cphd_con.check("check_antenna_mlfreqdilationsf")
+    assert cphd_con.passes() and not cphd_con.failures()


### PR DESCRIPTION
# Description
This PR adds a handful of CPHD consistency checks related to fields added in CPHD v1.1.0

## Notes
- new example-cphd XML
  - in order to not perturb things too much; I upgraded the existing `example-cphd-1.0.1.xml` to `example-cphd-1.1.0.xml` and then added a rather different `data/example-cphd-1.0.1.xml` that was bistatic to provide some diversity. Unfortunately, because of the filenames, the git diff is rather tragic. Here is a manual diff:

<details>
<summary>manual diff</summary>

```diff
$ diff -y --suppress-common-lines frommain-example-cphd-1.0.1.xml data/example-cphd-1.1.0.xml 
<CPHD xmlns="http://api.nsgreg.nga.mil/schema/cphd/1.0.1">    | <CPHD xmlns="http://api.nsgreg.nga.mil/schema/cphd/1.1.0">
    <NumBytesPVP>224</NumBytesPVP>                            |     <NumBytesPVP>352</NumBytesPVP>
                                                              >       <SignalNormal>true</SignalNormal>
                                                              >         <TxPolRef>
                                                              >           <AmpH>0.15595041814031432</AmpH>
                                                              >           <AmpV>0.9877648845154707</AmpV>
                                                              >           <PhaseV>0.0</PhaseV>
                                                              >         </TxPolRef>
                                                              >         <RcvPolRef>
                                                              >           <AmpH>0.1559148176398521</AmpH>
                                                              >           <AmpV>0.9877705045405697</AmpV>
                                                              >           <PhaseV>0.0</PhaseV>
                                                              >         </RcvPolRef>
      <Offset>16</Offset>                                     |       <Offset>24</Offset>
      <Offset>17</Offset>                                     |       <Offset>25</Offset>
      <Offset>20</Offset>                                     |       <Offset>28</Offset>
      <Offset>24</Offset>                                     |       <Offset>32</Offset>
      <Offset>25</Offset>                                     |       <Offset>33</Offset>
      <Offset>26</Offset>                                     |       <Offset>34</Offset>
      <Offset>23</Offset>                                     |       <Offset>31</Offset>
      <Offset>27</Offset>                                     |       <Offset>35</Offset>
                                                              >     <TxAntenna>
                                                              >       <TxACX>
                                                              >         <Offset>16</Offset>
                                                              >         <Size>3</Size>
                                                              >         <Format>X=F8;Y=F8;Z=F8;</Format>
                                                              >       </TxACX>
                                                              >       <TxACY>
                                                              >         <Offset>19</Offset>
                                                              >         <Size>3</Size>
                                                              >         <Format>X=F8;Y=F8;Z=F8;</Format>
                                                              >       </TxACY>
                                                              >       <TxEB>
                                                              >         <Offset>22</Offset>
                                                              >         <Size>2</Size>
                                                              >         <Format>DCX=F8;DCY=F8;</Format>
                                                              >       </TxEB>
                                                              >     </TxAntenna>
                                                              >     <RcvAntenna>
                                                              >       <RcvACX>
                                                              >         <Offset>36</Offset>
                                                              >         <Size>3</Size>
                                                              >         <Format>X=F8;Y=F8;Z=F8;</Format>
                                                              >       </RcvACX>
                                                              >       <RcvACY>
                                                              >         <Offset>39</Offset>
                                                              >         <Size>3</Size>
                                                              >         <Format>X=F8;Y=F8;Z=F8;</Format>
                                                              >       </RcvACY>
                                                              >       <RcvEB>
                                                              >         <Offset>42</Offset>
                                                              >         <Size>2</Size>
                                                              >         <Format>DCX=F8;DCY=F8;</Format>
                                                              >       </RcvEB>
                                                              >     </RcvAntenna>
                                                              >       <AntPolRef>
                                                              >         <AmpX>0.0</AmpX>
                                                              >         <AmpY>1.0</AmpY>
                                                              >         <PhaseY>0.0</PhaseY>
                                                              >       </AntPolRef>
                                                              >         <AntGPId>transmit_array</AntGPId>
                                                              >         <AntGPId>transmit_element</AntGPId>
                                                              >       <AntPolRef>
                                                              >         <AmpX>0.0</AmpX>
                                                              >         <AmpY>1.0</AmpY>
                                                              >         <PhaseY>0.0</PhaseY>
                                                              >       </AntPolRef>
                                                              >         <AntGPId>receive_array</AntGPId>
                                                              >         <AntGPId>receive_element</AntGPId>
</CPHD>                                                       / </CPHD>
                                                                                                                                                                                                                                                                                                                             

```

</details>

- antenna PVP checks and tests borrowed heavily from [CRSD checks](https://github.com/ValkyrieSystems/sarkit/blob/main/sarkit/verification/_crsd_consistency.py#L836-L854)
- for `check_antenna_useacfpvp` and `check_antenna_useebpvp`, I debated being more lenient and only checking apats/acfs that were referenced by channels and only checking that the associated (Tx OR Rcv, not Tx AND Rcv) PVPs were available. Although I think this is more useful, it was more code to write/test and hard to justify given the text of the document, so I opted for the more onerous checks