### PR TITLE
Bugfix: ElementWrapper.setdefault behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Failure when writing very small SICDs
+- `ElementWrapper.setdefault` now properly inserts subelements
 
 
 ## [1.8.0] - 2026-05-06

--- a/docs/source/reference/generated/sarkit.xmlhelp.ElementWrapper.rst
+++ b/docs/source/reference/generated/sarkit.xmlhelp.ElementWrapper.rst
@@ -13,8 +13,9 @@
          :toctree:
       
          ElementWrapper.add
-         ElementWrapper.get
          ElementWrapper.find
          ElementWrapper.findall
          ElementWrapper.from_dict
+         ElementWrapper.get
+         ElementWrapper.setdefault
          ElementWrapper.to_dict

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -353,11 +353,16 @@ Accessing keys that are not schema-valid raises a `KeyError`:
    Traceback (most recent call last):
    KeyError: 'NotValid'
 
-Unlike normal dictionaries, `KeyError` can still be raised by `get()` when the key is not schema-valid
+Unlike normal dictionaries, `KeyError` can still be raised by `get()` and `setdefault()` when the key is not
+schema-valid
 
 .. doctest::
 
    >>> wrappedsicd.get("NotValid", default=None)
+   Traceback (most recent call last):
+   KeyError: 'NotValid'
+
+   >>> wrappedsicd.setdefault("NotValid", "foo")
    Traceback (most recent call last):
    KeyError: 'NotValid'
 
@@ -428,7 +433,9 @@ Use :py:meth:`~sarkit.xmlhelp.ElementWrapper.add` to add repeatable children.
    ('AB', 'CD', 'EF')
 
 
-:py:meth:`~sarkit.xmlhelp.ElementWrapper.findall` and :py:meth:`~sarkit.xmlhelp.ElementWrapper.find` can find children with specific traits.  This is particularly helpful for CPHD and CRSD when a lot of Identifier references exist.
+:py:meth:`~sarkit.xmlhelp.ElementWrapper.findall` and :py:meth:`~sarkit.xmlhelp.ElementWrapper.find` can find children
+with specific traits.
+This is particularly helpful for CPHD and CRSD when a lot of Identifier references exist.
 
 .. doctest::
 

--- a/sarkit/xmlhelp/_core.py
+++ b/sarkit/xmlhelp/_core.py
@@ -272,6 +272,15 @@ class ElementWrapper(collections.abc.MutableMapping):
 
         return default
 
+    def setdefault(self, localname: str, default=None):
+        """Return value from an ElementWrapper if present. If not, insert ``localname`` with a value of ``default``
+        and return ``default``. If the localname is not schema-valid a KeyError is raised.
+        """
+        if localname in self:
+            return self[localname]
+        self[localname] = default
+        return default
+
     def _handle_subelem(
         self, subelem: "lxml.etree.Element | None", subelem_localname: str
     ):

--- a/tests/core/xmlhelp/test_core.py
+++ b/tests/core/xmlhelp/test_core.py
@@ -199,3 +199,19 @@ def test_elementwrapper_tofromdict():
     }
     # transcoders can add zeros to sparse polynomials/matrices, etc.
     assert orig_elempaths.issubset(fromdict_elempaths)
+
+
+def test_elementwrapper_setdefault():
+    root_ns = "urn:SIDD:3.0.0"
+    siddroot = lxml.etree.Element(f"{{{root_ns}}}SIDD")
+    xmlhelp = sksidd.XsdHelper(root_ns)
+    wrapped_siddroot = skxml.ElementWrapper(siddroot, xsdhelper=xmlhelp)
+
+    assert wrapped_siddroot["ProductCreation"].setdefault("ProductName", "foo") == "foo"
+    assert wrapped_siddroot["ProductCreation"]["ProductName"] == "foo"
+    assert wrapped_siddroot["ProductCreation"].setdefault("ProductName", "bar") == "foo"
+    with pytest.raises(ValueError):
+        wrapped_siddroot["Display"].setdefault("NumBands")
+    assert wrapped_siddroot["Display"].setdefault("NumBands", 24) == 24
+    with pytest.raises(KeyError):
+        wrapped_siddroot["ProductCreation"].setdefault("NotARealFieldName")


### PR DESCRIPTION
# Description
Currently, `ElementWrapper.setdefault` does not behave like a `dict`, because of the nature of how membership is tested in the inherited method:

```python
>>> import sarkit.sicd as sksicd
>>> import lxml.etree
>>> ew = sksicd.ElementWrapper(lxml.etree.parse("data/example-sicd-1.5.xml").getroot())
>>> ew["MatchInfo"].setdefault("NumMatchTypes", 24)
ElementWrapper({})
```

This PR fixes the behavior, so that `setdefault` now operates as you might expect:

```python
>>> import sarkit.sicd as sksicd
>>> import lxml.etree
>>> ew = sksicd.ElementWrapper(lxml.etree.parse("data/example-sicd-1.5.xml").getroot())
>>> ew["MatchInfo"].setdefault("NumMatchTypes", 24)
24
>>> ew["MatchInfo"]["NumMatchTypes"]
24
>>> ew["MatchInfo"].setdefault("NumMatchTypes", 8)
24
```