### PR TITLE
CRSD: add antenna beamshape computations 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Antenna parameters computations `compute_eb` and `compute_apat` in `sarkit.crsd`
+
 ### Fixed
 - Failure when writing very small SICDs
 - `ElementWrapper.setdefault` now properly inserts subelements

--- a/data/example-crsd-1.0.xml
+++ b/data/example-crsd-1.0.xml
@@ -204,8 +204,8 @@
       </SupportArray>
       <SupportArray>
         <SAId>transmit_element</SAId>
-        <NumRows>2</NumRows>
-        <NumCols>2</NumCols>
+        <NumRows>23</NumRows>
+        <NumCols>25</NumCols>
         <BytesPerElement>8</BytesPerElement>
         <ArrayByteOffset>4328</ArrayByteOffset>
       </SupportArray>
@@ -214,21 +214,21 @@
         <NumRows>21</NumRows>
         <NumCols>21</NumCols>
         <BytesPerElement>8</BytesPerElement>
-        <ArrayByteOffset>4360</ArrayByteOffset>
+        <ArrayByteOffset>8928</ArrayByteOffset>
       </SupportArray>
       <SupportArray>
         <SAId>receive_element</SAId>
-        <NumRows>2</NumRows>
-        <NumCols>2</NumCols>
+        <NumRows>27</NumRows>
+        <NumCols>29</NumCols>
         <BytesPerElement>8</BytesPerElement>
-        <ArrayByteOffset>7888</ArrayByteOffset>
+        <ArrayByteOffset>12456</ArrayByteOffset>
       </SupportArray>
       <SupportArray>
         <SAId>the xm array</SAId>
         <NumRows>1</NumRows>
         <NumCols>2001</NumCols>
         <BytesPerElement>8</BytesPerElement>
-        <ArrayByteOffset>7920</ArrayByteOffset>
+        <ArrayByteOffset>18720</ArrayByteOffset>
       </SupportArray>
     </Support>
     <Transmit>
@@ -493,8 +493,8 @@
       <ElementFormat>Gain=F4;Phase=F4;</ElementFormat>
       <X0>-1.0</X0>
       <Y0>-1.0</Y0>
-      <XSS>2.0</XSS>
-      <YSS>2.0</YSS>
+      <XSS>0.09090909090909091</XSS>
+      <YSS>0.08333333333333333</YSS>
     </GainPhaseArray>
     <GainPhaseArray>
       <Identifier>receive_array</Identifier>
@@ -509,8 +509,8 @@
       <ElementFormat>Gain=F4;Phase=F4;</ElementFormat>
       <X0>-1.0</X0>
       <Y0>-1.0</Y0>
-      <XSS>2.0</XSS>
-      <YSS>2.0</YSS>
+      <XSS>0.07692307692307693</XSS>
+      <YSS>0.07142857142857142</YSS>
       <NODATA>ffc00000ffc00000</NODATA>
     </GainPhaseArray>
     <FxResponseArray>

--- a/sarkit/crsd/__init__.py
+++ b/sarkit/crsd/__init__.py
@@ -103,6 +103,10 @@ Antenna Parameters
    :toctree: generated/
 
    interpolate_support_array
+   compute_eb
+   ApatParams
+   ArrayElemSaMetadata
+   compute_apat
    compute_h_v_los_unit_vectors
    compute_h_v_pol_parameters
 
@@ -142,10 +146,14 @@ CRSD 1.0
 """
 
 from ._computations import (
+    ApatParams,
+    ArrayElemSaMetadata,
+    compute_apat,
     compute_apc_to_pt_geometry_parameters,
     compute_arp_to_rpt_geometry,
     compute_dwelltimes_using_dta,
     compute_dwelltimes_using_poly,
+    compute_eb,
     compute_h_v_los_unit_vectors,
     compute_h_v_pol_parameters,
     compute_ref_point_parameters,
@@ -207,6 +215,8 @@ __all__ = [
     "SECTION_TERMINATOR",
     "VERSION_INFO",
     "AddedPxpType",
+    "ApatParams",
+    "ArrayElemSaMetadata",
     "BoolType",
     "DblType",
     "EdfType",
@@ -235,10 +245,12 @@ __all__ = [
     "XyzPolyType",
     "XyzType",
     "binary_format_string_to_dtype",
+    "compute_apat",
     "compute_apc_to_pt_geometry_parameters",
     "compute_arp_to_rpt_geometry",
     "compute_dwelltimes_using_dta",
     "compute_dwelltimes_using_poly",
+    "compute_eb",
     "compute_h_v_los_unit_vectors",
     "compute_h_v_pol_parameters",
     "compute_ref_point_parameters",

--- a/sarkit/crsd/_computations.py
+++ b/sarkit/crsd/_computations.py
@@ -3,7 +3,9 @@ Select calculations from the CRSD D&I
 """
 
 import copy
+import dataclasses
 import functools
+from typing import Self
 
 import lxml.etree
 import numpy as np
@@ -307,6 +309,13 @@ def interpolate_support_array(
     sa = np.asarray(sa)
     x = np.atleast_1d(x)
     y = np.atleast_1d(y)
+    if sa.dtype.names is not None:
+        sa_out = np.empty(shape=x.shape, dtype=sa.dtype)
+        for name in sa.dtype.names:
+            sa_out[name], dv = interpolate_support_array(
+                x, y, x_0, y_0, x_ss, y_ss, sa[name], dv_sa
+            )
+        return sa_out, dv
     num_rows, num_cols = sa.shape
     dv = np.ones_like(x, dtype=bool)
 
@@ -633,3 +642,216 @@ def compute_reference_geometry(
         }
 
     return refgeom.elem
+
+
+def compute_eb(
+    eb0: npt.ArrayLike,
+    f: npt.ArrayLike,
+    fa_0: npt.ArrayLike,
+    ebfs_dcxsf: npt.ArrayLike,
+    ebfs_dcysf: npt.ArrayLike,
+) -> np.ndarray:
+    """Compute the electrical boresight (EB) pointing vector at frequency ``f``.
+
+    Parameters
+    ----------
+    eb0 : (..., 2) array_like
+        Electrical boresight steering vector at antenna reference frequency with DCX, DCY in last dimension.
+    f : array_like
+        Frequencies in Hz at which to compute the electrical boresight.
+    fa_0 : array_like
+        Antenna pattern reference frequency in Hz.
+    ebfs_dcxsf, ebfs_dcysf : array_like
+        EB frequency shift scale factors for DCX and DCY, respectively (dimensionless).
+
+    Returns
+    -------
+    (..., 2) ndarray
+        EB steering vector at frequency ``f``.
+    """
+    fa_0 = np.asarray(fa_0)
+    eb0 = np.asarray(eb0)
+
+    # 9.2.4
+    # (1)
+    delta_f_frac = (np.asarray(f) - fa_0) / fa_0
+
+    # (2)
+    eb_dcx = eb0[..., 0] / (1 + np.asarray(ebfs_dcxsf) * delta_f_frac)
+    eb_dcy = eb0[..., 1] / (1 + np.asarray(ebfs_dcysf) * delta_f_frac)
+
+    return np.stack((eb_dcx, eb_dcy), axis=-1)
+
+
+@dataclasses.dataclass(kw_only=True)
+class ApatParams:
+    """Set of Antenna Pattern parameters"""
+
+    fa_0: float
+    cG_BS: np.ndarray  # noqa N815
+    EBFS_DCXSF: float
+    EBFS_DCYSF: float
+    MLFD_DCXSF: float
+    MLFD_DCYSF: float
+
+    @classmethod
+    def from_xml(cls, crsd_xmltree: lxml.etree.ElementTree, apat_id: str) -> Self:
+        """Extract relevant antenna pattern parameters from CRSD XML.
+
+        Parameters
+        ----------
+        crsd_xmltree : lxml.etree.ElementTree
+            CRSD XML metadata
+        apat_id : str
+            String that uniquely identifies the antenna pattern
+
+        Returns
+        -------
+        ApatParams
+            The antenna pattern parameter object initialized with values from the XML.
+        """
+        crsd_ew = skcrsd_xml.ElementWrapper(crsd_xmltree.getroot())
+        apat_ew = crsd_ew["Antenna"].find("AntPattern", Identifier=apat_id)
+        return cls(
+            fa_0=apat_ew["FreqZero"],
+            cG_BS=apat_ew["GainBSPoly"],
+            EBFS_DCXSF=apat_ew["EBFreqShift"]["DCXSF"],
+            EBFS_DCYSF=apat_ew["EBFreqShift"]["DCYSF"],
+            MLFD_DCXSF=apat_ew["MLFreqDilation"]["DCXSF"],
+            MLFD_DCYSF=apat_ew["MLFreqDilation"]["DCYSF"],
+        )
+
+
+@dataclasses.dataclass(kw_only=True)
+class ArrayElemSaMetadata:
+    """Gain/Phase array metadata"""
+
+    NumRows: int
+    NumCols: int
+    dcx_0: float
+    dcy_0: float
+    dcx_ss: float
+    dcy_ss: float
+
+    @classmethod
+    def from_xml(cls, crsd_xmltree: lxml.etree.ElementTree, sa_id: str) -> Self:
+        """Extract relevant support array metadata parameters from CRSD XML.
+
+        Parameters
+        ----------
+        crsd_xmltree : lxml.etree.ElementTree
+            CRSD XML metadata
+        sa_id : str
+            Unique support array identifier
+
+        Returns
+        -------
+        ArrayElemSaMetadata
+            The support array metadata parameter object initialized with values from the XML.
+        """
+        crsd_ew = skcrsd_xml.ElementWrapper(crsd_xmltree.getroot())
+        sa_data_ew = crsd_ew["Data"]["Support"].find("SupportArray", SAId=sa_id)
+        sa_ew = crsd_ew["SupportArray"].find("GainPhaseArray", Identifier=sa_id)
+        return cls(
+            NumRows=sa_data_ew["NumRows"],
+            NumCols=sa_data_ew["NumCols"],
+            dcx_0=sa_ew["X0"],
+            dcy_0=sa_ew["Y0"],
+            dcx_ss=sa_ew["XSS"],
+            dcy_ss=sa_ew["YSS"],
+        )
+
+
+def compute_apat(
+    eb0: npt.ArrayLike,
+    ap: npt.ArrayLike,
+    f: npt.ArrayLike,
+    *,
+    apat_params: ApatParams,
+    array_sa: npt.ArrayLike,
+    array_sa_metadata: ArrayElemSaMetadata,
+    elem_sa: npt.ArrayLike,
+    elem_sa_metadata: ArrayElemSaMetadata,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute the antenna beam shape pattern for selected antenna pointing vectors and frequencies.
+
+    Parameters
+    ----------
+    eb0 : (..., 2) array_like
+        Electrical boresight steering vector at antenna reference frequency with DCX, DCY in last dimension.
+    ap : (..., 2) array_like
+        Selected antenna pointing vectors with DCX, DCY in last dimension.
+    f : array_like
+        Frequencies in Hz at which to compute the electrical boresight.
+    apat_params : ApatParams
+        Input set of APAT parameters
+    array_sa : array_like
+        APAT array gain/phase support array
+    array_sa_metadata : ArrayElemSaMetadata
+        APAT array gain/phase support array metadata
+    elem_sa : array_like
+        APAT element gain/phase support array
+    elem_sa_metadata : ArrayElemSaMetadata
+        APAT element gain/phase support array metadata
+
+    Returns
+    -------
+    gp_bs : (...) ndarray
+        Beam shape gain phase for selected pointing vectors and frequencies.
+    dv : (...) ndarray
+        Data valid flag for each element in ``gp_bs``
+    """
+    ap = np.asarray(ap)
+
+    # 9.3.4
+    # (1)
+    eb = compute_eb(
+        eb0, f, apat_params.fa_0, apat_params.EBFS_DCXSF, apat_params.EBFS_DCYSF
+    )
+
+    # (2)
+    delta_f_frac = (np.asarray(f) - apat_params.fa_0) / apat_params.fa_0
+    delta_g_bs = npp.polyval(delta_f_frac, apat_params.cG_BS)
+
+    # (3)
+    arr_sf_dcx = 1 + apat_params.MLFD_DCXSF * delta_f_frac
+    arr_sf_dcy = 1 + apat_params.MLFD_DCYSF * delta_f_frac
+
+    # (4)
+    delta_ap_dcx = (ap[..., 0] - eb[..., 0]) * arr_sf_dcx
+    delta_ap_dcy = (ap[..., 1] - eb[..., 1]) * arr_sf_dcy
+
+    # (5)
+    gp_arr, dv_arr = interpolate_support_array(
+        delta_ap_dcx,
+        delta_ap_dcy,
+        array_sa_metadata.dcx_0,
+        array_sa_metadata.dcy_0,
+        array_sa_metadata.dcx_ss,
+        array_sa_metadata.dcy_ss,
+        array_sa,
+        ~array_sa.mask["Gain"] if np.ma.isMaskedArray(array_sa) else None,  # type: ignore
+    )
+
+    # (6)
+    gp_elem, dv_elem = interpolate_support_array(
+        ap[..., 0],
+        ap[..., 1],
+        elem_sa_metadata.dcx_0,
+        elem_sa_metadata.dcy_0,
+        elem_sa_metadata.dcx_ss,
+        elem_sa_metadata.dcy_ss,
+        elem_sa,
+        ~elem_sa.mask["Gain"] if np.ma.isMaskedArray(elem_sa) else None,  # type: ignore
+    )
+
+    # (7)
+    # bs = beam shape, not boresight
+    gp_bs = np.empty(
+        np.broadcast_shapes(gp_arr.shape, gp_elem.shape), dtype=gp_arr.dtype
+    )
+    gp_bs["Gain"] = delta_g_bs + gp_arr["Gain"] + gp_elem["Gain"]
+    gp_bs["Phase"] = gp_arr["Phase"] + gp_elem["Phase"]
+    dv = dv_arr & dv_elem
+
+    return gp_bs, dv

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,6 +208,33 @@ def example_crsdsar(tmp_path_factory):
     pvps["DFIC0"][1] = -10
     pvps["FICRate"][1] = 10
 
+    # Gain/Phase arrays
+    gp_arrays = {}
+    crsd_ew = skcrsd.ElementWrapper(crsd_etree.getroot())
+    for gp_ew in crsd_ew["SupportArray"]["GainPhaseArray"]:
+        sa_id = gp_ew["Identifier"]
+        sadata_ew = crsd_ew["Data"]["Support"].find("SupportArray", SAId=sa_id)
+        x = (
+            gp_ew["X0"]
+            + np.arange(sadata_ew["NumRows"])[..., np.newaxis] * gp_ew["XSS"]
+        )
+        y = gp_ew["Y0"] + np.arange(sadata_ew["NumCols"]) * gp_ew["YSS"]
+        arr = np.zeros(
+            (sadata_ew["NumRows"], sadata_ew["NumCols"]),
+            dtype=skcrsd.binary_format_string_to_dtype(gp_ew["ElementFormat"]),
+        )
+        x_coef = -12.0 / max(abs(x)) ** 2
+        y_coef = -12.0 / max(abs(y)) ** 2
+        arr["Gain"] = x_coef * x**2 + y_coef * y**2
+        arr["Phase"] = x + y
+        nodata = (x**2 + y**2) > 1
+        arr[nodata] = np.nan
+        if nodata.any():
+            gp_ew["NODATA"] = np.full(
+                (), np.nan, dtype=arr.dtype.newbyteorder(">")
+            ).tobytes()
+        gp_arrays[sa_id] = arr
+
     tmp_crsd = (
         tmp_path_factory.mktemp("data") / good_crsd_xml_path.with_suffix(".crsd").name
     )
@@ -220,6 +247,8 @@ def example_crsdsar(tmp_path_factory):
         cw.write_ppp(sequence_id, ppps)
         cw.write_pvp(channel_id, pvps)
         cw.write_signal(channel_id, signal)
+        for sa_id, arr in gp_arrays.items():
+            cw.write_support_array(sa_id, arr)
     yield tmp_crsd
 
 

--- a/tests/core/crsd/test_computations.py
+++ b/tests/core/crsd/test_computations.py
@@ -159,3 +159,78 @@ def test_compute_reference_geometry_tx(example_crsdtx):
     basis_version = lxml.etree.QName(crsdxml.getroot()).namespace
     schema = lxml.etree.XMLSchema(file=skcrsd.VERSION_INFO[basis_version]["schema"])
     schema.assertValid(crsdxml)
+
+
+def test_compute_eb():
+    eb0 = [0.5, 0.3]
+    eb = skcrsd.compute_eb(eb0, [12, 10], 10, 0.8, 0.3)
+    assert not np.allclose(eb0, eb[0])
+    np.testing.assert_array_equal(eb0, eb[1])
+
+    eb = skcrsd.compute_eb(
+        np.zeros((3, 4, 5, 2)),
+        np.ones((3, 1, 5)),
+        np.ones((4, 1)),
+        np.ones((3, 1, 1)),
+        np.ones(
+            5,
+        ),
+    )
+    assert eb.shape == (3, 4, 5, 2)
+
+
+def test_compute_apat(example_crsdsar):
+    with open(example_crsdsar, "rb") as f, skcrsd.Reader(f) as r:
+        crsdxml = r.metadata.xmltree
+        crsd_ew = skcrsd.ElementWrapper(crsdxml.getroot())
+        apat_ew = crsd_ew["Antenna"]["AntPattern"][0]
+        array_gp = r.read_support_array(apat_ew["ArrayGPId"])
+        elem_gp = r.read_support_array(apat_ew["ElemGPId"])
+
+    array_meta = skcrsd.ArrayElemSaMetadata.from_xml(crsdxml, apat_ew["ArrayGPId"])
+
+    # array pattern valid within DCX/DCY= ~ +/-0.00038
+    # element pattern valid within DCX/DCY unit circle
+    rng = np.random.default_rng()
+    ap = 0.0007 * rng.random((6, 5, 3, 2)) - 0.00035
+    eb = 0.0007 * rng.random((3, 2)) - 0.00035
+
+    gp_bs, dv = skcrsd.compute_apat(
+        eb,
+        ap,
+        apat_ew["FreqZero"],
+        apat_params=skcrsd.ApatParams.from_xml(crsdxml, apat_ew["Identifier"]),
+        array_sa=array_gp,
+        array_sa_metadata=array_meta,
+        elem_sa=elem_gp,
+        elem_sa_metadata=skcrsd.ArrayElemSaMetadata.from_xml(
+            crsdxml, apat_ew["ElemGPId"]
+        ),
+    )
+    assert gp_bs.shape == (6, 5, 3)
+    assert gp_bs.shape == dv.shape
+    assert np.array_equal(dv, np.abs(ap - eb).max(axis=-1) < np.abs(array_meta.dcx_0))
+
+    ap = [
+        [0.0, 0.0],
+        [1.0, 1.0],
+        [0.0, 0.0],
+    ]
+    eb = [
+        [0.0, 0.0],
+        [1.0, 1.0],
+        [0.0005, 0.0005],  # outside array but within element
+    ]
+    gp_bs, dv = skcrsd.compute_apat(
+        eb,
+        ap,
+        apat_ew["FreqZero"],
+        apat_params=skcrsd.ApatParams.from_xml(crsdxml, apat_ew["Identifier"]),
+        array_sa=array_gp,
+        array_sa_metadata=array_meta,
+        elem_sa=elem_gp,
+        elem_sa_metadata=skcrsd.ArrayElemSaMetadata.from_xml(
+            crsdxml, apat_ew["ElemGPId"]
+        ),
+    )
+    assert np.array_equal(dv, [True, False, False])

--- a/tests/core/crsd/test_crsdinfo.py
+++ b/tests/core/crsd/test_crsdinfo.py
@@ -43,11 +43,11 @@ def test_raw(example_crsdsar):
         check=True,
     )
     raw_xml = proc.stdout
-
+    parser = lxml.etree.XMLParser(remove_blank_text=True)
     assert len(raw_xml) <= len(pretty_xml)
-    assert lxml.etree.tostring(
-        lxml.etree.fromstring(raw_xml), pretty_print=True
-    ) == lxml.etree.tostring(lxml.etree.fromstring(pretty_xml), pretty_print=True)
+    assert lxml.etree.canonicalize(
+        lxml.etree.fromstring(raw_xml, parser=parser)
+    ) == lxml.etree.canonicalize(lxml.etree.fromstring(pretty_xml, parser=parser))
 
 
 def test_smart_open(example_crsdsar):


### PR DESCRIPTION
# Description
This PR adds some CRSD v1.0 antenna functions:
- `sarkit.crsd.compute_eb` as defined in 9.2.4
- `sarkit.crsd.compute_apat` as defined in 9.3.4