### PR TITLE
crsdinfo: add ability to list transmit pulse sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `--txsequences` argument to `crsdinfo` for listing transmit pulse sequences
+
 
 ## [1.6.0] - 2026-03-30
 

--- a/sarkit/crsd/_crsdinfo.py
+++ b/sarkit/crsd/_crsdinfo.py
@@ -23,6 +23,9 @@ def _parser():
     )
     parser.add_argument("--channels", "-c", action="store_true", help="List channels")
     parser.add_argument(
+        "--txsequences", "-t", action="store_true", help="List transmit pulse sequences"
+    )
+    parser.add_argument(
         "--raw",
         choices=["XML", "SUPPORT", "PPP", "PVP", "SIGNAL"],
         help="Extract raw bytes of a BLOCK",
@@ -58,6 +61,11 @@ def main(args=None):
         if config.channels:
             root = lxml.etree.fromstring(xmlstr)
             for node in root.findall("./{*}Data/{*}Receive/{*}Channel/{*}ChId"):
+                print(node.text)
+
+        if config.txsequences:
+            root = lxml.etree.fromstring(xmlstr)
+            for node in root.findall("./{*}Data/{*}Transmit/{*}TxSequence/{*}TxId"):
                 print(node.text)
 
 

--- a/tests/core/crsd/test_crsdinfo.py
+++ b/tests/core/crsd/test_crsdinfo.py
@@ -25,6 +25,13 @@ def test_channel(example_crsdsar):
     assert proc.stdout.splitlines() == ["the channel"]
 
 
+def test_txsequence(example_crsdsar):
+    proc = subprocess.run(
+        ["crsdinfo", "-t", example_crsdsar], capture_output=True, text=True, check=True
+    )
+    assert proc.stdout.splitlines() == ["the sequence"]
+
+
 def test_raw(example_crsdsar):
     proc = subprocess.run(
         ["crsdinfo", "-x", example_crsdsar], stdout=subprocess.PIPE, check=True


### PR DESCRIPTION
# Description
This PR adds a `--txsequences` arg to `crsdinfo` that is the Transmit Pulse Sequence equivalent to the existing `--channel` (receive channel) capability:

## Demo
```console
$ pdm run crsdinfo -t https://govsco.com/content/spotlight.crsd
SyntheticChannel
```