### PR TITLE
Bugfix: spurious dimensionality for scalar input to interpolate_support_array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Erroneous output dimensionality for scalar inputs to `sarkit.crsd.interpolate_support_array`
+
 
 ## [1.8.1] - 2026-06-03
 

--- a/sarkit/crsd/_computations.py
+++ b/sarkit/crsd/_computations.py
@@ -507,8 +507,8 @@ def interpolate_support_array(
         Data valid array, where `True` indicates that ``values`` contains a valid value
     """
     sa = np.asarray(sa)
-    x = np.atleast_1d(x)
-    y = np.atleast_1d(y)
+    x = np.asarray(x)
+    y = np.asarray(y)
     num_rows, num_cols = sa.shape
     dv = np.ones_like(x, dtype=bool)
 

--- a/tests/core/crsd/test_computations.py
+++ b/tests/core/crsd/test_computations.py
@@ -83,15 +83,16 @@ def test_compute_dwelltimes():
 
 
 @pytest.mark.parametrize("use_mask", (True, False))
-def test_interpolate_support_array(use_mask):
+@pytest.mark.parametrize("in_shape", [(), (24,), (3, 40, 50)])
+def test_interpolate_support_array(use_mask, in_shape):
     dcx_0, dcy_0 = -0.75, -0.8
     num_rows, num_cols = 51, 29
 
     dcx = np.linspace(dcx_0, -dcx_0, num_rows, endpoint=True)
     dcy = np.linspace(dcy_0, -dcy_0, num_cols, endpoint=True)
 
-    dcx_ss = np.diff(dcx[:2])
-    dcy_ss = np.diff(dcy[:2])
+    dcx_ss = dcx[1] - dcx[0]
+    dcy_ss = dcy[1] - dcy[0]
 
     dcxx, dcyy = np.meshgrid(dcx, dcy, indexing="ij")
 
@@ -99,7 +100,7 @@ def test_interpolate_support_array(use_mask):
     valid = np.sqrt(dcxx**2 + dcyy**2) < 0.9
 
     rng = np.random.default_rng()
-    dcx_i, dcy_i = 2 * rng.random((2, 3, 40, 50)) - 1
+    dcx_i, dcy_i = 2 * rng.random((2,) + in_shape) - 1
     v, dv = skcrsd.interpolate_support_array(
         dcx_i,
         dcy_i,
@@ -110,6 +111,8 @@ def test_interpolate_support_array(use_mask):
         sa,
         dv_sa=valid if use_mask else None,
     )
+    assert v.shape == in_shape
+    assert dv.shape == in_shape
 
     sa_masked = sa.copy()
     sa_masked[~valid] = np.nan


### PR DESCRIPTION
# Description
While using `sarkit.crsd.interpolate_support_array`, I found confusing output behavior for scalar inputs, that can be illustrated by running the revised test without this proposed change:

<details>
<summary>revised test run in main</summary>

```console
$ pytest tests/core/crsd/test_computations.py::test_interpolate_support_array[in_shape0-True]
================================================================================================== test session starts ==================================================================================================
platform linux -- Python 3.13.5, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarkit
configfile: pyproject.toml
collected 1 item                                                                                                                                                                                                        

tests/core/crsd/test_computations.py F                                                                                                                                                                            [100%]

======================================================================================================= FAILURES ========================================================================================================
____________________________________________________________________________________ test_interpolate_support_array[in_shape0-True] _____________________________________________________________________________________

use_mask = True, in_shape = ()

    @pytest.mark.parametrize("use_mask", (True, False))
    @pytest.mark.parametrize("in_shape", [(), (24,), (3, 40, 50)])
    def test_interpolate_support_array(use_mask, in_shape):
        dcx_0, dcy_0 = -0.75, -0.8
        num_rows, num_cols = 51, 29
    
        dcx = np.linspace(dcx_0, -dcx_0, num_rows, endpoint=True)
        dcy = np.linspace(dcy_0, -dcy_0, num_cols, endpoint=True)
    
        dcx_ss = dcx[1] - dcx[0]
        dcy_ss = dcy[1] - dcy[0]
    
        dcxx, dcyy = np.meshgrid(dcx, dcy, indexing="ij")
    
        sa = dcxx**2 + dcyy**2
        valid = np.sqrt(dcxx**2 + dcyy**2) < 0.9
    
        rng = np.random.default_rng()
        dcx_i, dcy_i = 2 * rng.random((2,) + in_shape) - 1
        v, dv = skcrsd.interpolate_support_array(
            dcx_i,
            dcy_i,
            dcx_0,
            dcy_0,
            dcx_ss,
            dcy_ss,
            sa,
            dv_sa=valid if use_mask else None,
        )
>       assert v.shape == in_shape
E       assert (1,) == ()
E         
E         Left contains one more item: 1
E         Use -v to get more diff

tests/core/crsd/test_computations.py:114: AssertionError
================================================================================================ short test summary info ================================================================================================
FAILED tests/core/crsd/test_computations.py::test_interpolate_support_array[in_shape0-True] - assert (1,) == ()
=================================================================================================== 1 failed in 0.47s ===================================================================================================
                                                                                                                                                                                                                         

```

</details>

I think this is due to two unnecessary `atleast_1d` calls. Changing these to `asarray` does not change the result but would make output dimensionality more intuitive/self-consistent