### PR TITLE
CRSD: Add IAC <-> scene methods 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Additional CPHD consistency checks for optional antenna fields introduced in v1.1.0
 - `--txsequences` argument to `crsdinfo` for listing transmit pulse sequences
+- Methods for converting to & from image area coordinates in `sarkit.crsd`
 
 
 ## [1.6.0] - 2026-03-30

--- a/sarkit/cphd/__init__.py
+++ b/sarkit/cphd/__init__.py
@@ -66,6 +66,8 @@ CPHD Signal Model
    compute_t_ref
    compute_t_ref_from_pvps
 
+.. _skcphd_scenecoords:
+
 Scene Coordinates & Collection Geometry
 =======================================
 

--- a/sarkit/cphd/_scenecoords.py
+++ b/sarkit/cphd/_scenecoords.py
@@ -5,6 +5,7 @@ import numpy as np
 import numpy.typing as npt
 
 import sarkit.wgs84
+import sarkit.xmlhelp
 
 from . import _xml as cphd_xml
 
@@ -144,6 +145,12 @@ def ecf_to_iac(cphd_xmltree: lxml.etree.ElementTree, pt: npt.ArrayLike) -> np.nd
         Array of positions in IAC coordinates with IAX, IAY, IAZ components in meters in the last dimension.
     """
     sc_ew = cphd_xml.ElementWrapper(cphd_xmltree.find("{*}SceneCoordinates"))
+    return ecf_to_iac_from_ew(sc_ew, pt)
+
+
+def ecf_to_iac_from_ew(
+    sc_ew: sarkit.xmlhelp.ElementWrapper, pt: npt.ArrayLike
+) -> np.ndarray:
     if "Planar" in sc_ew["ReferenceSurface"]:
         return planar_ecf_to_iac(
             pt,
@@ -180,6 +187,12 @@ def iac_to_ecf(
         Array of positions in ECF coordinates with X, Y, Z components in meters in the last dimension.
     """
     sc_ew = cphd_xml.ElementWrapper(cphd_xmltree.find("{*}SceneCoordinates"))
+    return iac_to_ecf_from_ew(sc_ew, pt_iac)
+
+
+def iac_to_ecf_from_ew(
+    sc_ew: sarkit.xmlhelp.ElementWrapper, pt_iac: npt.ArrayLike
+) -> np.ndarray:
     if "Planar" in sc_ew["ReferenceSurface"]:
         return planar_iac_to_ecf(
             pt_iac,
@@ -217,6 +230,12 @@ def llh_to_iac(
         Array of positions in IAC coordinates with IAX, IAY, IAZ components in meters in the last dimension.
     """
     sc_ew = cphd_xml.ElementWrapper(cphd_xmltree.find("{*}SceneCoordinates"))
+    return llh_to_iac_from_ew(sc_ew, pt_llh)
+
+
+def llh_to_iac_from_ew(
+    sc_ew: sarkit.xmlhelp.ElementWrapper, pt_llh: npt.ArrayLike
+) -> np.ndarray:
     if "Planar" in sc_ew["ReferenceSurface"]:
         return planar_ecf_to_iac(
             sarkit.wgs84.geodetic_to_cartesian(pt_llh),
@@ -254,6 +273,12 @@ def iac_to_llh(
         ellipsoidal height (m)] in the last dimension.
     """
     sc_ew = cphd_xml.ElementWrapper(cphd_xmltree.find("{*}SceneCoordinates"))
+    return iac_to_llh_from_ew(sc_ew, pt_iac)
+
+
+def iac_to_llh_from_ew(
+    sc_ew: sarkit.xmlhelp.ElementWrapper, pt_iac: npt.ArrayLike
+) -> np.ndarray:
     if "Planar" in sc_ew["ReferenceSurface"]:
         pt = planar_iac_to_ecf(
             pt_iac,

--- a/sarkit/crsd/__init__.py
+++ b/sarkit/crsd/__init__.py
@@ -59,6 +59,23 @@ XML Metadata
    ImageAreaCornerPointsType
    ParameterType
 
+Scene Coordinates
+=================
+
+.. admonition:: See also
+
+   CRSD explicitly references CPHD D & I SceneCoordinates branch. See :ref:`skcphd_scenecoords` in :mod:`sarkit.cphd`.
+
+Convenience functions that operate on parsed XML trees:
+
+.. autosummary::
+   :toctree: generated/
+
+   ecf_to_iac
+   iac_to_ecf
+   llh_to_iac
+   iac_to_llh
+
 Receive Channel Parameters
 ==========================
 
@@ -152,6 +169,12 @@ from ._io import (
     mask_support_array,
     read_file_header,
 )
+from ._scenecoords import (
+    ecf_to_iac,
+    iac_to_ecf,
+    iac_to_llh,
+    llh_to_iac,
+)
 from ._xml import (
     AddedPxpType,
     BoolType,
@@ -221,9 +244,13 @@ __all__ = [
     "compute_ref_point_parameters",
     "compute_reference_geometry",
     "dtype_to_binary_format_string",
+    "ecf_to_iac",
     "get_ppp_dtype",
     "get_pvp_dtype",
+    "iac_to_ecf",
+    "iac_to_llh",
     "interpolate_support_array",
+    "llh_to_iac",
     "mask_support_array",
     "read_file_header",
 ]

--- a/sarkit/crsd/_scenecoords.py
+++ b/sarkit/crsd/_scenecoords.py
@@ -1,0 +1,42 @@
+"""Calculations related to geographic coordinates in the imaged scene.
+
+CRSD D&I DD explicitly states equivalence to CPHD.
+"""
+
+import lxml.etree
+import numpy as np
+import numpy.typing as npt
+
+import sarkit.cphd._scenecoords as cphd_scenecoords
+import sarkit.crsd._xml as crsd_xml
+
+
+def ecf_to_iac(crsd_xmltree: lxml.etree.ElementTree, pt: npt.ArrayLike) -> np.ndarray:
+    sc_ew = crsd_xml.ElementWrapper(crsd_xmltree.find("{*}SceneCoordinates"))
+    return cphd_scenecoords.ecf_to_iac_from_ew(sc_ew, pt)
+
+
+def iac_to_ecf(
+    crsd_xmltree: lxml.etree.ElementTree, pt_iac: npt.ArrayLike
+) -> np.ndarray:
+    sc_ew = crsd_xml.ElementWrapper(crsd_xmltree.find("{*}SceneCoordinates"))
+    return cphd_scenecoords.iac_to_ecf_from_ew(sc_ew, pt_iac)
+
+
+def llh_to_iac(
+    crsd_xmltree: lxml.etree.ElementTree, pt_llh: npt.ArrayLike
+) -> np.ndarray:
+    sc_ew = crsd_xml.ElementWrapper(crsd_xmltree.find("{*}SceneCoordinates"))
+    return cphd_scenecoords.llh_to_iac_from_ew(sc_ew, pt_llh)
+
+
+def iac_to_llh(
+    crsd_xmltree: lxml.etree.ElementTree, pt_iac: npt.ArrayLike
+) -> np.ndarray:
+    sc_ew = crsd_xml.ElementWrapper(crsd_xmltree.find("{*}SceneCoordinates"))
+    return cphd_scenecoords.iac_to_llh_from_ew(sc_ew, pt_iac)
+
+
+for func in (ecf_to_iac, iac_to_ecf, llh_to_iac, iac_to_llh):
+    newdoc = getattr(getattr(cphd_scenecoords, func.__name__), "__doc__", "")
+    func.__doc__ = newdoc.replace("cphd", "crsd").replace("CPHD", "CRSD")

--- a/sarkit/verification/_crsd_consistency.py
+++ b/sarkit/verification/_crsd_consistency.py
@@ -1507,7 +1507,9 @@ class CrsdConsistency(con.ConsistencyChecker):
         iacps = self.xmlhelp.load("{*}SceneCoordinates/{*}ImageAreaCornerPoints")
         # lay out the XY corners in clockwise order
         xy_lim_corners = [x1y1, [x1y1[0], x2y2[1]], x2y2, [x2y2[0], x1y1[1]]]
-        xy_lim_ecf = [self.iac_to_ecf(xy) for xy in xy_lim_corners]
+        xy_lim_ecf = [
+            skcrsd.iac_to_ecf(self.crsdroot.getroottree(), xy) for xy in xy_lim_corners
+        ]
         xy_lim_llh = sarkit.wgs84.cartesian_to_geodetic(xy_lim_ecf)
         # find which IACP most closely corresponds to the first XY corner
         num_roll = np.argmin(np.linalg.norm(xy_lim_llh[0, :2] - iacps))
@@ -2416,33 +2418,20 @@ class CrsdConsistency(con.ConsistencyChecker):
 
     def assert_iac_matches_ecf(self, iac_coord, ecf_coord, tol=1.0):
         """Asserts that the IAC and ECF coordinates are a matched set"""
-        assert np.linalg.norm(ecf_coord - self.iac_to_ecf(iac_coord)) < tol
+        assert (
+            np.linalg.norm(
+                ecf_coord - skcrsd.iac_to_ecf(self.crsdroot.getroottree(), iac_coord)
+            )
+            < tol
+        )
 
     def iac_to_ecf(self, iac_coord):
-        """Converts ImageAreaCoordinates to ECF"""
-        if (
-            self.crsdroot.find("{*}SceneCoordinates/{*}ReferenceSurface/{*}Planar")
-            is not None
-        ):
-            iarp = self.xmlhelp.load("{*}SceneCoordinates/{*}IARP/{*}ECF")
-            uiax = self.xmlhelp.load(
-                "{*}SceneCoordinates/{*}ReferenceSurface/{*}Planar/{*}uIAX"
-            )
-            uiay = self.xmlhelp.load(
-                "{*}SceneCoordinates/{*}ReferenceSurface/{*}Planar/{*}uIAY"
-            )
-            return iarp + uiax * iac_coord[0] + uiay * iac_coord[1]
-        else:
-            iarp_llh = self.xmlhelp.load("{*}SceneCoordinates/{*}IARP/{*}LLH")
-            uiax_ll = self.xmlhelp.load(
-                "{*}SceneCoordinates/{*}ReferenceSurface/{*}HAE/{*}uIAXLL"
-            )
-            uiay_ll = self.xmlhelp.load(
-                "{*}SceneCoordinates/{*}ReferenceSurface/{*}HAE/{*}uIAYLL"
-            )
-            llh_coord = iarp_llh.copy()
-            llh_coord[:2] += uiax_ll * iac_coord[0] + uiay_ll * iac_coord[1]
-            return sarkit.wgs84.geodetic_to_cartesian(llh_coord)
+        """Converts ImageAreaCoordinates to ECF
+
+        .. deprecated:: 1.7.0
+           Use :py:func:`sarkit.crsd.iac_to_ecf` instead.
+        """
+        return skcrsd.iac_to_ecf(self.crsdroot.getroottree(), iac_coord)
 
 
 # Improve rendered docstring

--- a/tests/core/crsd/test_scenecoords.py
+++ b/tests/core/crsd/test_scenecoords.py
@@ -1,0 +1,63 @@
+import pathlib
+
+import lxml.etree
+import numpy as np
+import pytest
+
+import sarkit.crsd as skcrsd
+import sarkit.wgs84
+import tests.utils
+
+DATAPATH = pathlib.Path(__file__).parents[3] / "data"
+
+
+def get_planar_xmltree():
+    return lxml.etree.parse(DATAPATH / "example-crsd-1.0.xml")
+
+
+def get_hae_xmltree():
+    xmltree = get_planar_xmltree()
+    tests.utils.replace_planar_with_hae(skcrsd.ElementWrapper(xmltree.getroot()))
+    return xmltree
+
+
+@pytest.mark.parametrize(
+    ("surf_type", "xmltree_func"),
+    [
+        ("Planar", get_planar_xmltree),
+        ("HAE", get_hae_xmltree),
+    ],
+)
+def test_derived_tofrom_iac(surf_type, xmltree_func):
+    """Check the derived xmltree-based IAC to/from ecf & llh methods"""
+    xmltree = xmltree_func()
+    ew = skcrsd.ElementWrapper(xmltree.getroot())
+    sc_ew = ew["SceneCoordinates"]
+    assert surf_type in sc_ew["ReferenceSurface"]
+
+    rng = np.random.default_rng()
+
+    pt_iacs = 24 * rng.random((6, 5, 4, 3))
+
+    # to/from ecf
+    pt_ecf_from_iac = skcrsd.iac_to_ecf(xmltree, pt_iacs)
+    pt_iac_from_ecf = skcrsd.ecf_to_iac(xmltree, pt_ecf_from_iac)
+    assert np.allclose(pt_iacs, pt_iac_from_ecf)
+
+    # to/from llh
+    pt_llh_from_iac = skcrsd.iac_to_llh(xmltree, pt_iacs)
+    pt_iac_from_llh = skcrsd.llh_to_iac(xmltree, pt_llh_from_iac)
+    assert np.allclose(pt_iacs, pt_iac_from_llh)
+    assert np.allclose(
+        pt_ecf_from_iac, sarkit.wgs84.geodetic_to_cartesian(pt_llh_from_iac)
+    )
+
+    # check 2d cases
+    assert np.array_equal(
+        skcrsd.iac_to_ecf(xmltree, pt_iacs[..., :2]),
+        skcrsd.iac_to_ecf(xmltree, pt_iacs * [1, 1, 0]),
+    )
+    assert np.array_equal(
+        skcrsd.iac_to_llh(xmltree, pt_iacs[..., :2]),
+        skcrsd.iac_to_llh(xmltree, pt_iacs * [1, 1, 0]),
+    )

--- a/tests/verification/test_crsd_consistency.py
+++ b/tests/verification/test_crsd_consistency.py
@@ -2157,8 +2157,8 @@ def test_assert_iac_matches_ecf_hae(crsd_con):
     crsd_con.crsdroot.find("{*}SceneCoordinates/{*}ReferenceSurface").append(hae)
     iaxll = np.array([-2e-5, 1e-5])
     iayll = np.array([1.0e-5, 2e-5])
-    crsd_con.xmlhelp.set_elem(hae.find("{*}uIAXLL"), iaxll)
-    crsd_con.xmlhelp.set_elem(hae.find("{*}uIAYLL"), iayll)
+    crsd_con.xmlhelp.set_elem(hae.find("{*}uIAXLL"), np.deg2rad(iaxll))
+    crsd_con.xmlhelp.set_elem(hae.find("{*}uIAYLL"), np.deg2rad(iayll))
     crsd_con.assert_iac_matches_ecf(
         [0, 0], crsd_con.xmlhelp.load("{*}SceneCoordinates/{*}IARP/{*}ECF")
     )


### PR DESCRIPTION
# Description
This PR adds methods for computing to/from image area coordinates to `sarkit.crsd` using the CPHD methods introduced in https://github.com/ValkyrieSystems/sarkit/pull/117

Because CRSD v1.0 D & I section 5 explicitly references reuse of CPHD, I opted to only bring over the convenience methods while at least linking to their CPHD roots in the docs.

This MR also fixes a minor bug in the CRSD consistency checker where HAE IACs were not being converted quite properly.

> The / CRSDxx / SceneCoordinates branch is similar to the / CPHD / SceneCoordinates 
> branch of the XML instance contained in all CPHD V1.1.0 products. The parameter names 
> and definitions are identical. The sets of required versus optional elements is similar. The 
> guidance provided in Section 6 of the CPHD V1.1.0 D&I document is directly applicable to 
> all CRSD products. Refer to Table 1-2