### PR TITLE
Bugfix: RcvPlatform/DopplerConeAng in compute_scp_coa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Calculation of SCPCOA/Bistatic/RcvPlatform/DopplerConeAng in `sarkit.sicd.compute_scp_coa`
+
 
 ## [1.7.0] - 2026-04-20
 

--- a/data/example-sicd-1.5.xml
+++ b/data/example-sicd-1.5.xml
@@ -11,151 +11,151 @@
     <InformationSecurityMarking/>
   </CollectionInfo>
   <ImageCreation>
-    <Application>Valkyrie Systems Sage | sar_common_kit 1.12.7.0</Application>
-    <DateTime>2024-05-29T14:14:28.527158Z</DateTime>
+    <Application>Valkyrie Systems Sage | sar_common_kit 2.1.3.0</Application>
+    <DateTime>2026-04-21T22:16:27Z</DateTime>
   </ImageCreation>
   <ImageData>
     <PixelType>RE32F_IM32F</PixelType>
-    <NumRows>5727</NumRows>
-    <NumCols>2362</NumCols>
+    <NumRows>1887</NumRows>
+    <NumCols>3347</NumCols>
     <FirstRow>0</FirstRow>
     <FirstCol>0</FirstCol>
     <FullImage>
-      <NumRows>5727</NumRows>
-      <NumCols>2362</NumCols>
+      <NumRows>1887</NumRows>
+      <NumCols>3347</NumCols>
     </FullImage>
     <SCPPixel>
-      <Row>2862</Row>
-      <Col>1181</Col>
+      <Row>942</Row>
+      <Col>1673</Col>
     </SCPPixel>
     <ValidData size="32">
       <Vertex index="1">
         <Row>257</Row>
-        <Col>458</Col>
+        <Col>1646</Col>
       </Vertex>
       <Vertex index="2">
-        <Row>257</Row>
-        <Col>664</Col>
+        <Row>258</Row>
+        <Col>1995</Col>
       </Vertex>
       <Vertex index="3">
-        <Row>257</Row>
-        <Col>871</Col>
+        <Row>258</Row>
+        <Col>2345</Col>
       </Vertex>
       <Vertex index="4">
-        <Row>257</Row>
-        <Col>1077</Col>
+        <Row>259</Row>
+        <Col>2694</Col>
       </Vertex>
       <Vertex index="5">
-        <Row>257</Row>
-        <Col>1283</Col>
+        <Row>260</Row>
+        <Col>3043</Col>
       </Vertex>
       <Vertex index="6">
-        <Row>257</Row>
-        <Col>1489</Col>
+        <Row>431</Row>
+        <Col>3049</Col>
       </Vertex>
       <Vertex index="7">
-        <Row>257</Row>
-        <Col>1695</Col>
+        <Row>602</Row>
+        <Col>3056</Col>
       </Vertex>
       <Vertex index="8">
-        <Row>258</Row>
-        <Col>1901</Col>
+        <Row>773</Row>
+        <Col>3062</Col>
       </Vertex>
       <Vertex index="9">
-        <Row>909</Row>
-        <Col>1927</Col>
+        <Row>945</Row>
+        <Col>3068</Col>
       </Vertex>
       <Vertex index="10">
-        <Row>1560</Row>
-        <Col>1953</Col>
+        <Row>1116</Row>
+        <Col>3075</Col>
       </Vertex>
       <Vertex index="11">
-        <Row>2212</Row>
-        <Col>1979</Col>
+        <Row>1287</Row>
+        <Col>3081</Col>
       </Vertex>
       <Vertex index="12">
-        <Row>2863</Row>
-        <Col>2005</Col>
+        <Row>1459</Row>
+        <Col>3088</Col>
       </Vertex>
       <Vertex index="13">
-        <Row>3515</Row>
-        <Col>2032</Col>
+        <Row>1630</Row>
+        <Col>3094</Col>
       </Vertex>
       <Vertex index="14">
-        <Row>4167</Row>
-        <Col>2058</Col>
+        <Row>1629</Row>
+        <Col>2745</Col>
       </Vertex>
       <Vertex index="15">
-        <Row>4819</Row>
-        <Col>2084</Col>
+        <Row>1628</Row>
+        <Col>2397</Col>
       </Vertex>
       <Vertex index="16">
-        <Row>5471</Row>
-        <Col>2110</Col>
+        <Row>1628</Row>
+        <Col>2048</Col>
       </Vertex>
       <Vertex index="17">
-        <Row>5470</Row>
-        <Col>1904</Col>
+        <Row>1627</Row>
+        <Col>1700</Col>
       </Vertex>
       <Vertex index="18">
-        <Row>5470</Row>
-        <Col>1697</Col>
+        <Row>1628</Row>
+        <Col>1351</Col>
       </Vertex>
       <Vertex index="19">
-        <Row>5470</Row>
-        <Col>1491</Col>
+        <Row>1628</Row>
+        <Col>1002</Col>
       </Vertex>
       <Vertex index="20">
-        <Row>5470</Row>
-        <Col>1285</Col>
+        <Row>1629</Row>
+        <Col>654</Col>
       </Vertex>
       <Vertex index="21">
-        <Row>5470</Row>
-        <Col>1079</Col>
+        <Row>1630</Row>
+        <Col>305</Col>
       </Vertex>
       <Vertex index="22">
-        <Row>5470</Row>
-        <Col>873</Col>
+        <Row>1459</Row>
+        <Col>298</Col>
       </Vertex>
       <Vertex index="23">
-        <Row>5470</Row>
-        <Col>667</Col>
+        <Row>1287</Row>
+        <Col>291</Col>
       </Vertex>
       <Vertex index="24">
-        <Row>5471</Row>
-        <Col>461</Col>
+        <Row>1116</Row>
+        <Col>284</Col>
       </Vertex>
       <Vertex index="25">
-        <Row>4819</Row>
-        <Col>435</Col>
+        <Row>945</Row>
+        <Col>277</Col>
       </Vertex>
       <Vertex index="26">
-        <Row>4167</Row>
-        <Col>409</Col>
+        <Row>773</Row>
+        <Col>271</Col>
       </Vertex>
       <Vertex index="27">
-        <Row>3515</Row>
-        <Col>382</Col>
+        <Row>602</Row>
+        <Col>264</Col>
       </Vertex>
       <Vertex index="28">
-        <Row>2863</Row>
-        <Col>356</Col>
+        <Row>431</Row>
+        <Col>257</Col>
       </Vertex>
       <Vertex index="29">
-        <Row>2212</Row>
-        <Col>330</Col>
+        <Row>260</Row>
+        <Col>250</Col>
       </Vertex>
       <Vertex index="30">
-        <Row>1560</Row>
-        <Col>304</Col>
+        <Row>259</Row>
+        <Col>599</Col>
       </Vertex>
       <Vertex index="31">
-        <Row>909</Row>
-        <Col>278</Col>
+        <Row>258</Row>
+        <Col>948</Col>
       </Vertex>
       <Vertex index="32">
         <Row>258</Row>
-        <Col>252</Col>
+        <Col>1297</Col>
       </Vertex>
     </ValidData>
   </ImageData>
@@ -175,239 +175,210 @@
     </SCP>
     <ImageCorners>
       <ICP index="1:FRFC">
-        <Lat>0.014897862606592356</Lat>
-        <Lon>-0.017437308528912253</Lon>
+        <Lat>-0.006126571400955924</Lat>
+        <Lon>0.017283079586162455</Lon>
       </ICP>
       <ICP index="2:FRLC">
-        <Lat>0.014897768031627434</Lat>
-        <Lon>0.021163623843799044</Lon>
+        <Lat>-0.012331171557977747</Lat>
+        <Lon>-0.0144421013463132</Lon>
       </ICP>
       <ICP index="3:LRLC">
-        <Lat>-0.014908271521658396</Lat>
-        <Lon>0.017419658573337677</Lon>
+        <Lat>0.0061461552128400845</Lat>
+        <Lon>-0.0172860938866399</Lon>
       </ICP>
       <ICP index="4:LRFC">
-        <Lat>-0.014908176943349049</Lat>
-        <Lon>-0.021181273798596613</Lon>
+        <Lat>0.012350755369704848</Lat>
+        <Lon>0.014439087045752906</Lon>
       </ICP>
     </ImageCorners>
     <ValidData size="32">
       <Vertex index="1">
-        <Lat>0.013565541682007258</Lat>
-        <Lon>-0.010106046843261916</Lon>
+        <Lat>-0.0066582982978102626</Lat>
+        <Lon>0.0012848041668228232</Lon>
       </Vertex>
       <Vertex index="2">
-        <Lat>0.013565541801622458</Lat>
-        <Lon>-0.0067373646010435535</Lon>
+        <Lat>-0.0073050298297243094</Lat>
+        <Lon>-0.0020220584089089026</Lon>
       </Vertex>
       <Vertex index="3">
-        <Lat>0.01356554187325984</Lat>
-        <Lon>-0.003368682312502394</Lon>
+        <Lat>-0.007951761323298475</Lat>
+        <Lon>-0.005328920970046269</Lon>
       </Vertex>
       <Vertex index="4">
-        <Lat>0.013565541897120899</Lat>
-        <Lon>-8.516417242015484e-13</Lon>
+        <Lat>-0.008598492763663562</Lat>
+        <Lon>-0.008635783493339553</Lon>
       </Vertex>
       <Vertex index="5">
-        <Lat>0.013565541873261311</Lat>
-        <Lon>0.0033686823106291604</Lon>
+        <Lat>-0.009245224252379138</Lat>
+        <Lon>-0.011942645968888018</Lon>
       </Vertex>
       <Vertex index="6">
-        <Lat>0.013565541801625912</Lat>
-        <Lon>0.006737364598634134</Lon>
+        <Lat>-0.007580649732669179</Lat>
+        <Lon>-0.012263846996410059</Lon>
       </Vertex>
       <Vertex index="7">
-        <Lat>0.013565541682010298</Lat>
-        <Lon>0.010106046839808005</Lon>
+        <Lat>-0.005916075203817641</Lat>
+        <Lon>-0.012585048023160619</Lon>
       </Vertex>
       <Vertex index="8">
-        <Lat>0.013565541514099444</Lat>
-        <Lon>0.013474729010749732</Lon>
+        <Lat>-0.004251500587649142</Lat>
+        <Lon>-0.012906249051457675</Lon>
       </Vertex>
       <Vertex index="9">
-        <Lat>0.010174156220276785</Lat>
-        <Lon>0.01347472901163532</Lon>
+        <Lat>-0.0025869260547361763</Lat>
+        <Lon>-0.013227450081701382</Lon>
       </Vertex>
       <Vertex index="10">
-        <Lat>0.006782770853358983</Lat>
-        <Lon>0.013474729012158562</Lon>
+        <Lat>-0.000922351517662309</Lat>
+        <Lon>-0.013548651111680772</Lon>
       </Vertex>
       <Vertex index="11">
-        <Lat>0.0033913854376698156</Lat>
-        <Lon>0.013474729012430834</Lon>
+        <Lat>0.0007422230207025416</Lat>
+        <Lon>-0.01386985214174407</Lon>
       </Vertex>
       <Vertex index="12">
-        <Lat>-2.6022512747123617e-12</Lat>
-        <Lon>0.013474729012516382</Lon>
+        <Lat>0.002406797557612273</Lat>
+        <Lon>-0.014191053172256727</Lon>
       </Vertex>
       <Vertex index="13">
-        <Lat>-0.003391385443368514</Lat>
-        <Lon>0.013474729012433899</Lon>
+        <Lat>0.0040713719935210994</Lat>
+        <Lon>-0.01451225416634876</Lon>
       </Vertex>
       <Vertex index="14">
-        <Lat>-0.006782770860703309</Lat>
-        <Lon>0.013474729012166842</Lon>
+        <Lat>0.004718103621157948</Lat>
+        <Lon>-0.011205391773205805</Lon>
       </Vertex>
       <Vertex index="15">
-        <Lat>-0.01017415623079379</Lat>
-        <Lon>0.013474729011650225</Lon>
+        <Lat>0.005364835179664479</Lat>
+        <Lon>-0.007898529278065449</Lon>
       </Vertex>
       <Vertex index="16">
-        <Lat>-0.01356554152995587</Lat>
-        <Lon>0.013474729010784626</Lon>
+        <Lat>0.006011566746054287</Lat>
+        <Lon>-0.004591666736536951</Lon>
       </Vertex>
       <Vertex index="17">
-        <Lat>-0.013565541692520524</Lat>
-        <Lon>0.010106046839828532</Lon>
+        <Lat>0.0066582983057487935</Lat>
+        <Lon>-0.0012848041675840038</Lon>
       </Vertex>
       <Vertex index="18">
-        <Lat>-0.013565541808964347</Lat>
-        <Lon>0.006737364598650603</Lon>
+        <Lat>0.00730502984953755</Lat>
+        <Lon>0.002022058409211866</Lon>
       </Vertex>
       <Vertex index="19">
-        <Lat>-0.013565541878958582</Lat>
-        <Lon>0.003368682310640344</Lon>
+        <Lat>0.007951761373546461</Lat>
+        <Lon>0.00532892097367416</Lon>
       </Vertex>
       <Vertex index="20">
-        <Lat>-0.013565541902314552</Lat>
-        <Lon>-8.418411092555245e-13</Lon>
+        <Lat>0.008598492879257858</Lat>
+        <Lon>0.008635783505043793</Lon>
       </Vertex>
       <Vertex index="21">
-        <Lat>-0.013565541878965639</Lat>
-        <Lon>-0.0033686823124879583</Lon>
+        <Lat>0.009245224252379272</Lat>
+        <Lon>0.011942645968888254</Lon>
       </Vertex>
       <Vertex index="22">
-        <Lat>-0.013565541808972332</Lat>
-        <Lon>-0.00673736460103327</Lon>
+        <Lat>0.007580649732669179</Lat>
+        <Lon>0.012263846996409866</Lon>
       </Vertex>
       <Vertex index="23">
-        <Lat>-0.013565541692531232</Lat>
-        <Lon>-0.010106046843241515</Lon>
+        <Lat>0.005916075294117977</Lat>
+        <Lon>0.012585048025994576</Lon>
       </Vertex>
       <Vertex index="24">
-        <Lat>-0.013565541529955526</Lat>
-        <Lon>-0.013474729015924553</Lon>
+        <Lat>0.004251500750036273</Lat>
+        <Lon>0.012906249047080496</Lon>
       </Vertex>
       <Vertex index="25">
-        <Lat>-0.010174156230794866</Lat>
-        <Lon>-0.013474729015065781</Lon>
+        <Lat>0.0025869262067987624</Lat>
+        <Lon>0.013227450067127267</Lon>
       </Vertex>
       <Vertex index="26">
-        <Lat>-0.0067827708607095276</Lat>
-        <Lon>-0.013474729014560594</Lon>
+        <Lat>0.0009223516674140818</Lat>
+        <Lon>0.013548651085773602</Lon>
       </Vertex>
       <Vertex index="27">
-        <Lat>-0.0033913854433709027</Lat>
-        <Lon>-0.013474729014291217</Lon>
+        <Lat>-0.0007422228649831243</Lat>
+        <Lon>0.013869852102636797</Lon>
       </Vertex>
       <Vertex index="28">
-        <Lat>-2.5992199764179006e-12</Lat>
-        <Lon>-0.01347472901420946</Lon>
+        <Lat>-0.002406797387115515</Lat>
+        <Lon>0.014191053117302566</Lon>
       </Vertex>
       <Vertex index="29">
-        <Lat>0.003391385437666461</Lat>
-        <Lon>-0.013474729014291921</Lon>
+        <Lat>-0.0040713719935214976</Lat>
+        <Lon>0.014512254166348588</Lon>
       </Vertex>
       <Vertex index="30">
-        <Lat>0.006782770853353226</Lat>
-        <Lon>-0.013474729014563733</Lon>
+        <Lat>-0.004718103539890185</Lat>
+        <Lon>0.011205391739869638</Lon>
       </Vertex>
       <Vertex index="31">
-        <Lat>0.010174156220270113</Lat>
-        <Lon>-0.013474729015082692</Lon>
+        <Lat>-0.005364835151488935</Lat>
+        <Lon>0.007898529265976721</Lon>
       </Vertex>
       <Vertex index="32">
-        <Lat>0.013565541514092755</Lat>
-        <Lon>-0.01347472901595803</Lon>
+        <Lat>-0.006011566737036761</Lat>
+        <Lon>0.004591666733275805</Lon>
       </Vertex>
     </ValidData>
-    <GeoInfo name="synthetic_targets">
-      <GeoInfo name="target0">
-        <Desc name="ecef">[6378137.0, -1500.0000000000002, 1499.9999999999998]</Desc>
-      </GeoInfo>
-      <GeoInfo name="target1">
-        <Desc name="ecef">[6378137.0, -1.3597399555105185e-13, 1500.0]</Desc>
-      </GeoInfo>
-      <GeoInfo name="target2">
-        <Desc name="ecef">[6378137.0, 1499.9999999999998, 1500.0000000000002]</Desc>
-      </GeoInfo>
-      <GeoInfo name="target3">
-        <Desc name="ecef">[6378137.0, -1500.0, -1.3597399555105185e-13]</Desc>
-      </GeoInfo>
-      <GeoInfo name="target4">
-        <Desc name="ecef">[6378137.0, 0.0, 0.0]</Desc>
-      </GeoInfo>
-      <GeoInfo name="target5">
-        <Desc name="ecef">[6378137.0, 1500.0, 1.3597399555105185e-13]</Desc>
-      </GeoInfo>
-      <GeoInfo name="target6">
-        <Desc name="ecef">[6378137.0, -1499.9999999999998, -1500.0000000000002]</Desc>
-      </GeoInfo>
-      <GeoInfo name="target7">
-        <Desc name="ecef">[6378137.0, 1.3597399555105185e-13, -1500.0]</Desc>
-      </GeoInfo>
-      <GeoInfo name="target8">
-        <Desc name="ecef">[6378137.0, 1500.0000000000002, -1499.9999999999998]</Desc>
-      </GeoInfo>
-    </GeoInfo>
   </GeoData>
   <Grid>
     <ImagePlane>SLANT</ImagePlane>
     <Type>RGAZIM</Type>
     <TimeCOAPoly order1="0" order2="0">
-      <Coef exponent1="0" exponent2="0">1.220622599302364</Coef>
+      <Coef exponent1="0" exponent2="0">0.7442796573752982</Coef>
     </TimeCOAPoly>
     <Row>
       <UVectECF>
-        <X>-0.6324666831642389</X>
-        <Y>-1.8785395735164345e-06</Y>
-        <Z>-0.7745875646155944</Z>
+        <X>-0.7577284835278988</X>
+        <Y>-0.12444449578831761</Y>
+        <Z>0.6405943434304757</Z>
       </UVectECF>
-      <SS>0.4457608086829121</SS>
-      <ImpRespWid>0.5052016895768469</ImpRespWid>
+      <SS>0.7144713214899325</SS>
+      <ImpRespWid>0.8117636231352299</ImpRespWid>
       <Sgn>-1</Sgn>
-      <ImpRespBW>1.753244705578659</ImpRespBW>
-      <KCtr>52.73973463842882</KCtr>
-      <DeltaK1>-0.8766223527893331</DeltaK1>
-      <DeltaK2>0.876622352789326</DeltaK2>
+      <ImpRespBW>1.0911331356276435</ImpRespBW>
+      <KCtr>51.878099135944815</KCtr>
+      <DeltaK1>-0.5455665678138217</DeltaK1>
+      <DeltaK2>0.5455665678138217</DeltaK2>
       <DeltaKCOAPoly order1="0" order2="0">
-        <Coef exponent1="0" exponent2="0">-7.1054273576009995e-15</Coef>
+        <Coef exponent1="0" exponent2="0">-0.0</Coef>
       </DeltaKCOAPoly>
     </Row>
     <Col>
       <UVectECF>
-        <X>0.15186491422355175</X>
-        <Y>0.9805917870219334</Y>
-        <Z>-0.12400320535344456</Z>
+        <X>0.03282260801643133</X>
+        <Y>-0.9876739387301663</Y>
+        <Z>-0.15304531081897746</Z>
       </UVectECF>
-      <SS>1.7839287889393634</SS>
-      <ImpRespWid>1.992421560873471</ImpRespWid>
+      <SS>1.0735284290643405</SS>
+      <ImpRespWid>1.194337286740694</ImpRespWid>
       <Sgn>-1</Sgn>
-      <ImpRespBW>0.4445556125741249</ImpRespBW>
-      <KCtr>1.4140792425898493e-08</KCtr>
-      <DeltaK1>-0.22227780628706245</DeltaK1>
-      <DeltaK2>0.22227780628706245</DeltaK2>
+      <ImpRespBW>0.7416181319409029</ImpRespBW>
+      <KCtr>-4.574037704152544e-09</KCtr>
+      <DeltaK1>-0.37080906597045143</DeltaK1>
+      <DeltaK2>0.37080906597045143</DeltaK2>
       <DeltaKCOAPoly order1="0" order2="0">
         <Coef exponent1="0" exponent2="0">-0.0</Coef>
       </DeltaKCOAPoly>
     </Col>
   </Grid>
   <Timeline>
-    <CollectStart>2024-05-29T14:12:54.201358Z</CollectStart>
-    <CollectDuration>2.5506314363333673</CollectDuration>
+    <CollectStart>2026-04-21T22:15:58Z</CollectStart>
+    <CollectDuration>1.5924245422541488</CollectDuration>
     <IPP size="1">
       <Set index="1">
-        <TStart>0.0056816788146032745</TStart>
-        <TEnd>2.5457378091913605</TEnd>
+        <TStart>0.001986333546548465</TStart>
+        <TEnd>1.5907182852954267</TEnd>
         <IPPStart>0</IPPStart>
-        <IPPEnd>3267</IPPEnd>
+        <IPPEnd>5671</IPPEnd>
         <IPPPoly order1="5">
-          <Coef exponent1="0">-7.309967755320728</Coef>
-          <Coef exponent1="1">1286.5858834408305</Coef>
-          <Coef exponent1="2">-5.5515038096979516e-05</Coef>
-          <Coef exponent1="3">-4.3570087476994035e-08</Coef>
-          <Coef exponent1="4">1.8377033854619403e-10</Coef>
-          <Coef exponent1="5">1.5271499300195306e-13</Coef>
+          <Coef exponent1="0">-7.0914961533634875</Coef>
+          <Coef exponent1="1">3570.1436789232707</Coef>
+          <Coef exponent1="2">-0.0005276999059762899</Coef>
+          <Coef exponent1="3">3.2754226137928975e-08</Coef>
+          <Coef exponent1="4">1.7234734609005118e-08</Coef>
+          <Coef exponent1="5">-2.4783299417014267e-11</Coef>
         </IPPPoly>
       </Set>
     </IPP>
@@ -415,37 +386,37 @@
   <Position>
     <ARPPoly>
       <X order1="5">
-        <Coef exponent1="0">7454209.806422097</Coef>
-        <Coef exponent1="1">188.91655848763938</Coef>
-        <Coef exponent1="2">-2.362373172007106</Coef>
-        <Coef exponent1="3">0.008127437652222326</Coef>
-        <Coef exponent1="4">-2.92667702058293e-05</Coef>
-        <Coef exponent1="5">-1.368075007928718e-07</Coef>
+        <Coef exponent1="0">6829502.11327607</Coef>
+        <Coef exponent1="1">-232.13384922642356</Coef>
+        <Coef exponent1="2">8.568620664938184</Coef>
+        <Coef exponent1="3">0.030777343562157427</Coef>
+        <Coef exponent1="4">-0.0017599079875829323</Coef>
+        <Coef exponent1="5">-2.251083099378394e-06</Coef>
       </X>
       <Y order1="5">
-        <Coef exponent1="0">-7806.301805510545</Coef>
-        <Coef exponent1="1">6399.79719992698</Coef>
-        <Coef exponent1="2">-1.5176922483654318</Coef>
-        <Coef exponent1="3">0.012467192043075523</Coef>
-        <Coef exponent1="4">3.726013254183058e-05</Coef>
-        <Coef exponent1="5">-1.397447612729364e-07</Coef>
+        <Coef exponent1="0">69188.50164354361</Coef>
+        <Coef exponent1="1">6602.961210546177</Coef>
+        <Coef exponent1="2">-2.2973211720884663</Coef>
+        <Coef exponent1="3">0.13711263839312077</Coef>
+        <Coef exponent1="4">0.00027368382774271767</Coef>
+        <Coef exponent1="5">-1.808250532008919e-05</Coef>
       </Y>
       <Z order1="5">
-        <Coef exponent1="0">1320352.0463603565</Coef>
-        <Coef exponent1="1">-1803.7760411526824</Coef>
-        <Coef exponent1="2">2.4966351791850445</Coef>
-        <Coef exponent1="3">0.004834761184214687</Coef>
-        <Coef exponent1="4">-3.7703330808027104e-05</Coef>
-        <Coef exponent1="5">-9.370498209584064e-08</Coef>
+        <Coef exponent1="0">-382210.001700217</Coef>
+        <Coef exponent1="1">1023.915512484802</Coef>
+        <Coef exponent1="2">-0.8630204468562598</Coef>
+        <Coef exponent1="3">0.025900506522856408</Coef>
+        <Coef exponent1="4">0.00017763909143795755</Coef>
+        <Coef exponent1="5">-2.950325932225787e-06</Coef>
       </Z>
     </ARPPoly>
     <GRPPoly>
       <X order1="4">
-        <Coef exponent1="0">6378136.999999999</Coef>
-        <Coef exponent1="1">1.0117353019721192e-09</Coef>
-        <Coef exponent1="2">-1.300545089959474e-09</Coef>
-        <Coef exponent1="3">9.753603318545005e-10</Coef>
-        <Coef exponent1="4">-1.8293251800574153e-12</Coef>
+        <Coef exponent1="0">6378136.999999996</Coef>
+        <Coef exponent1="1">1.9851892774635126e-08</Coef>
+        <Coef exponent1="2">-4.696834300074891e-08</Coef>
+        <Coef exponent1="3">3.717811759378776e-08</Coef>
+        <Coef exponent1="4">-1.134479406195356e-08</Coef>
       </X>
       <Y order1="4">
         <Coef exponent1="0">0.0</Coef>
@@ -464,76 +435,76 @@
     </GRPPoly>
     <TxAPCPoly>
       <X order1="5">
-        <Coef exponent1="0">7228591.873064234</Coef>
-        <Coef exponent1="1">349.35203072665144</Coef>
-        <Coef exponent1="2">-3.5888150542803015</Coef>
-        <Coef exponent1="3">-5.723841062565759e-05</Coef>
-        <Coef exponent1="4">3.0087728187636757e-07</Coef>
-        <Coef exponent1="5">-4.625526166678253e-10</Coef>
+        <Coef exponent1="0">6814039.790190997</Coef>
+        <Coef exponent1="1">134.61698180373304</Coef>
+        <Coef exponent1="2">-4.2675243372756855</Coef>
+        <Coef exponent1="3">-2.663403629975812e-05</Coef>
+        <Coef exponent1="4">2.1713702933477124e-07</Coef>
+        <Coef exponent1="5">5.303087667050172e-08</Coef>
       </X>
       <Y order1="5">
-        <Coef exponent1="0">-1049712.7187069822</Coef>
-        <Coef exponent1="1">6236.733905546889</Coef>
-        <Coef exponent1="2">0.5211481133917936</Coef>
-        <Coef exponent1="3">-0.001032145860271645</Coef>
-        <Coef exponent1="4">-4.4279215119308946e-08</Coef>
-        <Coef exponent1="5">2.3725686228796543e-10</Coef>
+        <Coef exponent1="0">213993.75072911583</Coef>
+        <Coef exponent1="1">5382.906798028648</Coef>
+        <Coef exponent1="2">-0.13403449085492233</Coef>
+        <Coef exponent1="3">-0.0011235974358028706</Coef>
+        <Coef exponent1="4">1.3125488978465116e-08</Coef>
+        <Coef exponent1="5">3.311017835263107e-10</Coef>
       </Y>
       <Z order1="5">
-        <Coef exponent1="0">1037377.8795793299</Coef>
-        <Coef exponent1="1">3876.4857837673303</Coef>
-        <Coef exponent1="2">-0.5150370396531049</Coef>
-        <Coef exponent1="3">-0.0006413991418346274</Coef>
-        <Coef exponent1="4">4.1109885533649076e-08</Coef>
-        <Coef exponent1="5">2.732374834891698e-10</Coef>
+        <Coef exponent1="0">-381622.8863085307</Coef>
+        <Coef exponent1="1">5422.42972684943</Coef>
+        <Coef exponent1="2">0.2389905627611193</Coef>
+        <Coef exponent1="3">-0.0011319651539432873</Coef>
+        <Coef exponent1="4">-1.2504332933503368e-08</Coef>
+        <Coef exponent1="5">-2.7636602008539114e-09</Coef>
       </Z>
     </TxAPCPoly>
     <RcvAPC size="1">
       <RcvAPCPoly index="1">
         <X order1="5">
-          <Coef exponent1="0">7228591.873064231</Coef>
-          <Coef exponent1="1">349.35203073848567</Coef>
-          <Coef exponent1="2">-3.5888150782417543</Coef>
-          <Coef exponent1="3">-5.721932194916093e-05</Coef>
-          <Coef exponent1="4">2.9420750505303616e-07</Coef>
-          <Coef exponent1="5">3.7643643999940754e-10</Coef>
+          <Coef exponent1="0">6818176.555581735</Coef>
+          <Coef exponent1="1">-113.15015800950331</Coef>
+          <Coef exponent1="2">-4.270104943675465</Coef>
+          <Coef exponent1="3">2.4288247117231106e-05</Coef>
+          <Coef exponent1="4">7.141928003967236e-07</Coef>
+          <Coef exponent1="5">-6.113453337167422e-08</Coef>
         </X>
         <Y order1="5">
-          <Coef exponent1="0">1037377.879579329</Coef>
-          <Coef exponent1="1">3876.485783772678</Coef>
-          <Coef exponent1="2">-0.5150370506416224</Coef>
-          <Coef exponent1="3">-0.0006413897271125511</Coef>
-          <Coef exponent1="4">3.7579090483879526e-08</Coef>
-          <Coef exponent1="5">7.661408873950234e-10</Coef>
+          <Coef exponent1="0">-69181.12202632822</Coef>
+          <Coef exponent1="1">6820.799858281281</Coef>
+          <Coef exponent1="2">0.04330965520731738</Coef>
+          <Coef exponent1="3">-0.001423791930655521</Coef>
+          <Coef exponent1="4">-2.714347932553484e-09</Coef>
+          <Coef exponent1="5">-2.4765257766838546e-10</Coef>
         </Y>
         <Z order1="5">
-          <Coef exponent1="0">1049712.7187069813</Coef>
-          <Coef exponent1="1">-6236.733905544733</Coef>
-          <Coef exponent1="2">-0.5211481187626775</Coef>
-          <Coef exponent1="3">0.001032150750149735</Coef>
-          <Coef exponent1="4">4.233522616045636e-08</Coef>
-          <Coef exponent1="5">5.136923640479921e-11</Coef>
+          <Coef exponent1="0">-360992.3589466505</Coef>
+          <Coef exponent1="1">-3443.8926846702957</Coef>
+          <Coef exponent1="2">0.22609196599029524</Coef>
+          <Coef exponent1="3">0.0007188269998665166</Coef>
+          <Coef exponent1="4">-2.6949580939956374e-08</Coef>
+          <Coef exponent1="5">7.081648732562689e-10</Coef>
         </Z>
       </RcvAPCPoly>
     </RcvAPC>
   </Position>
   <RadarCollection>
     <TxFrequency>
-      <Min>9831251195.313576</Min>
-      <Max>10168748804.686424</Max>
+      <Min>7914224902.942896</Min>
+      <Max>8085775097.057104</Max>
     </TxFrequency>
     <Waveform size="1">
       <WFParameters index="1">
-        <TxPulseLength>1.3499904374914016e-05</TxPulseLength>
-        <TxRFBandwidth>337497609.3728504</TxRFBandwidth>
-        <TxFreqStart>9831251195.313576</TxFreqStart>
-        <TxFMRate>25000000000000.0</TxFMRate>
-        <RcvDemodType>STRETCH</RcvDemodType>
-        <RcvWindowLength>2.5878502230492327e-05</RcvWindowLength>
-        <ADCSampleRate>371357935.6673492</ADCSampleRate>
-        <RcvIFBandwidth>340411441.0284035</RcvIFBandwidth>
-        <RcvFreqStart>9831251195.313576</RcvFreqStart>
-        <RcvFMRate>25000000000000.0</RcvFMRate>
+        <TxPulseLength>1.1436679607613818e-06</TxPulseLength>
+        <TxRFBandwidth>171550194.11420727</TxRFBandwidth>
+        <TxFreqStart>7914224902.942896</TxFreqStart>
+        <TxFMRate>150000000000000.0</TxFMRate>
+        <RcvDemodType>CHIRP</RcvDemodType>
+        <RcvWindowLength>7.70313242195461e-06</RcvWindowLength>
+        <ADCSampleRate>205860232.9370487</ADCSampleRate>
+        <RcvIFBandwidth>188705213.525628</RcvIFBandwidth>
+        <RcvFreqStart>8000000000.0</RcvFreqStart>
+        <RcvFMRate>0.0</RcvFMRate>
       </WFParameters>
     </Waveform>
     <TxPolarization>V</TxPolarization>
@@ -546,24 +517,24 @@
     <Area>
       <Corner>
         <ACP index="1">
-          <Lat>0.013565541522053958</Lat>
-          <Lon>-0.01347472901336879</Lon>
-          <HAE>0.3539563147351146</HAE>
+          <Lat>-0.004071371993520929</Lat>
+          <Lon>0.014512254166348713</Lon>
+          <HAE>0.220586814917624</HAE>
         </ACP>
         <ACP index="2">
-          <Lat>0.013565541522053961</Lat>
-          <Lon>0.013474729013368785</Lon>
-          <HAE>0.3539563147351146</HAE>
+          <Lat>-0.009245224252378946</Lat>
+          <Lon>-0.011942645968887807</Lon>
+          <HAE>0.22103187534958124</HAE>
         </ACP>
         <ACP index="3">
-          <Lat>-0.013565541522053958</Lat>
-          <Lon>0.01347472901336879</Lon>
-          <HAE>0.3539563147351146</HAE>
+          <Lat>0.004071371993520929</Lat>
+          <Lon>-0.014512254166348713</Lon>
+          <HAE>0.220586814917624</HAE>
         </ACP>
         <ACP index="4">
-          <Lat>-0.013565541522053961</Lat>
-          <Lon>-0.013474729013368785</Lon>
-          <HAE>0.3539563147351146</HAE>
+          <Lat>0.009245224252378946</Lat>
+          <Lon>0.011942645968887807</Lon>
+          <HAE>0.22103187534958124</HAE>
         </ACP>
       </Corner>
       <Plane>
@@ -573,35 +544,35 @@
             <Y>0.0</Y>
             <Z>0.0</Z>
           </ECF>
-          <Line>3486.0</Line>
-          <Sample>1125.0</Sample>
+          <Line>918.0</Line>
+          <Sample>1874.0</Sample>
         </RefPt>
         <XDir>
           <UVectECF>
             <X>0.0</X>
-            <Y>7.850462293418876e-17</Y>
-            <Z>-1.0</Z>
+            <Y>-0.19069832758209104</Y>
+            <Z>0.9816486886139021</Z>
           </UVectECF>
-          <LineSpacing>0.43033155140602114</LineSpacing>
-          <NumLines>6973</NumLines>
+          <LineSpacing>0.8172928503583853</LineSpacing>
+          <NumLines>1837</NumLines>
           <FirstLine>0</FirstLine>
         </XDir>
         <YDir>
           <UVectECF>
             <X>0.0</X>
-            <Y>1.0</Y>
-            <Z>7.850462293418876e-17</Z>
+            <Y>-0.9816486886139021</Y>
+            <Z>-0.19069832758209104</Z>
           </UVectECF>
-          <SampleSpacing>1.3334613092121825</SampleSpacing>
-          <NumSamples>2251</NumSamples>
+          <SampleSpacing>0.8003304056038929</SampleSpacing>
+          <NumSamples>3749</NumSamples>
           <FirstSample>0</FirstSample>
         </YDir>
         <SegmentList size="1">
           <Segment index="1">
             <StartLine>0</StartLine>
             <StartSample>0</StartSample>
-            <EndLine>6972</EndLine>
-            <EndSample>2250</EndSample>
+            <EndLine>1836</EndLine>
+            <EndSample>3748</EndSample>
             <Identifier>the segment</Identifier>
             <SegmentPolygon size="4">
               <SV index="1">
@@ -610,14 +581,14 @@
               </SV>
               <SV index="2">
                 <Line>-0.5</Line>
-                <Sample>2250.5</Sample>
+                <Sample>3748.5</Sample>
               </SV>
               <SV index="3">
-                <Line>6972.5</Line>
-                <Sample>2250.5</Sample>
+                <Line>1836.5</Line>
+                <Sample>3748.5</Sample>
               </SV>
               <SV index="4">
-                <Line>6972.5</Line>
+                <Line>1836.5</Line>
                 <Sample>-0.5</Sample>
               </SV>
             </SegmentPolygon>
@@ -630,14 +601,14 @@
           </Vertex>
           <Vertex index="2">
             <Line>-0.5</Line>
-            <Sample>2250.5</Sample>
+            <Sample>3748.5</Sample>
           </Vertex>
           <Vertex index="3">
-            <Line>6972.5</Line>
-            <Sample>2250.5</Sample>
+            <Line>1836.5</Line>
+            <Sample>3748.5</Sample>
           </Vertex>
           <Vertex index="4">
-            <Line>6972.5</Line>
+            <Line>1836.5</Line>
             <Sample>-0.5</Sample>
           </Vertex>
         </Polygon>
@@ -650,11 +621,11 @@
       <ChanIndex>1</ChanIndex>
     </RcvChanProc>
     <TxRcvPolarizationProc>V:V</TxRcvPolarizationProc>
-    <TStartProc>0.005681678814600955</TStartProc>
-    <TEndProc>2.544960558148007</TEndProc>
+    <TStartProc>0.0019863335465475215</TStartProc>
+    <TEndProc>1.5904381843919515</TEndProc>
     <TxFrequencyProc>
-      <MinProc>9831251195.31346</MinProc>
-      <MaxProc>10168748804.68658</MaxProc>
+      <MinProc>7914224902.942802</MinProc>
+      <MaxProc>8085775097.057162</MaxProc>
     </TxFrequencyProc>
     <SegmentIdentifier>the segment</SegmentIdentifier>
     <ImageFormAlgo>PFA</ImageFormAlgo>
@@ -669,97 +640,97 @@
       <Parameter name="kazimuth">fixed</Parameter>
     </Processing>
     <Processing>
-      <Type>Valkyrie Systems Sage | sar_common_kit 1.12.7.0 @ 2024-05-29T14:12:54.542381Z</Type>
+      <Type>Valkyrie Systems Sage | sar_common_kit 2.1.3.0 @ 2026-04-21T22:15:58Z</Type>
       <Applied>true</Applied>
     </Processing>
     <Processing>
       <Type>polar_deterministic_phase</Type>
       <Applied>true</Applied>
       <Parameter name="phase_contiguous">true</Parameter>
-      <Parameter name="quadratic_type">none</Parameter>
-      <Parameter name="linear_type">none</Parameter>
+      <Parameter name="quadratic_type">one_dimensional</Parameter>
+      <Parameter name="linear_type">one_dimensional</Parameter>
       <Parameter name="constant_type">one_dimensional</Parameter>
     </Processing>
   </ImageFormation>
   <SCPCOA>
-    <SCPTime>1.220622599302364</SCPTime>
+    <SCPTime>0.7442796573752982</SCPTime>
     <ARPPos>
-      <X>7454436.897212301</X>
-      <Y>3.196803887290116</Y>
-      <Z>1318154.045054647</Z>
+      <X>6829334.099529434</X>
+      <Y>74101.73535561281</Y>
+      <Z>-381448.3895529903</Z>
     </ARPPos>
     <ARPVel>
-      <X>183.18553958831498</X>
-      <Y>6396.148135849851</Y>
-      <Z>-1797.6598076071073</Z>
+      <X>-219.3307074502215</X>
+      <Y>6599.769796873022</Y>
+      <Z>1022.674186720536</Z>
     </ARPVel>
     <ARPAcc>
-      <X>-4.665751377210959</X>
-      <Y>-2.943416986273964</Y>
-      <Z>5.028001363512413</Z>
+      <X>17.26296561298696</X>
+      <Y>-3.980671272558043</Y>
+      <Z>-1.6092210582983228</Z>
     </ARPAcc>
-    <SideOfTrack>R</SideOfTrack>
-    <SlantRange>1701749.5571450454</SlantRange>
-    <GroundRange>1116294.5815923752</GroundRange>
-    <DopplerConeAng>78.92654152200815</DopplerConeAng>
-    <GrazeAng>39.232345287680424</GrazeAng>
-    <IncidenceAng>50.767654712319576</IncidenceAng>
-    <TwistAng>-11.30659792863627</TwistAng>
-    <SlopeAng>40.57506621800416</SlopeAng>
-    <AzimAng>0.00013895445024772232</AzimAng>
-    <LayoverAng>17.54326436775956</LayoverAng>
+    <SideOfTrack>L</SideOfTrack>
+    <SlantRange>595460.1277155819</SlantRange>
+    <GroundRange>362516.0439385509</GroundRange>
+    <DopplerConeAng>89.99993655898173</DopplerConeAng>
+    <GrazeAng>49.26435316516479</GrazeAng>
+    <IncidenceAng>40.73564683483521</IncidenceAng>
+    <TwistAng>-2.8830483687849697</TwistAng>
+    <SlopeAng>49.32677972877933</SlopeAng>
+    <AzimAng>169.00641496591686</AzimAng>
+    <LayoverAng>172.80889385823605</LayoverAng>
     <Bistatic>
-      <BistaticAng>75.52489181855174</BistaticAng>
-      <BistaticAngRate>-0.0340344908580102</BistaticAngRate>
+      <BistaticAng>27.142132282858896</BistaticAng>
+      <BistaticAngRate>-0.1507498467644411</BistaticAngRate>
       <TxPlatform>
-        <Time>1.2149461737909288</Time>
+        <Time>0.7422229004109115</Time>
         <Pos>
-          <X>7229011.019446171</X>
-          <Y>-1042134.655298896</Y>
-          <Z>1042086.8397567043</Z>
+          <X>6814137.3550297525</X>
+          <Y>217988.99312706164</Y>
+          <Z>-377598.10359357775</Z>
         </Pos>
         <Vel>
-          <X>340.63134517481444</X>
-          <Y>6237.995668410955</Y>
-          <Z>3875.2314592071652</Z>
+          <X>128.28202963930843</X>
+          <Y>5382.705974161435</Y>
+          <Z>5422.782624580846</Z>
         </Vel>
         <Acc>
-          <X>-7.178042045200563</X>
-          <Y>1.0347714409874964</Y>
-          <Z>-1.034748933920567</Z>
+          <X>-8.535165415792923</X>
+          <Y>-0.2730726507191883</Y>
+          <Z>0.472939997500545</Z>
         </Acc>
-        <SideOfTrack>R</SideOfTrack>
-        <SlantRange>1701756.803523214</SlantRange>
-        <GroundRange>1282722.60115929</GroundRange>
-        <DopplerConeAng>79.99897665632014</DopplerConeAng>
-        <GrazeAng>29.999829628178375</GrazeAng>
-        <IncidenceAng>60.000170371821625</IncidenceAng>
-        <AzimAng>314.9986855385722</AzimAng>
+        <SideOfTrack>L</SideOfTrack>
+        <SlantRange>616600.2258741774</SlantRange>
+        <GroundRange>407550.8904550475</GroundRange>
+        <DopplerConeAng>79.99857223802604</DopplerConeAng>
+        <GrazeAng>44.999757418893516</GrazeAng>
+        <IncidenceAng>45.000242581106484</IncidenceAng>
+        <AzimAng>150.00197721213226</AzimAng>
       </TxPlatform>
       <RcvPlatform>
-        <Time>1.2262990248137993</Time>
+        <Time>0.7461953827853025</Time>
         <Pos>
-          <X>7229014.886120505</X>
-          <Y>1042130.8346154559</Y>
-          <Z>1042063.8361967074</Z>
+          <X>6818089.745839898</X>
+          <Y>-64091.449141601355</Y>
+          <Z>-363562.04957839084</Z>
         </Pos>
         <Vel>
-          <X>340.54985391074274</X>
-          <Y>3875.2197116091465</Y>
-          <Z>-6238.007415617825</Z>
+          <X>-119.52278153164109</X>
+          <Y>6820.86211487159</Y>
+          <Z>-3443.5540664068726</Z>
         </Vel>
         <Acc>
-          <X>-7.17804584140809</X>
-          <Y>-1.034792608466006</Y>
-          <Z>-1.0347011189112367</Z>
+          <X>-8.540096880680835</X>
+          <Y>0.08024472843205936</Y>
+          <Z>0.455402070126429</Z>
         </Acc>
-        <SideOfTrack>R</SideOfTrack>
-        <SlantRange>1701742.3107668809</SlantRange>
-        <GroundRange>1282705.8664475959</GroundRange>
-        <DopplerConeAng>79.99897665619744</DopplerConeAng>
-        <GrazeAng>30.000261674499125</GrazeAng>
-        <IncidenceAng>59.99973832550087</IncidenceAng>
-        <AzimAng>45.001841827292225</AzimAng>
+        <SideOfTrack>L</SideOfTrack>
+        <SlantRange>574320.0295295091</SlantRange>
+        <GroundRange>345009.7838138197</GroundRange>
+        <DopplerConeAng>100.00122351272505</DopplerConeAng>
+        <GrazeAng>49.99970180042929</GrazeAng>
+        <IncidenceAng>40.00029819957071</IncidenceAng>
+        <AzimAng>189.99780677851265</AzimAng>
       </RcvPlatform>
     </Bistatic>
   </SCPCOA>
@@ -767,97 +738,227 @@
     <NoiseLevel>
       <NoiseLevelType>ABSOLUTE</NoiseLevelType>
       <NoisePoly order1="0" order2="0">
-        <Coef exponent1="0" exponent2="0">-70.61028002864373</Coef>
+        <Coef exponent1="0" exponent2="0">-67.85314215301139</Coef>
       </NoisePoly>
     </NoiseLevel>
-    <RCSSFPoly order1="5" order2="4">
-      <Coef exponent1="0" exponent2="0">1.0009107550886</Coef>
-      <Coef exponent1="0" exponent2="1">-1.2656962480467898e-08</Coef>
-      <Coef exponent1="0" exponent2="2">1.841160823979366e-07</Coef>
-      <Coef exponent1="0" exponent2="3">7.37605984703672e-14</Coef>
-      <Coef exponent1="0" exponent2="4">2.3376306367702188e-14</Coef>
-      <Coef exponent1="1" exponent2="0">1.8645443146453884e-06</Coef>
-      <Coef exponent1="1" exponent2="1">-5.974449624682831e-08</Coef>
-      <Coef exponent1="1" exponent2="2">1.477222002059004e-13</Coef>
-      <Coef exponent1="1" exponent2="3">-1.567005982925404e-14</Coef>
-      <Coef exponent1="1" exponent2="4">5.62973990351021e-21</Coef>
-      <Coef exponent1="2" exponent2="0">2.9915266098531715e-07</Coef>
-      <Coef exponent1="2" exponent2="1">-2.5952777137288582e-14</Coef>
-      <Coef exponent1="2" exponent2="2">6.391795060352621e-14</Coef>
-      <Coef exponent1="2" exponent2="3">5.490727612893473e-20</Coef>
-      <Coef exponent1="2" exponent2="4">1.0910470909479996e-20</Coef>
-      <Coef exponent1="3" exponent2="0">-3.652591414143523e-14</Coef>
-      <Coef exponent1="3" exponent2="1">-1.457647634489385e-14</Coef>
-      <Coef exponent1="3" exponent2="2">-4.566165397967709e-20</Coef>
-      <Coef exponent1="3" exponent2="3">-1.0062412563341771e-20</Coef>
-      <Coef exponent1="3" exponent2="4">-4.039707185538362e-26</Coef>
-      <Coef exponent1="4" exponent2="0">6.245092836531276e-14</Coef>
-      <Coef exponent1="4" exponent2="1">9.22097450583639e-20</Coef>
-      <Coef exponent1="4" exponent2="2">1.9018060090238893e-20</Coef>
-      <Coef exponent1="4" exponent2="3">2.676161031873004e-26</Coef>
-      <Coef exponent1="4" exponent2="4">2.0473637507616747e-27</Coef>
-      <Coef exponent1="5" exponent2="0">-1.4156917307094574e-19</Coef>
-      <Coef exponent1="5" exponent2="1">-7.008482656417528e-21</Coef>
-      <Coef exponent1="5" exponent2="2">-7.161305555692102e-26</Coef>
-      <Coef exponent1="5" exponent2="3">5.030180584628427e-28</Coef>
-      <Coef exponent1="5" exponent2="4">5.986398355224382e-33</Coef>
+    <RCSSFPoly order1="4" order2="6">
+      <Coef exponent1="0" exponent2="0">0.9995564844443969</Coef>
+      <Coef exponent1="0" exponent2="1">-4.512025205802459e-08</Coef>
+      <Coef exponent1="0" exponent2="2">4.485364227533628e-07</Coef>
+      <Coef exponent1="0" exponent2="3">9.115861511859726e-15</Coef>
+      <Coef exponent1="0" exponent2="4">8.246752484063312e-14</Coef>
+      <Coef exponent1="0" exponent2="5">8.242837856070258e-20</Coef>
+      <Coef exponent1="0" exponent2="6">3.0327268947826845e-20</Coef>
+      <Coef exponent1="1" exponent2="0">6.562670443856132e-06</Coef>
+      <Coef exponent1="1" exponent2="1">-6.528292750825136e-08</Coef>
+      <Coef exponent1="1" exponent2="2">1.4977413385655355e-12</Coef>
+      <Coef exponent1="1" exponent2="3">-2.06707097052728e-14</Coef>
+      <Coef exponent1="1" exponent2="4">3.0335449443620667e-19</Coef>
+      <Coef exponent1="1" exponent2="5">-1.474890633120764e-20</Coef>
+      <Coef exponent1="1" exponent2="6">-1.733863415998571e-25</Coef>
+      <Coef exponent1="2" exponent2="0">6.479188353416587e-07</Coef>
+      <Coef exponent1="2" exponent2="1">1.3718174582152094e-13</Coef>
+      <Coef exponent1="2" exponent2="2">3.422761180866727e-13</Coef>
+      <Coef exponent1="2" exponent2="3">-6.994564381206083e-20</Coef>
+      <Coef exponent1="2" exponent2="4">4.271623660010685e-20</Coef>
+      <Coef exponent1="2" exponent2="5">2.7374939941713916e-25</Coef>
+      <Coef exponent1="2" exponent2="6">3.5244029618074744e-26</Coef>
+      <Coef exponent1="3" exponent2="0">-2.372498680863021e-13</Coef>
+      <Coef exponent1="3" exponent2="1">-4.6043402992652674e-14</Coef>
+      <Coef exponent1="3" exponent2="2">-8.22154842985437e-19</Coef>
+      <Coef exponent1="3" exponent2="3">-3.072074760010437e-20</Coef>
+      <Coef exponent1="3" exponent2="4">-8.303110713776874e-25</Coef>
+      <Coef exponent1="3" exponent2="5">-1.006919495479769e-26</Coef>
+      <Coef exponent1="3" exponent2="6">-2.3069938113911927e-31</Coef>
+      <Coef exponent1="4" exponent2="0">2.5182698689051695e-13</Coef>
+      <Coef exponent1="4" exponent2="1">2.4043561203932755e-19</Coef>
+      <Coef exponent1="4" exponent2="2">1.739072326795405e-20</Coef>
+      <Coef exponent1="4" exponent2="3">4.0266341298088717e-25</Coef>
+      <Coef exponent1="4" exponent2="4">2.0289941132413786e-25</Coef>
+      <Coef exponent1="4" exponent2="5">7.396382646062382e-32</Coef>
+      <Coef exponent1="4" exponent2="6">-3.901590618009349e-32</Coef>
     </RCSSFPoly>
+    <SigmaZeroSFPoly order1="4" order2="6">
+      <Coef exponent1="0" exponent2="0">0.5271717098032256</Coef>
+      <Coef exponent1="0" exponent2="1">-1.0352625842446279e-07</Coef>
+      <Coef exponent1="0" exponent2="2">2.3655900247822784e-07</Coef>
+      <Coef exponent1="0" exponent2="3">-2.0404949004943128e-14</Coef>
+      <Coef exponent1="0" exponent2="4">4.349252541183133e-14</Coef>
+      <Coef exponent1="0" exponent2="5">2.810091941059306e-20</Coef>
+      <Coef exponent1="0" exponent2="6">1.5994457487490534e-20</Coef>
+      <Coef exponent1="1" exponent2="0">4.168268945691486e-06</Coef>
+      <Coef exponent1="1" exponent2="1">-3.443048742624329e-08</Coef>
+      <Coef exponent1="1" exponent2="2">1.1124680087053262e-12</Coef>
+      <Coef exponent1="1" exponent2="3">-1.0901921338323315e-14</Coef>
+      <Coef exponent1="1" exponent2="4">2.1924759453958104e-19</Coef>
+      <Coef exponent1="1" exponent2="5">-7.778269170279783e-21</Coef>
+      <Coef exponent1="1" exponent2="6">-6.890793925189292e-26</Coef>
+      <Coef exponent1="2" exponent2="0">3.417171159187171e-07</Coef>
+      <Coef exponent1="2" exponent2="1">-3.496530318754147e-14</Coef>
+      <Coef exponent1="2" exponent2="2">1.805002878886817e-13</Coef>
+      <Coef exponent1="2" exponent2="3">-4.9105658487974874e-20</Coef>
+      <Coef exponent1="2" exponent2="4">2.2539356875361637e-20</Coef>
+      <Coef exponent1="2" exponent2="5">1.1355641607831063e-25</Coef>
+      <Coef exponent1="2" exponent2="6">1.858368502424979e-26</Coef>
+      <Coef exponent1="3" exponent2="0">3.885437213552711e-13</Coef>
+      <Coef exponent1="3" exponent2="1">-2.4282747884656178e-14</Coef>
+      <Coef exponent1="3" exponent2="2">-1.7990018539450408e-19</Coef>
+      <Coef exponent1="3" exponent2="3">-1.6201216311969563e-20</Coef>
+      <Coef exponent1="3" exponent2="4">-3.6610762272518636e-25</Coef>
+      <Coef exponent1="3" exponent2="5">-5.309930845938084e-27</Coef>
+      <Coef exponent1="3" exponent2="6">-1.0272324772190147e-31</Coef>
+      <Coef exponent1="4" exponent2="0">1.3279861597783992e-13</Coef>
+      <Coef exponent1="4" exponent2="1">1.1747579528901327e-19</Coef>
+      <Coef exponent1="4" exponent2="2">9.210883645929614e-21</Coef>
+      <Coef exponent1="4" exponent2="3">8.944249927520826e-26</Coef>
+      <Coef exponent1="4" exponent2="4">1.0696851483270806e-25</Coef>
+      <Coef exponent1="4" exponent2="5">5.931072904250642e-32</Coef>
+      <Coef exponent1="4" exponent2="6">-2.056767714817772e-32</Coef>
+    </SigmaZeroSFPoly>
+    <BetaZeroSFPoly order1="5" order2="6">
+      <Coef exponent1="0" exponent2="0">0.8088743972258872</Coef>
+      <Coef exponent1="0" exponent2="1">-4.1876086859784246e-08</Coef>
+      <Coef exponent1="0" exponent2="2">3.6297060051043723e-07</Coef>
+      <Coef exponent1="0" exponent2="3">5.121239161109766e-15</Coef>
+      <Coef exponent1="0" exponent2="4">6.673415330426811e-14</Coef>
+      <Coef exponent1="0" exponent2="5">6.581841972336254e-20</Coef>
+      <Coef exponent1="0" exponent2="6">2.4541852623660132e-20</Coef>
+      <Coef exponent1="1" exponent2="0">4.274938631040472e-06</Coef>
+      <Coef exponent1="1" exponent2="1">-5.282893819550024e-08</Coef>
+      <Coef exponent1="1" exponent2="2">7.496899680091746e-13</Coef>
+      <Coef exponent1="1" exponent2="3">-1.6727629687581142e-14</Coef>
+      <Coef exponent1="1" exponent2="4">1.5626353687552165e-19</Coef>
+      <Coef exponent1="1" exponent2="5">-1.1935244123539981e-20</Coef>
+      <Coef exponent1="1" exponent2="6">-1.7065450718584042e-25</Coef>
+      <Coef exponent1="2" exponent2="0">5.243162204636224e-07</Coef>
+      <Coef exponent1="2" exponent2="1">1.6662329988379421e-13</Coef>
+      <Coef exponent1="2" exponent2="2">2.769572228440086e-13</Coef>
+      <Coef exponent1="2" exponent2="3">-1.7849359949500833e-20</Coef>
+      <Coef exponent1="2" exponent2="4">3.458395057627198e-20</Coef>
+      <Coef exponent1="2" exponent2="5">2.2871120698662217e-25</Coef>
+      <Coef exponent1="2" exponent2="6">2.851546780990516e-26</Coef>
+      <Coef exponent1="3" exponent2="0">-7.771940418215222e-13</Coef>
+      <Coef exponent1="3" exponent2="1">-3.726140865040365e-14</Coef>
+      <Coef exponent1="3" exponent2="2">-1.021722653754844e-18</Coef>
+      <Coef exponent1="3" exponent2="3">-2.485661550598688e-20</Coef>
+      <Coef exponent1="3" exponent2="4">-6.345705294607292e-25</Coef>
+      <Coef exponent1="3" exponent2="5">-8.14938916291348e-27</Coef>
+      <Coef exponent1="3" exponent2="6">-2.4012674464163275e-31</Coef>
+      <Coef exponent1="4" exponent2="0">2.037705481932153e-13</Coef>
+      <Coef exponent1="4" exponent2="1">2.7328575464457674e-19</Coef>
+      <Coef exponent1="4" exponent2="2">1.413757844248607e-20</Coef>
+      <Coef exponent1="4" exponent2="3">2.8270485456944833e-25</Coef>
+      <Coef exponent1="4" exponent2="4">1.64134783447877e-25</Coef>
+      <Coef exponent1="4" exponent2="5">9.770946108344675e-32</Coef>
+      <Coef exponent1="4" exponent2="6">-3.1558261981767345e-32</Coef>
+      <Coef exponent1="5" exponent2="0">-5.406075351784971e-19</Coef>
+      <Coef exponent1="5" exponent2="1">3.677408090910964e-24</Coef>
+      <Coef exponent1="5" exponent2="2">4.0787309617498535e-26</Coef>
+      <Coef exponent1="5" exponent2="3">-1.0730738582875164e-29</Coef>
+      <Coef exponent1="5" exponent2="4">-5.483013095973188e-31</Coef>
+      <Coef exponent1="5" exponent2="5">2.9564762416103535e-36</Coef>
+      <Coef exponent1="5" exponent2="6">1.205024060127711e-37</Coef>
+    </BetaZeroSFPoly>
+    <GammaZeroSFPoly order1="5" order2="6">
+      <Coef exponent1="0" exponent2="0">0.6957192163765541</Coef>
+      <Coef exponent1="0" exponent2="1">-1.4789538907054675e-07</Coef>
+      <Coef exponent1="0" exponent2="2">3.1219166594496043e-07</Coef>
+      <Coef exponent1="0" exponent2="3">-3.043871571651747e-14</Coef>
+      <Coef exponent1="0" exponent2="4">5.739795035203836e-14</Coef>
+      <Coef exponent1="0" exponent2="5">3.489837649970753e-20</Coef>
+      <Coef exponent1="0" exponent2="6">2.1108199003100785e-20</Coef>
+      <Coef exponent1="1" exponent2="0">6.849075369494093e-06</Coef>
+      <Coef exponent1="1" exponent2="1">-4.543897237852733e-08</Coef>
+      <Coef exponent1="1" exponent2="2">2.073633641136981e-12</Coef>
+      <Coef exponent1="1" exponent2="3">-1.4387569882660523e-14</Coef>
+      <Coef exponent1="1" exponent2="4">4.0106710030700983e-19</Coef>
+      <Coef exponent1="1" exponent2="5">-1.0265063808765686e-20</Coef>
+      <Coef exponent1="1" exponent2="6">-4.998144726582695e-26</Coef>
+      <Coef exponent1="2" exponent2="0">4.5098202340982176e-07</Coef>
+      <Coef exponent1="2" exponent2="1">-1.4207044389234918e-13</Coef>
+      <Coef exponent1="2" exponent2="2">2.3821286588095857e-13</Coef>
+      <Coef exponent1="2" exponent2="3">-9.399990442526014e-20</Coef>
+      <Coef exponent1="2" exponent2="4">2.9746219013504145e-20</Coef>
+      <Coef exponent1="2" exponent2="5">1.2773882373888758e-25</Coef>
+      <Coef exponent1="2" exponent2="6">2.4525090294058528e-26</Coef>
+      <Coef exponent1="3" exponent2="0">1.3865149770957533e-12</Coef>
+      <Coef exponent1="3" exponent2="1">-3.2046482645929964e-14</Coef>
+      <Coef exponent1="3" exponent2="2">2.26055682558691e-19</Coef>
+      <Coef exponent1="3" exponent2="3">-2.1381345041648924e-20</Coef>
+      <Coef exponent1="3" exponent2="4">-4.272406075737914e-25</Coef>
+      <Coef exponent1="3" exponent2="5">-7.007274017681857e-27</Coef>
+      <Coef exponent1="3" exponent2="6">-8.729646831699079e-32</Coef>
+      <Coef exponent1="4" exponent2="0">1.7525828552518888e-13</Coef>
+      <Coef exponent1="4" exponent2="1">9.338565299901421e-20</Coef>
+      <Coef exponent1="4" exponent2="2">1.2155419617820148e-20</Coef>
+      <Coef exponent1="4" exponent2="3">6.887554467151335e-26</Coef>
+      <Coef exponent1="4" exponent2="4">1.4116761782510466e-25</Coef>
+      <Coef exponent1="4" exponent2="5">6.61068817162638e-32</Coef>
+      <Coef exponent1="4" exponent2="6">-2.7143838912664756e-32</Coef>
+      <Coef exponent1="5" exponent2="0">3.40213645078927e-19</Coef>
+      <Coef exponent1="5" exponent2="1">-3.0855372601856517e-26</Coef>
+      <Coef exponent1="5" exponent2="2">1.6053627666104335e-26</Coef>
+      <Coef exponent1="5" exponent2="3">7.722273783420746e-31</Coef>
+      <Coef exponent1="5" exponent2="4">2.849127066362302e-31</Coef>
+      <Coef exponent1="5" exponent2="5">-4.137762677890247e-38</Coef>
+      <Coef exponent1="5" exponent2="6">-5.623525857953493e-38</Coef>
+    </GammaZeroSFPoly>
   </Radiometric>
   <Antenna>
     <Tx>
       <XAxisPoly>
         <X order1="5">
-          <Coef exponent1="0">0.1385797228721903</Coef>
-          <Coef exponent1="1">-0.002760945178520682</Coef>
-          <Coef exponent1="2">-2.6203366249547734e-06</Coef>
-          <Coef exponent1="3">1.4485678722368534e-08</Coef>
-          <Coef exponent1="4">4.876927786251232e-11</Coef>
-          <Coef exponent1="5">-1.1376979196412772e-13</Coef>
+          <Coef exponent1="0">0.1485136819190053</Coef>
+          <Coef exponent1="1">-0.009097208698964859</Coef>
+          <Coef exponent1="2">-2.9192471304146546e-05</Coef>
+          <Coef exponent1="3">5.058379152751132e-07</Coef>
+          <Coef exponent1="4">4.84615770586438e-09</Coef>
+          <Coef exponent1="5">-3.819065533755534e-11</Coef>
         </X>
         <Y order1="5">
-          <Coef exponent1="0">0.7506670547090979</Coef>
-          <Coef exponent1="1">0.002439091450415394</Coef>
-          <Coef exponent1="2">-5.082427564355023e-06</Coef>
-          <Coef exponent1="3">-2.8097256219038232e-08</Coef>
-          <Coef exponent1="4">1.9002256433101935e-11</Coef>
-          <Coef exponent1="5">3.6828276318198224e-13</Coef>
+          <Coef exponent1="0">0.780477662169785</Coef>
+          <Coef exponent1="1">-0.003832341325564988</Coef>
+          <Coef exponent1="2">-6.750601179098808e-05</Coef>
+          <Coef exponent1="3">1.7761441884848833e-08</Coef>
+          <Coef exponent1="4">6.855676942509568e-09</Coef>
+          <Coef exponent1="5">2.585068378608851e-11</Coef>
         </Y>
         <Z order1="5">
-          <Coef exponent1="0">0.6459834621590832</Coef>
-          <Coef exponent1="1">-0.0022420613876123915</Coef>
-          <Coef exponent1="2">-7.927564976264752e-06</Coef>
-          <Coef exponent1="3">1.0018936627184642e-08</Coef>
-          <Coef exponent1="4">9.62944465867411e-11</Coef>
-          <Coef exponent1="5">2.0815204363838186e-14</Coef>
+          <Coef exponent1="0">0.6072876625923178</Coef>
+          <Coef exponent1="1">0.007150016417138304</Coef>
+          <Coef exponent1="2">-2.842470756125102e-05</Coef>
+          <Coef exponent1="3">-6.751782965694428e-07</Coef>
+          <Coef exponent1="4">5.296414181213278e-10</Coef>
+          <Coef exponent1="5">7.677854042430181e-11</Coef>
         </Z>
       </XAxisPoly>
       <YAxisPoly>
         <X order1="5">
-          <Coef exponent1="0">0.8552805091032545</Coef>
-          <Coef exponent1="1">0.00010376114141890252</Coef>
-          <Coef exponent1="2">-1.0609071111614952e-06</Coef>
-          <Coef exponent1="3">-1.207112657984025e-10</Coef>
-          <Coef exponent1="4">6.538241092703245e-13</Coef>
-          <Coef exponent1="5">-5.76536979126892e-16</Coef>
+          <Coef exponent1="0">-0.6926778281801399</Coef>
+          <Coef exponent1="1">-0.00010937291692460795</Coef>
+          <Coef exponent1="2">3.4557074897542944e-06</Coef>
+          <Coef exponent1="3">7.21833022134145e-10</Coef>
+          <Coef exponent1="4">-1.1469299288090318e-11</Coef>
+          <Coef exponent1="5">-3.1243709209366384e-15</Coef>
         </X>
         <Y order1="5">
-          <Coef exponent1="0">0.23813408977855877</Coef>
-          <Coef exponent1="1">0.0005620596491955484</Coef>
-          <Coef exponent1="2">7.653455689187554e-07</Coef>
-          <Coef exponent1="3">-6.62799773310883e-10</Coef>
-          <Coef exponent1="4">-1.2207571830256701e-12</Coef>
-          <Coef exponent1="5">4.229217799962556e-16</Coef>
+          <Coef exponent1="0">0.5203854302504101</Coef>
+          <Coef exponent1="1">-0.0005747828577218941</Coef>
+          <Coef exponent1="2">1.967629235010238e-06</Coef>
+          <Coef exponent1="3">3.6071417854744394e-09</Coef>
+          <Coef exponent1="4">-1.4440561203198273e-11</Coef>
+          <Coef exponent1="5">-1.8145243344110582e-14</Coef>
         </Y>
         <Z order1="5">
-          <Coef exponent1="0">-0.4602036571273811</Coef>
-          <Coef exponent1="1">0.000483678131134207</Coef>
-          <Coef exponent1="2">-9.665445237464232e-07</Coef>
-          <Coef exponent1="3">-8.87617267201027e-10</Coef>
-          <Coef exponent1="4">1.688275707351889e-12</Coef>
-          <Coef exponent1="5">5.84714577712134e-16</Coef>
+          <Coef exponent1="0">-0.49939606559397504</Coef>
+          <Coef exponent1="1">-0.0004472370640190388</Coef>
+          <Coef exponent1="2">-2.1998310931080544e-06</Coef>
+          <Coef exponent1="3">1.7061223656134975e-09</Coef>
+          <Coef exponent1="4">1.5705229445431088e-11</Coef>
+          <Coef exponent1="5">6.399820529300171e-16</Coef>
         </Z>
       </YAxisPoly>
-      <FreqZero>10000000000.0</FreqZero>
+      <FreqZero>8000000000.0</FreqZero>
       <EB>
         <DCXPoly order1="0">
           <Coef exponent1="0">0.0</Coef>
@@ -869,15 +970,15 @@
       <Array>
         <GainPoly order1="8" order2="8">
           <Coef exponent1="0" exponent2="0">0.0</Coef>
-          <Coef exponent1="0" exponent2="1">1.830851508157883e-12</Coef>
-          <Coef exponent1="0" exponent2="2">-1814485.8372625443</Coef>
-          <Coef exponent1="0" exponent2="3">-2.208286609514295e-06</Coef>
-          <Coef exponent1="0" exponent2="4">-67647577942.01662</Coef>
-          <Coef exponent1="0" exponent2="5">1.1886185612774636</Coef>
-          <Coef exponent1="0" exponent2="6">-1463292882577055.0</Coef>
-          <Coef exponent1="0" exponent2="7">-140393.14526142203</Coef>
-          <Coef exponent1="0" exponent2="8">-1.0883947565151394e+21</Coef>
-          <Coef exponent1="1" exponent2="0">1.830851508157883e-12</Coef>
+          <Coef exponent1="0" exponent2="1">1.009612415522748e-12</Coef>
+          <Coef exponent1="0" exponent2="2">-383172.3932529755</Coef>
+          <Coef exponent1="0" exponent2="3">-3.5931372812468714e-07</Coef>
+          <Coef exponent1="0" exponent2="4">-3016709627.9721355</Coef>
+          <Coef exponent1="0" exponent2="5">0.029047578220966968</Coef>
+          <Coef exponent1="0" exponent2="6">-13780124670138.145</Coef>
+          <Coef exponent1="0" exponent2="7">-599.3096165762773</Coef>
+          <Coef exponent1="0" exponent2="8">-2.1644569691145935e+18</Coef>
+          <Coef exponent1="1" exponent2="0">1.009612415522748e-12</Coef>
           <Coef exponent1="1" exponent2="1">0.0</Coef>
           <Coef exponent1="1" exponent2="2">0.0</Coef>
           <Coef exponent1="1" exponent2="3">0.0</Coef>
@@ -886,7 +987,7 @@
           <Coef exponent1="1" exponent2="6">0.0</Coef>
           <Coef exponent1="1" exponent2="7">0.0</Coef>
           <Coef exponent1="1" exponent2="8">0.0</Coef>
-          <Coef exponent1="2" exponent2="0">-1814485.8372625443</Coef>
+          <Coef exponent1="2" exponent2="0">-383172.3932529755</Coef>
           <Coef exponent1="2" exponent2="1">0.0</Coef>
           <Coef exponent1="2" exponent2="2">0.0</Coef>
           <Coef exponent1="2" exponent2="3">0.0</Coef>
@@ -895,7 +996,7 @@
           <Coef exponent1="2" exponent2="6">0.0</Coef>
           <Coef exponent1="2" exponent2="7">0.0</Coef>
           <Coef exponent1="2" exponent2="8">0.0</Coef>
-          <Coef exponent1="3" exponent2="0">-2.208286609514295e-06</Coef>
+          <Coef exponent1="3" exponent2="0">-3.5931372812468714e-07</Coef>
           <Coef exponent1="3" exponent2="1">0.0</Coef>
           <Coef exponent1="3" exponent2="2">0.0</Coef>
           <Coef exponent1="3" exponent2="3">0.0</Coef>
@@ -904,7 +1005,7 @@
           <Coef exponent1="3" exponent2="6">0.0</Coef>
           <Coef exponent1="3" exponent2="7">0.0</Coef>
           <Coef exponent1="3" exponent2="8">0.0</Coef>
-          <Coef exponent1="4" exponent2="0">-67647577942.01662</Coef>
+          <Coef exponent1="4" exponent2="0">-3016709627.9721355</Coef>
           <Coef exponent1="4" exponent2="1">0.0</Coef>
           <Coef exponent1="4" exponent2="2">0.0</Coef>
           <Coef exponent1="4" exponent2="3">0.0</Coef>
@@ -913,7 +1014,7 @@
           <Coef exponent1="4" exponent2="6">0.0</Coef>
           <Coef exponent1="4" exponent2="7">0.0</Coef>
           <Coef exponent1="4" exponent2="8">0.0</Coef>
-          <Coef exponent1="5" exponent2="0">1.1886185612774636</Coef>
+          <Coef exponent1="5" exponent2="0">0.029047578220966968</Coef>
           <Coef exponent1="5" exponent2="1">0.0</Coef>
           <Coef exponent1="5" exponent2="2">0.0</Coef>
           <Coef exponent1="5" exponent2="3">0.0</Coef>
@@ -922,7 +1023,7 @@
           <Coef exponent1="5" exponent2="6">0.0</Coef>
           <Coef exponent1="5" exponent2="7">0.0</Coef>
           <Coef exponent1="5" exponent2="8">0.0</Coef>
-          <Coef exponent1="6" exponent2="0">-1463292882577055.0</Coef>
+          <Coef exponent1="6" exponent2="0">-13780124670138.145</Coef>
           <Coef exponent1="6" exponent2="1">0.0</Coef>
           <Coef exponent1="6" exponent2="2">0.0</Coef>
           <Coef exponent1="6" exponent2="3">0.0</Coef>
@@ -931,7 +1032,7 @@
           <Coef exponent1="6" exponent2="6">0.0</Coef>
           <Coef exponent1="6" exponent2="7">0.0</Coef>
           <Coef exponent1="6" exponent2="8">0.0</Coef>
-          <Coef exponent1="7" exponent2="0">-140393.14526142203</Coef>
+          <Coef exponent1="7" exponent2="0">-599.3096165762773</Coef>
           <Coef exponent1="7" exponent2="1">0.0</Coef>
           <Coef exponent1="7" exponent2="2">0.0</Coef>
           <Coef exponent1="7" exponent2="3">0.0</Coef>
@@ -940,7 +1041,7 @@
           <Coef exponent1="7" exponent2="6">0.0</Coef>
           <Coef exponent1="7" exponent2="7">0.0</Coef>
           <Coef exponent1="7" exponent2="8">0.0</Coef>
-          <Coef exponent1="8" exponent2="0">-1.0883947565151394e+21</Coef>
+          <Coef exponent1="8" exponent2="0">-2.1644569691145935e+18</Coef>
           <Coef exponent1="8" exponent2="1">0.0</Coef>
           <Coef exponent1="8" exponent2="2">0.0</Coef>
           <Coef exponent1="8" exponent2="3">0.0</Coef>
@@ -970,57 +1071,57 @@
     <Rcv>
       <XAxisPoly>
         <X order1="5">
-          <Coef exponent1="0">0.13857972287219025</Coef>
-          <Coef exponent1="1">-0.00276094517852056</Coef>
-          <Coef exponent1="2">-2.620336625243285e-06</Coef>
-          <Coef exponent1="3">1.4485678988875624e-08</Coef>
-          <Coef exponent1="4">4.8769161197407225e-11</Coef>
-          <Coef exponent1="5">-1.1375096936147393e-13</Coef>
+          <Coef exponent1="0">-0.14315402850068526</Coef>
+          <Coef exponent1="1">-0.010503310410643726</Coef>
+          <Coef exponent1="2">3.339052025583719e-05</Coef>
+          <Coef exponent1="3">7.169035783445546e-07</Coef>
+          <Coef exponent1="4">-6.515810911362789e-09</Coef>
+          <Coef exponent1="5">-5.950858635733351e-11</Coef>
         </X>
         <Y order1="5">
-          <Coef exponent1="0">0.6459834621590832</Coef>
-          <Coef exponent1="1">-0.002242061387614175</Coef>
-          <Coef exponent1="2">-7.927564972177376e-06</Coef>
-          <Coef exponent1="3">1.0018932954832954e-08</Coef>
-          <Coef exponent1="4">9.629586368326803e-11</Coef>
-          <Coef exponent1="5">2.0618376108071688e-14</Coef>
+          <Coef exponent1="0">0.9250707308662041</Coef>
+          <Coef exponent1="1">0.001347702553954909</Coef>
+          <Coef exponent1="2">-8.372580013300319e-05</Coef>
+          <Coef exponent1="3">2.1930154886371446e-07</Coef>
+          <Coef exponent1="4">9.12295927886897e-09</Coef>
+          <Coef exponent1="5">-7.138284240350041e-11</Coef>
         </Y>
         <Z order1="5">
-          <Coef exponent1="0">-0.7506670547090983</Coef>
-          <Coef exponent1="1">-0.0024390914504133017</Coef>
-          <Coef exponent1="2">5.082427558756091e-06</Coef>
-          <Coef exponent1="3">2.8097261855089025e-08</Coef>
-          <Coef exponent1="4">-1.9004683908030164e-11</Coef>
-          <Coef exponent1="5">-3.679090656234575e-13</Coef>
+          <Coef exponent1="0">-0.35178269857780337</Coef>
+          <Coef exponent1="1">0.007818211059299163</Coef>
+          <Coef exponent1="2">1.2501616663410946e-05</Coef>
+          <Coef exponent1="3">-7.549061506868814e-07</Coef>
+          <Coef exponent1="4">1.0552962685137459e-09</Coef>
+          <Coef exponent1="5">8.818445981543945e-11</Coef>
         </Z>
       </XAxisPoly>
       <YAxisPoly>
         <X order1="5">
-          <Coef exponent1="0">0.8552805091032539</Coef>
-          <Coef exponent1="1">0.00010376114142167065</Coef>
-          <Coef exponent1="2">-1.0609071180596748e-06</Coef>
-          <Coef exponent1="3">-1.207043400114697e-10</Coef>
-          <Coef exponent1="4">6.507868530371908e-13</Coef>
-          <Coef exponent1="5">-9.743797322315395e-17</Coef>
+          <Coef exponent1="0">-0.6248833411275703</Coef>
+          <Coef exponent1="1">9.481431049175265e-05</Coef>
+          <Coef exponent1="2">3.5679293472187755e-06</Coef>
+          <Coef exponent1="3">-8.265605717862494e-10</Coef>
+          <Coef exponent1="4">-1.55205596686381e-11</Coef>
+          <Coef exponent1="5">4.986051434719449e-15</Coef>
         </X>
         <Y order1="5">
-          <Coef exponent1="0">-0.4602036571273811</Coef>
-          <Coef exponent1="1">0.00048367813113425924</Coef>
-          <Coef exponent1="2">-9.665445239876957e-07</Coef>
-          <Coef exponent1="3">-8.876169832814811e-10</Coef>
-          <Coef exponent1="4">1.6881432972254367e-12</Coef>
-          <Coef exponent1="5">6.050807582195414e-16</Coef>
+          <Coef exponent1="0">-0.36011842237296604</Coef>
+          <Coef exponent1="1">-0.0006126962993722069</Coef>
+          <Coef exponent1="2">-1.0255250817528488e-06</Coef>
+          <Coef exponent1="3">3.9581206417096156e-09</Coef>
+          <Coef exponent1="4">8.659797851910697e-12</Coef>
+          <Coef exponent1="5">-2.0736569642359105e-14</Coef>
         </Y>
         <Z order1="5">
-          <Coef exponent1="0">-0.23813408977855874</Coef>
-          <Coef exponent1="1">-0.0005620596491953135</Coef>
-          <Coef exponent1="2">-7.653455692406227e-07</Coef>
-          <Coef exponent1="3">6.627999246022303e-10</Coef>
-          <Coef exponent1="4">1.2207431985624998e-12</Coef>
-          <Coef exponent1="5">-4.2550048742723904e-16</Coef>
+          <Coef exponent1="0">-0.6927016181941922</Coef>
+          <Coef exponent1="1">0.0002329940299801696</Coef>
+          <Coef exponent1="2">-2.368830577041677e-06</Coef>
+          <Coef exponent1="3">-7.134150490994215e-10</Coef>
+          <Coef exponent1="4">1.964137740117996e-11</Coef>
+          <Coef exponent1="5">-3.928446324267675e-15</Coef>
         </Z>
       </YAxisPoly>
-      <FreqZero>10000000000.0</FreqZero>
+      <FreqZero>8000000000.0</FreqZero>
       <EB>
         <DCXPoly order1="0">
           <Coef exponent1="0">0.0</Coef>
@@ -1032,15 +1133,15 @@
       <Array>
         <GainPoly order1="8" order2="8">
           <Coef exponent1="0" exponent2="0">0.0</Coef>
-          <Coef exponent1="0" exponent2="1">1.830851508157883e-12</Coef>
-          <Coef exponent1="0" exponent2="2">-1814485.8372625443</Coef>
-          <Coef exponent1="0" exponent2="3">-2.208286609514295e-06</Coef>
-          <Coef exponent1="0" exponent2="4">-67647577942.01662</Coef>
-          <Coef exponent1="0" exponent2="5">1.1886185612774636</Coef>
-          <Coef exponent1="0" exponent2="6">-1463292882577055.0</Coef>
-          <Coef exponent1="0" exponent2="7">-140393.14526142203</Coef>
-          <Coef exponent1="0" exponent2="8">-1.0883947565151394e+21</Coef>
-          <Coef exponent1="1" exponent2="0">1.830851508157883e-12</Coef>
+          <Coef exponent1="0" exponent2="1">2.502357375631804e-12</Coef>
+          <Coef exponent1="0" exponent2="2">-331013.7615138647</Coef>
+          <Coef exponent1="0" exponent2="3">7.779233036576076e-08</Coef>
+          <Coef exponent1="0" exponent2="4">-2251319770.0951843</Coef>
+          <Coef exponent1="0" exponent2="5">0.003632243275635647</Coef>
+          <Coef exponent1="0" exponent2="6">-8884002260231.28</Coef>
+          <Coef exponent1="0" exponent2="7">421.18712354060864</Coef>
+          <Coef exponent1="0" exponent2="8">-1.2054697251382866e+18</Coef>
+          <Coef exponent1="1" exponent2="0">2.502357375631804e-12</Coef>
           <Coef exponent1="1" exponent2="1">0.0</Coef>
           <Coef exponent1="1" exponent2="2">0.0</Coef>
           <Coef exponent1="1" exponent2="3">0.0</Coef>
@@ -1049,7 +1150,7 @@
           <Coef exponent1="1" exponent2="6">0.0</Coef>
           <Coef exponent1="1" exponent2="7">0.0</Coef>
           <Coef exponent1="1" exponent2="8">0.0</Coef>
-          <Coef exponent1="2" exponent2="0">-1814485.8372625443</Coef>
+          <Coef exponent1="2" exponent2="0">-331013.7615138647</Coef>
           <Coef exponent1="2" exponent2="1">0.0</Coef>
           <Coef exponent1="2" exponent2="2">0.0</Coef>
           <Coef exponent1="2" exponent2="3">0.0</Coef>
@@ -1058,7 +1159,7 @@
           <Coef exponent1="2" exponent2="6">0.0</Coef>
           <Coef exponent1="2" exponent2="7">0.0</Coef>
           <Coef exponent1="2" exponent2="8">0.0</Coef>
-          <Coef exponent1="3" exponent2="0">-2.208286609514295e-06</Coef>
+          <Coef exponent1="3" exponent2="0">7.779233036576076e-08</Coef>
           <Coef exponent1="3" exponent2="1">0.0</Coef>
           <Coef exponent1="3" exponent2="2">0.0</Coef>
           <Coef exponent1="3" exponent2="3">0.0</Coef>
@@ -1067,7 +1168,7 @@
           <Coef exponent1="3" exponent2="6">0.0</Coef>
           <Coef exponent1="3" exponent2="7">0.0</Coef>
           <Coef exponent1="3" exponent2="8">0.0</Coef>
-          <Coef exponent1="4" exponent2="0">-67647577942.01662</Coef>
+          <Coef exponent1="4" exponent2="0">-2251319770.0951843</Coef>
           <Coef exponent1="4" exponent2="1">0.0</Coef>
           <Coef exponent1="4" exponent2="2">0.0</Coef>
           <Coef exponent1="4" exponent2="3">0.0</Coef>
@@ -1076,7 +1177,7 @@
           <Coef exponent1="4" exponent2="6">0.0</Coef>
           <Coef exponent1="4" exponent2="7">0.0</Coef>
           <Coef exponent1="4" exponent2="8">0.0</Coef>
-          <Coef exponent1="5" exponent2="0">1.1886185612774636</Coef>
+          <Coef exponent1="5" exponent2="0">0.003632243275635647</Coef>
           <Coef exponent1="5" exponent2="1">0.0</Coef>
           <Coef exponent1="5" exponent2="2">0.0</Coef>
           <Coef exponent1="5" exponent2="3">0.0</Coef>
@@ -1085,7 +1186,7 @@
           <Coef exponent1="5" exponent2="6">0.0</Coef>
           <Coef exponent1="5" exponent2="7">0.0</Coef>
           <Coef exponent1="5" exponent2="8">0.0</Coef>
-          <Coef exponent1="6" exponent2="0">-1463292882577055.0</Coef>
+          <Coef exponent1="6" exponent2="0">-8884002260231.28</Coef>
           <Coef exponent1="6" exponent2="1">0.0</Coef>
           <Coef exponent1="6" exponent2="2">0.0</Coef>
           <Coef exponent1="6" exponent2="3">0.0</Coef>
@@ -1094,7 +1195,7 @@
           <Coef exponent1="6" exponent2="6">0.0</Coef>
           <Coef exponent1="6" exponent2="7">0.0</Coef>
           <Coef exponent1="6" exponent2="8">0.0</Coef>
-          <Coef exponent1="7" exponent2="0">-140393.14526142203</Coef>
+          <Coef exponent1="7" exponent2="0">421.18712354060864</Coef>
           <Coef exponent1="7" exponent2="1">0.0</Coef>
           <Coef exponent1="7" exponent2="2">0.0</Coef>
           <Coef exponent1="7" exponent2="3">0.0</Coef>
@@ -1103,7 +1204,7 @@
           <Coef exponent1="7" exponent2="6">0.0</Coef>
           <Coef exponent1="7" exponent2="7">0.0</Coef>
           <Coef exponent1="7" exponent2="8">0.0</Coef>
-          <Coef exponent1="8" exponent2="0">-1.0883947565151394e+21</Coef>
+          <Coef exponent1="8" exponent2="0">-1.2054697251382866e+18</Coef>
           <Coef exponent1="8" exponent2="1">0.0</Coef>
           <Coef exponent1="8" exponent2="2">0.0</Coef>
           <Coef exponent1="8" exponent2="3">0.0</Coef>
@@ -1138,37 +1239,37 @@
       <Z>0.0</Z>
     </FPN>
     <IPN>
-      <X>0.7595544373616576</X>
-      <Y>-0.19606057028786392</Y>
-      <Z>-0.6201913493470818</Z>
+      <X>0.6517439847812057</X>
+      <Y>-0.09494081430676284</Y>
+      <Z>0.7524732686289929</Z>
     </IPN>
-    <PolarAngRefTime>1.2206225993023674</PolarAngRefTime>
+    <PolarAngRefTime>0.7442796573752969</PolarAngRefTime>
     <PolarAngPoly order1="9">
-      <Coef exponent1="0">0.004675603312478452</Coef>
-      <Coef exponent1="1">-0.003828024629854423</Coef>
-      <Coef exponent1="2">-2.0534202450677696e-06</Coef>
-      <Coef exponent1="3">1.6330042734228727e-08</Coef>
-      <Coef exponent1="4">2.8141525578340645e-11</Coef>
-      <Coef exponent1="5">-1.0877634693549419e-13</Coef>
-      <Coef exponent1="6">-7.010768197194295e-15</Coef>
-      <Coef exponent1="7">3.096179373981025e-15</Coef>
-      <Coef exponent1="8">-7.25744581845732e-16</Coef>
-      <Coef exponent1="9">6.835061157382706e-17</Coef>
+      <Coef exponent1="0">-0.008354018069220225</Coef>
+      <Coef exponent1="1">0.011226659506192244</Coef>
+      <Coef exponent1="2">-2.983305704121828e-06</Coef>
+      <Coef exponent1="3">-2.523004393918972e-07</Coef>
+      <Coef exponent1="4">1.0620030889117183e-09</Coef>
+      <Coef exponent1="5">-2.000864835029266e-11</Coef>
+      <Coef exponent1="6">7.610038170336881e-13</Coef>
+      <Coef exponent1="7">-5.207879296852919e-13</Coef>
+      <Coef exponent1="8">1.6165843707467063e-13</Coef>
+      <Coef exponent1="9">-2.0956210866132763e-14</Coef>
     </PolarAngPoly>
     <SpatialFreqSFPoly order1="8">
-      <Coef exponent1="0">0.7905497991684931</Coef>
-      <Coef exponent1="1">-0.04747343763300925</Coef>
-      <Coef exponent1="2">-0.03877390170180205</Coef>
-      <Coef exponent1="3">0.03373684498686244</Coef>
-      <Coef exponent1="4">0.004080681063554339</Coef>
-      <Coef exponent1="5">-0.007265643668194507</Coef>
-      <Coef exponent1="6">0.6062197250310172</Coef>
-      <Coef exponent1="7">-199.23671702338058</Coef>
-      <Coef exponent1="8">-25028.825068538503</Coef>
+      <Coef exponent1="0">0.9720693354306482</Coef>
+      <Coef exponent1="1">0.027532527057365665</Coef>
+      <Coef exponent1="2">-0.25906049823750077</Coef>
+      <Coef exponent1="3">-0.05637475878615559</Coef>
+      <Coef exponent1="4">0.29799028244663184</Coef>
+      <Coef exponent1="5">0.09302479125292004</Coef>
+      <Coef exponent1="6">-0.32941483190024945</Coef>
+      <Coef exponent1="7">1.8769021651725741</Coef>
+      <Coef exponent1="8">-172.15974741716585</Coef>
     </SpatialFreqSFPoly>
-    <Krg1>51.86311228563949</Krg1>
-    <Krg2>53.61635699121815</Krg2>
-    <Kaz1>-0.2224562254252088</Kaz1>
-    <Kaz2>0.2224562254252088</Kaz2>
+    <Krg1>51.332532568131015</Krg1>
+    <Krg2>52.42366570375866</Krg2>
+    <Kaz1>-0.3711126684807361</Kaz1>
+    <Kaz2>0.371112668480736</Kaz2>
   </PFA>
 </SICD>

--- a/sarkit/sicd/_xml.py
+++ b/sarkit/sicd/_xml.py
@@ -315,7 +315,7 @@ class ElementWrapper(skxml.ElementWrapper):
         )
 
 
-def compute_scp_coa(sicd_xmltree: lxml.etree.ElementTree) -> lxml.etree.ElementTree:
+def compute_scp_coa(sicd_xmltree: lxml.etree.ElementTree) -> lxml.etree.Element:
     """Return a SICD/SCPCOA XML containing parameters computed from other metadata.
 
     The namespace of the new SICD/SCPCOA element is retained from ``sicd_xmltree``.
@@ -467,37 +467,43 @@ def compute_scp_coa(sicd_xmltree: lxml.etree.ElementTree) -> lxml.etree.ElementT
                 * np.dot(bp_coa, bpdot_coa)
             )
 
-        def _steps_10_to_15(xmt_coa, vxmt_coa, u_xmt_coa, r_xmt_scp):
-            xmt_dec = np.linalg.norm(xmt_coa)
-            u_ec_xmt_coa = xmt_coa / xmt_dec
-            ea_xmt_coa = np.arccos(np.dot(u_ec_xmt_coa, u_scp))
-            rg_xmt_scp = scp_dec * ea_xmt_coa
+        def _steps_10_to_15(apc_coa, vapc_coa, u_apc_coa, r_apc_scp, rdot_acp_scp):
+            """Compute platform geometry parameters
 
-            left_xmt = np.cross(u_ec_xmt_coa, vxmt_coa)
-            side_of_track_xmt = "L" if np.dot(left_xmt, u_xmt_coa) < 0 else "R"
+            SICD v1.5 DIDD 4.9.2 describes these steps in terms of xmt and suggests replacement of some
+            parameters for the bistatic computation.  That list is incomplete.  This function
+            replaces "xmt" with "apc" to avoid mention of either platform internally.
+            """
+            apc_dec = np.linalg.norm(apc_coa)
+            u_ec_apc_coa = apc_coa / apc_dec
+            ea_apc_coa = np.arccos(np.dot(u_ec_apc_coa, u_scp))
+            rg_apc_scp = scp_dec * ea_apc_coa
 
-            vxmt_m = np.linalg.norm(vxmt_coa)
-            dca_xmt = np.arccos(-rdot_xmt_scp / vxmt_m)
+            left_apc = np.cross(u_ec_apc_coa, vapc_coa)
+            side_of_track_apc = "L" if np.dot(left_apc, u_apc_coa) < 0 else "R"
 
-            xmt_gpz_coa = np.dot((xmt_coa - scp), u_gpz)
-            xmt_etp_coa = xmt_coa - xmt_gpz_coa * u_gpz
-            u_gpx_x = (xmt_etp_coa - scp) / np.linalg.norm(xmt_etp_coa - scp)
+            vapc_m = np.linalg.norm(vapc_coa)
+            dca_apc = np.arccos(-rdot_acp_scp / vapc_m)
 
-            graz_xmt = np.arcsin(xmt_gpz_coa / r_xmt_scp)
-            incd_xmt = 90 - np.rad2deg(graz_xmt)
+            apc_gpz_coa = np.dot((apc_coa - scp), u_gpz)
+            apc_etp_coa = apc_coa - apc_gpz_coa * u_gpz
+            u_gpx_x = (apc_etp_coa - scp) / np.linalg.norm(apc_etp_coa - scp)
 
-            az_xmt_n = np.dot(u_north, u_gpx_x)
-            az_xmt_e = np.dot(u_east, u_gpx_x)
-            azim_xmt = np.arctan2(az_xmt_e, az_xmt_n)
+            graz_apc = np.arcsin(apc_gpz_coa / r_apc_scp)
+            incd_apc = 90 - np.rad2deg(graz_apc)
+
+            az_apc_n = np.dot(u_north, u_gpx_x)
+            az_apc_e = np.dot(u_east, u_gpx_x)
+            azim_apc = np.arctan2(az_apc_e, az_apc_n)
 
             return {
-                "SideOfTrack": side_of_track_xmt,
-                "SlantRange": r_xmt_scp,
-                "GroundRange": rg_xmt_scp,
-                "DopplerConeAng": np.rad2deg(dca_xmt),
-                "GrazeAng": np.rad2deg(graz_xmt),
-                "IncidenceAng": incd_xmt,
-                "AzimAng": np.rad2deg(azim_xmt) % 360,
+                "SideOfTrack": side_of_track_apc,
+                "SlantRange": r_apc_scp,
+                "GroundRange": rg_apc_scp,
+                "DopplerConeAng": np.rad2deg(dca_apc),
+                "GrazeAng": np.rad2deg(graz_apc),
+                "IncidenceAng": incd_apc,
+                "AzimAng": np.rad2deg(azim_apc) % 360,
             }
 
         scpcoa["Bistatic"]["BistaticAng"] = np.rad2deg(bistat_ang_coa)
@@ -507,13 +513,13 @@ def compute_scp_coa(sicd_xmltree: lxml.etree.ElementTree) -> lxml.etree.ElementT
             "Pos": xmt_coa,
             "Vel": vxmt_coa,
             "Acc": axmt_coa,
-            **_steps_10_to_15(xmt_coa, vxmt_coa, u_xmt_coa, r_xmt_scp),
+            **_steps_10_to_15(xmt_coa, vxmt_coa, u_xmt_coa, r_xmt_scp, rdot_xmt_scp),
         }
         scpcoa["Bistatic"]["RcvPlatform"] = {
             "Time": tr_coa,
             "Pos": rcv_coa,
             "Vel": vrcv_coa,
             "Acc": arcv_coa,
-            **_steps_10_to_15(rcv_coa, vrcv_coa, u_rcv_coa, r_rcv_scp),
+            **_steps_10_to_15(rcv_coa, vrcv_coa, u_rcv_coa, r_rcv_scp, rdot_rcv_scp),
         }
     return scpcoa.elem


### PR DESCRIPTION
# Description
This PR fixes a bug in `sarkit.sicd.compute_scp_coa` where the `SCPCOA/Bistatic/RcvPlatform/DopplerConeAng` was inadvertently using a Transmit parameter.

This only shows up for more diverse bistatic geometries, so to demonstrate this, I've updated `data/example-sicd-1.5.xml`

<details>
<summary>Here is the updated consistency checks run in main demonstrating the bug:</summary>

```console
$ pytest tests/verification/test_sicd_consistency.py::test_main -v
============================================================================================================================================= test session starts ==============================================================================================================================================
platform linux -- Python 3.13.5, pytest-9.0.3, pluggy-1.6.0 -- /home/vscuser/git/glweb/software/third-party/sarkit/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/vscuser/git/glweb/software/third-party/sarkit
configfile: pyproject.toml
collected 7 items                                                                                                                                                                                                                                                                                              

tests/verification/test_sicd_consistency.py::test_main[file0] PASSED                                                                                                                                                                                                                                     [ 14%]
tests/verification/test_sicd_consistency.py::test_main[file1] PASSED                                                                                                                                                                                                                                     [ 28%]
tests/verification/test_sicd_consistency.py::test_main[file2] PASSED                                                                                                                                                                                                                                     [ 42%]
tests/verification/test_sicd_consistency.py::test_main[file3] PASSED                                                                                                                                                                                                                                     [ 57%]
tests/verification/test_sicd_consistency.py::test_main[file4] PASSED                                                                                                                                                                                                                                     [ 71%]
tests/verification/test_sicd_consistency.py::test_main[file5] PASSED                                                                                                                                                                                                                                     [ 85%]
tests/verification/test_sicd_consistency.py::test_main[file6] FAILED                                                                                                                                                                                                                                     [100%]

=================================================================================================================================================== FAILURES ===================================================================================================================================================
_______________________________________________________________________________________________________________________________________________ test_main[file6] _______________________________________________________________________________________________________________________________________________

file = PosixPath('/home/vscuser/git/glweb/software/third-party/sarkit/data/example-sicd-1.5.xml')

    @pytest.mark.parametrize(
        "file",
        [
            good_sicd_xml_path,
        ]
        + list(DATAPATH.glob("example-sicd*.xml")),
    )
    def test_main(file):
>       assert not main([str(file), "-vv"])
E       AssertionError: assert not True
E        +  where True = main(['/home/vscuser/git/glweb/software/third-party/sarkit/data/example-sicd-1.5.xml', '-vv'])

tests/verification/test_sicd_consistency.py:122: AssertionError
--------------------------------------------------------------------------------------------------------------------------------------------- Captured stdout call ---------------------------------------------------------------------------------------------------------------------------------------------
check_scpcoa: Checks consistency of the values in the SCPCOA child elements.
    [Need] Need: SCPCOA/SCPTime matches defined calculation
    [Need] Need: SCPCOA/ARPPos matches defined calculation
    [Need] Need: SCPCOA/ARPVel matches defined calculation
    [Need] Need: SCPCOA/ARPAcc matches defined calculation
    [Need] Need: SCPCOA/SideOfTrack matches defined calculation
    [Need] Need: SCPCOA/SlantRange matches defined calculation
    [Need] Need: SCPCOA/GroundRange matches defined calculation
    [Need] Need: SCPCOA/DopplerConeAng matches defined calculation
    [Need] Need: SCPCOA/GrazeAng matches defined calculation
    [Need] Need: SCPCOA/IncidenceAng matches defined calculation
    [Need] Need: SCPCOA/TwistAng matches defined calculation
    [Need] Need: SCPCOA/SlopeAng matches defined calculation
    [Need] Need: SCPCOA/AzimAng matches defined calculation
    [Need] Need: SCPCOA/LayoverAng matches defined calculation
    [Need] Need: SCPCOA/BistaticAng matches defined calculation
    [Need] Need: SCPCOA/BistaticAngRate matches defined calculation
    [Need] Need: SCPCOA/Time matches defined calculation
    [Need] Need: SCPCOA/Pos matches defined calculation
    [Need] Need: SCPCOA/Vel matches defined calculation
    [Need] Need: SCPCOA/Acc matches defined calculation
    [Need] Need: SCPCOA/SideOfTrack matches defined calculation
    [Need] Need: SCPCOA/SlantRange matches defined calculation
    [Need] Need: SCPCOA/GroundRange matches defined calculation
    [Need] Need: SCPCOA/DopplerConeAng matches defined calculation
    [Need] Need: SCPCOA/GrazeAng matches defined calculation
    [Need] Need: SCPCOA/IncidenceAng matches defined calculation
    [Need] Need: SCPCOA/AzimAng matches defined calculation
    [Need] Need: {urn:SICD:1.5}TxPlatform contains only expected elements
    [Need] Need: SCPCOA/Time matches defined calculation
    [Need] Need: SCPCOA/Pos matches defined calculation
    [Need] Need: SCPCOA/Vel matches defined calculation
    [Need] Need: SCPCOA/Acc matches defined calculation
    [Need] Need: SCPCOA/SideOfTrack matches defined calculation
    [Need] Need: SCPCOA/SlantRange matches defined calculation
    [Need] Need: SCPCOA/GroundRange matches defined calculation
    [Error] Need: SCPCOA/DopplerConeAng matches defined calculation
        line#1694: assert actual_val == con.Approx(expected_val, **approx_args)

         where:
         actual_val == con.Approx(expected_val, **approx_args) = np.False_

         where:
         actual_val = 100.00122351272505

         where:
         con.Approx(expected_val, **approx_args) = 79.99856869831677 ± 1.0000799985686983

         where:
         con.Approx = <class 'sarkit.verification._consistency.Approx'>

         where:
         expected_val = 79.99856869831677

         where:
         con = <module 'sarkit.verification._consistency' from '/home/vscuser/git/glweb/software/third-
            party/sarkit/sarkit/verification/_consistency.py'>

         where:
         approx_args = {'atol': 1}
    [Need] Need: SCPCOA/GrazeAng matches defined calculation
    [Need] Need: SCPCOA/IncidenceAng matches defined calculation
    [Need] Need: SCPCOA/AzimAng matches defined calculation
    [Need] Need: {urn:SICD:1.5}RcvPlatform contains only expected elements
    [Need] Need: {urn:SICD:1.5}Bistatic contains only expected elements
    [Need] Need: {urn:SICD:1.5}SCPCOA contains only expected elements
=========================================================================================================================================== short test summary info ============================================================================================================================================
FAILED tests/verification/test_sicd_consistency.py::test_main[file6] - AssertionError: assert not True
========================================================================================================================================= 1 failed, 6 passed in 1.14s ==========================================================================================================================================
                                                                                                                                                                                                                                                                                                                

```

</details>