### PR TITLE
Add some SICD v1.4.0/v1.5 consistency checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Additional SICD consistency checks for v1.4.0+ conditional fields and v1.5-introduced polygons
+
 
 ## [1.7.1] - 2026-04-27
 

--- a/sarkit/verification/_cphd_consistency.py
+++ b/sarkit/verification/_cphd_consistency.py
@@ -310,7 +310,7 @@ class CphdConsistency(con.ConsistencyChecker):
         assert channel_id in self.pvps
         return self.pvps[channel_id]
 
-    def get_polygon(self, polygon_node, check=False, reverse=False):
+    def get_polygon(self, polygon_node, check=False):
         """Returns the polygon from the specified node, with basic polygon verification."""
         vertex_nodes = sorted(list(polygon_node), key=lambda x: int(x.attrib["index"]))
         polygon = np.asarray(
@@ -321,12 +321,11 @@ class CphdConsistency(con.ConsistencyChecker):
                 assert [int(x.attrib["index"]) for x in vertex_nodes] == list(
                     range(1, len(vertex_nodes) + 1)
                 )
-            if "size" in polygon_node.attrib:
-                size = int(polygon_node.attrib["size"])
-                with self.need(
-                    f"{_get_root_path(polygon_node)} size attribute matches the number of vertices"
-                ):
-                    assert size == len(vertex_nodes)
+            size = int(polygon_node.attrib["size"])
+            with self.need(
+                f"{_get_root_path(polygon_node)} size attribute matches the number of vertices"
+            ):
+                assert size == len(vertex_nodes)
             shg_polygon = shg.Polygon(polygon)
             with self.need(f"{_get_root_path(polygon_node)} is simple"):
                 assert shg_polygon.is_simple

--- a/sarkit/verification/_sicd_consistency.py
+++ b/sarkit/verification/_sicd_consistency.py
@@ -157,6 +157,14 @@ def _get_desdata_location(ntf):
     raise ValueError("Unable to find SICD DES")
 
 
+def _get_root_path(node):
+    path = []
+    while node is not None:
+        path.append(etree.QName(node).localname)
+        node = node.getparent()
+    return "/".join(reversed(path[:-1]))
+
+
 def per_grid_dim(method):
     method.per_grid_dim = True
     return method
@@ -602,6 +610,30 @@ class SicdConsistency(con.ConsistencyChecker):
             icp_strs.append(icp_strs[0])
             with self.need("DESSHLPG consistent with image corners"):
                 assert des_header["DESSHLPG"].value == "".join(icp_strs)
+
+    def check_bistatic_fields(self) -> None:
+        """Optional fields are consistent with CollectType = BISTATIC for SICD v1.4.0+"""
+        with self.precondition():
+            assert (
+                self.sicdroot.findtext("{*}CollectionInfo/{*}CollectType") == "BISTATIC"
+            )
+            this_ns = etree.QName(self.sicdroot).namespace
+            sicd_versions = list(sksicd.VERSION_INFO)
+            assert sicd_versions.index(this_ns) >= sicd_versions.index("urn:SICD:1.4.0")
+            required_fields = (
+                "{*}CollectionInfo/{*}IlluminatorName",
+                "{*}Position/{*}GRPPoly",
+                "{*}Position/{*}TxAPCPoly",
+                "{*}Position/{*}RcvAPC",
+            )
+            for field in required_fields:
+                with self.need(
+                    f"{field.replace('{*}', '')} required for CollectType=BISTATIC"
+                ):
+                    assert self.sicdroot.find(field) is not None
+
+            with self.need("Antenna/TwoWay not allowed when CollectType=BISTATIC"):
+                assert self.sicdroot.find("{*}Antenna/{*}TwoWay") is None
 
     def check_grid_sign(self) -> None:
         """Grid signs match."""
@@ -1244,6 +1276,46 @@ class SicdConsistency(con.ConsistencyChecker):
             with self.need("SegmentList segments have unique identifiers"):
                 assert len(set(segment_ids)) == len(segment_ids)
 
+    def _need_valid_polygon(self, polygon_node):
+        """Returns the polygon from the specified node, with basic polygon verification."""
+        vertex_nodes = sorted(list(polygon_node), key=lambda x: int(x.attrib["index"]))
+        polygon = np.asarray(
+            [self.xmlhelp.load_elem(vertex) for vertex in vertex_nodes]
+        )
+        root_path = _get_root_path(polygon_node)
+        with self.need(f"{root_path} indices are all present"):
+            assert [int(x.attrib["index"]) for x in vertex_nodes] == list(
+                range(1, len(vertex_nodes) + 1)
+            )
+        size = int(polygon_node.attrib["size"])
+        with self.need(f"{root_path} size attribute matches the number of vertices"):
+            assert size == len(vertex_nodes)
+        shg_polygon = shg.Polygon(polygon)
+        with self.need(f"{root_path} is simple"):
+            assert shg_polygon.is_simple
+        with self.need(f"{root_path} is clockwise"):
+            assert not shg_polygon.exterior.is_ccw
+        return polygon
+
+    def check_segment_polygons(self) -> None:
+        """SegmentPolygons are simple, valid and clockwise."""
+        segment_polygons = self.sicdroot.findall(
+            "{*}RadarCollection/{*}Area/{*}Plane/{*}SegmentList/{*}Segment/{*}SegmentPolygon"
+        )
+        with self.precondition():
+            assert segment_polygons
+            for segment_polygon in segment_polygons:
+                self._need_valid_polygon(segment_polygon)
+
+    def check_area_plane_polygon(self) -> None:
+        """RadarCollection/Area/Plane/Polygon is simple, valid and clockwise."""
+        area_plane_poly_elem = self.sicdroot.find(
+            "{*}RadarCollection/{*}Area/{*}Plane/{*}Polygon"
+        )
+        with self.precondition():
+            assert area_plane_poly_elem is not None
+            self._need_valid_polygon(area_plane_poly_elem)
+
     def _compute_area_plane_corners_ecef(self):
         plane = self.sicdroot.find("./{*}RadarCollection/{*}Area/{*}Plane")
         ref_ecf = self.xmlhelp.load_elem(plane.find("./{*}RefPt/{*}ECF"))
@@ -1826,6 +1898,34 @@ class SicdConsistency(con.ConsistencyChecker):
             with self.need("RangeBias >= 0.0"):
                 range_bias = float(components.findtext("./{*}RadarSensor/{*}RangeBias"))
                 assert range_bias >= con.Approx(0.0)
+
+    def check_errorstatistics_conditionals(self) -> None:
+        """Presence of ErrorStatistics child elements is consistent with CollectType."""
+        with self.precondition():
+            this_ns = etree.QName(self.sicdroot).namespace
+            sicd_versions = list(sksicd.VERSION_INFO)
+            assert sicd_versions.index(this_ns) >= sicd_versions.index("urn:SICD:1.4.0")
+            is_bistatic = (
+                self.sicdroot.findtext("{*}CollectionInfo/{*}CollectType") == "BISTATIC"
+            )
+            coltype = "BISTATIC" if is_bistatic else "MONOSTATIC"
+            if is_bistatic:
+                forbidden_fields = (
+                    "{*}ErrorStatistics/{*}CompositeSCP",
+                    "{*}ErrorStatistics/{*}Components",
+                    "{*}ErrorStatistics/{*}AdjustableParameterOffsets",
+                )
+            else:
+                forbidden_fields = (
+                    "{*}ErrorStatistics/{*}BistaticCompositeSCP",
+                    "{*}ErrorStatistics/{*}BistaticComponents",
+                    "{*}ErrorStatistics/{*}BistaticAdjustableParameterOffsets",
+                )
+            for field in forbidden_fields:
+                with self.need(
+                    f"{field.replace('{*}', '')} not allowed when CollectType={coltype}"
+                ):
+                    assert self.sicdroot.find(field) is None
 
     def check_txsequence_indices(self) -> None:
         """Checks consistency of the TxSequence/TxStep indexing."""

--- a/tests/verification/test_sicd_consistency.py
+++ b/tests/verification/test_sicd_consistency.py
@@ -1999,3 +1999,100 @@ def test_smart_open_contract(example_sicd, monkeypatch):
     monkeypatch.setattr(sarkit.verification._sicdcheck, "open", mock_open)
     assert not main([str(example_sicd)])
     mock_open.assert_called_once_with(str(example_sicd), "rb")
+
+
+def test_check_bistatic_fields():
+    xmltree = lxml.etree.parse(DATAPATH / "example-sicd-1.5.xml")
+    assert xmltree.findtext(".//{*}CollectType") == "BISTATIC"
+
+    req_elem = xmltree.find("{*}CollectionInfo/{*}IlluminatorName")
+    req_elem.getparent().remove(req_elem)
+
+    ant_elem = xmltree.find("{*}Antenna")
+    ant_elem.remove(ant_elem[0])
+    ant_elem[0].tag = ant_elem[0].tag.replace("Rcv", "TwoWay")
+
+    sicd_con = SicdConsistency.from_parts(xmltree)
+    sicd_con.check("check_against_schema")
+    assert sicd_con.passes() and not sicd_con.failures()
+    sicd_con.check("check_bistatic_fields")
+    testing.assert_failures(sicd_con, "IlluminatorName required")
+    testing.assert_failures(sicd_con, "TwoWay not allowed")
+
+
+def _invalid_index(poly_elem):
+    poly_elem[0].set("index", "-24")
+
+
+def _invalid_size(poly_elem):
+    poly_elem.set("size", str(len(poly_elem) + 1))
+
+
+def _not_simple(poly_elem):
+    old_index = poly_elem[-2].get("index")
+    poly_elem[-2].set("index", poly_elem[-1].get("index"))
+    poly_elem[-1].set("index", old_index)
+
+
+def _not_clockwise(poly_elem):
+    for vertex in poly_elem:
+        vertex.set("index", str(len(poly_elem) - 1 - int(vertex.get("index"))))
+
+
+@pytest.mark.parametrize(
+    "elem_path,check",
+    [
+        (
+            "{*}RadarCollection/{*}Area/{*}Plane/{*}SegmentList/{*}Segment/{*}SegmentPolygon",
+            "check_segment_polygons",
+        ),
+        ("{*}RadarCollection/{*}Area/{*}Plane/{*}Polygon", "check_area_plane_polygon"),
+    ],
+)
+@pytest.mark.parametrize(
+    "perturb_func,fail_pattern",
+    [
+        [_invalid_index, "indices are all present"],
+        [_invalid_size, "size attribute matches"],
+        [_not_simple, "is simple"],
+        [_not_clockwise, "is clockwise"],
+    ],
+)
+def test_valid_polygons(elem_path, check, perturb_func, fail_pattern):
+    xmltree = lxml.etree.parse(DATAPATH / "example-sicd-1.5.xml")
+    perturb_func(xmltree.find(elem_path))
+    sicd_con = SicdConsistency.from_parts(xmltree)
+    sicd_con.check(check)
+    testing.assert_failures(sicd_con, fail_pattern)
+
+
+def test_check_errorstatistics_conditionals_bi():
+    xmltree = lxml.etree.parse(DATAPATH / "example-sicd-1.5.xml")
+    assert xmltree.findtext(".//{*}CollectType") == "BISTATIC"
+    sicd_ew = sksicd.ElementWrapper(xmltree.getroot())
+    sicd_ew["ErrorStatistics"]["CompositeSCP"]["Rg"] = 1.0
+    sicd_ew["ErrorStatistics"]["CompositeSCP"]["Az"] = 1.0
+    sicd_ew["ErrorStatistics"]["CompositeSCP"]["RgAz"] = 1.0
+
+    sicd_con = SicdConsistency.from_parts(xmltree)
+    sicd_con.check("check_against_schema")
+    assert sicd_con.passes() and not sicd_con.failures()
+
+    sicd_con.check("check_errorstatistics_conditionals")
+    testing.assert_failures(sicd_con, "CompositeSCP not allowed")
+
+
+def test_check_errorstatistics_conditionals_mono():
+    xmltree = lxml.etree.parse(DATAPATH / "example-sicd-1.5.xml")
+    sicd_ew = sksicd.ElementWrapper(xmltree.getroot())
+    sicd_ew["CollectionInfo"]["CollectType"] = "MONOSTATIC"
+    sicd_ew["ErrorStatistics"]["BistaticCompositeSCP"]["RAvg"] = 1.0
+    sicd_ew["ErrorStatistics"]["BistaticCompositeSCP"]["RdotAvg"] = 1.0
+    sicd_ew["ErrorStatistics"]["BistaticCompositeSCP"]["RAvgRdotAvg"] = 1.0
+
+    sicd_con = SicdConsistency.from_parts(xmltree)
+    sicd_con.check("check_against_schema")
+    assert sicd_con.passes() and not sicd_con.failures()
+
+    sicd_con.check("check_errorstatistics_conditionals")
+    testing.assert_failures(sicd_con, "BistaticCompositeSCP not allowed")


### PR DESCRIPTION
# Description
This PR adds a few checks to `sicdcheck` based on v1.4.0 and v1.5 updates:

| check(s) | doc snippet|
| ------ | ------ |
| `check_bistatic_fields` |<img width="764" height="384" alt="image" src="https://github.com/user-attachments/assets/eac55537-7f0c-4cf2-b247-179b8352e3d8" /> |
| `check_segment_polygons` & `check_area_plane_polygon`  |<img width="774" height="281" alt="image" src="https://github.com/user-attachments/assets/4839085c-af6e-44cd-859a-2a8bfa55b332" /> |
| `check_errorstatistics_conditionals`| <img width="736" height="290" alt="image" src="https://github.com/user-attachments/assets/1cdaea63-3cfc-4002-899d-b9366f15f822" /> |