### PR TITLE
Fix SICD segmentation for single row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Failure when writing very small SICDs
+
 
 ## [1.8.0] - 2026-05-06
 

--- a/sarkit/sicd/_io.py
+++ b/sarkit/sicd/_io.py
@@ -627,25 +627,30 @@ def image_segment_sizing_calculations(
 
     icp_latlon = xml_helper.load("./{*}GeoData/{*}ImageCorners")
 
-    icp_ecef = [
-        sarkit.wgs84.geodetic_to_cartesian([np.deg2rad(lat), np.deg2rad(lon), 0])
-        for lat, lon in icp_latlon
-    ]
+    if num_is == 1:
+        iscp_latlon = icp_latlon[np.newaxis, ...]
+    else:
+        icp_ecef = [
+            sarkit.wgs84.geodetic_to_cartesian([np.deg2rad(lat), np.deg2rad(lon), 0])
+            for lat, lon in icp_latlon
+        ]
 
-    iscp_ecef = np.zeros((num_is, 4, 3))
-    for imidx in range(num_is):
-        wgt1 = (num_rows - 1 - first_row_is[imidx]) / (num_rows - 1)
-        wgt2 = first_row_is[imidx] / (num_rows - 1)
-        iscp_ecef[imidx][0] = wgt1 * icp_ecef[0] + wgt2 * icp_ecef[3]
-        iscp_ecef[imidx][1] = wgt1 * icp_ecef[1] + wgt2 * icp_ecef[2]
+        iscp_ecef = np.zeros((num_is, 4, 3))
+        for imidx in range(num_is):
+            wgt1 = (num_rows - 1 - first_row_is[imidx]) / (num_rows - 1)
+            wgt2 = first_row_is[imidx] / (num_rows - 1)
+            iscp_ecef[imidx][0] = wgt1 * icp_ecef[0] + wgt2 * icp_ecef[3]
+            iscp_ecef[imidx][1] = wgt1 * icp_ecef[1] + wgt2 * icp_ecef[2]
 
-    for imidx in range(num_is - 1):
-        iscp_ecef[imidx][2] = iscp_ecef[imidx + 1][1]
-        iscp_ecef[imidx][3] = iscp_ecef[imidx + 1][0]
-    iscp_ecef[num_is - 1][2] = icp_ecef[2]
-    iscp_ecef[num_is - 1][3] = icp_ecef[3]
+        for imidx in range(num_is - 1):
+            iscp_ecef[imidx][2] = iscp_ecef[imidx + 1][1]
+            iscp_ecef[imidx][3] = iscp_ecef[imidx + 1][0]
+        iscp_ecef[num_is - 1][2] = icp_ecef[2]
+        iscp_ecef[num_is - 1][3] = icp_ecef[3]
 
-    iscp_latlon = np.rad2deg(sarkit.wgs84.cartesian_to_geodetic(iscp_ecef)[:, :, :2])
+        iscp_latlon = np.rad2deg(
+            sarkit.wgs84.cartesian_to_geodetic(iscp_ecef)[:, :, :2]
+        )
 
     # 3.2.2 File Header and Image Sub-Header Parameters
     seginfos = []

--- a/tests/core/sicd/test_io.py
+++ b/tests/core/sicd/test_io.py
@@ -1,3 +1,4 @@
+import copy
 import pathlib
 
 import jbpy
@@ -514,3 +515,18 @@ def test_remote_read(example_sicd):
         ) as file_object:
             with sksicd.NitfReader(file_object) as r:
                 _ = r.read_image()
+
+
+def test_tiny_sicd(example_sicd, tmp_path):
+    subimage_file = tmp_path / "sub.sicd"
+    with example_sicd.open("rb") as ifile, sksicd.NitfReader(ifile) as reader:
+        subimage, subimage_xmltree = reader.read_sub_image(0, 0, 1, 1)
+        metadata = copy.deepcopy(reader.metadata)
+        metadata.xmltree = subimage_xmltree
+        with (
+            subimage_file.open("wb") as ofile,
+            sksicd.NitfWriter(ofile, metadata) as writer,
+        ):
+            writer.write_image(subimage)
+
+    assert subimage_file.exists()


### PR DESCRIPTION
Ran into a divide by zero error when trying to write a 1x1 SICD subimage.  Turns out the segmentation logic didn't implement the single segment shortcut in Volume 3 Section 3.2:

<img width="660" height="146" alt="image" src="https://github.com/user-attachments/assets/0687ea95-ef8a-445c-88bb-2cc20d9c7048" />
