### PR TITLE
Fix offset adjustments in conftest

### DIFF
--- a/data/example-crsd-1.0.xml
+++ b/data/example-crsd-1.0.xml
@@ -620,7 +620,7 @@
       <Format>X=F8;Y=F8;Z=F8;</Format>
     </RcvVel>
     <FRCV1>
-      <Offset>8</Offset>
+      <Offset>27</Offset>
       <Size>1</Size>
       <Format>F8</Format>
     </FRCV1>
@@ -680,7 +680,7 @@
       <Format>F8</Format>
     </DGRGC>
     <TxPulseIndex>
-      <Offset>27</Offset>
+      <Offset>8</Offset>
       <Size>1</Size>
       <Format>I8</Format>
     </TxPulseIndex>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -516,7 +516,7 @@ def example_crsdrcv(tmp_path_factory, example_crsdsar):
     _remove(crsd_etree, "{*}PVP/{*}TxPulseIndex")
     for pvp_offset in crsd_etree.findall("{*}PVP/*/{*}Offset"):
         if int(pvp_offset.text) > tx_pulse_index_offset:
-            pvp_offset.text = str(int(pvp_offset.text) - 8)
+            pvp_offset.text = str(int(pvp_offset.text) - 1)
     crsd_etree.find("{*}Data/{*}Receive/{*}NumBytesPVP").text = str(
         int(crsd_etree.findtext("{*}Data/{*}Receive/{*}NumBytesPVP")) - 8
     )


### PR DESCRIPTION
While attempting to reuse/modify the `sarkit` creation of a test `CRSDrcv` in `./tests/conftest.py` for a multi-channel `CRSDrcv`, I discovered that the PVP manipulation we do here is incorrect for the removal of `/PVP/TxPulseIndex`. We are subtracting `8` from the `Offset` instead of `1`.  This didn't fail our unit tests because `TxPulseIndex` was the last in the list.

In this MR:
* Fixed `Offset` manipulation
* Changed the XML for the example CPHD to put `TxPulseIndex` in the middle of the PVP list

After the XML update, I ran the code in `main` and observed many failures:

<details>
<Summary>Errors</Summary>

```

pdm run pytest ./tests/verification/test_crsd_consistency.py 
======================================================================================= test session starts ========================================================================================
platform linux -- Python 3.13.12, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/vscuser/repos/sarkit-remote
configfile: pyproject.toml
collected 596 items                                                                                                                                                                                

tests/verification/test_crsd_consistency.py ................................................................................................................................................ [ 24%]
........................................ssss......................................ss........................sssssssssssssssssssssssssssss.............sssss......ss.ss.ss......ssss......... [ 55%]
.......ss...EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE.... [ 87%]
.........EEE......................................................EE.....EEE                                                                                                                 [100%]

============================================================================================== ERRORS ============================================================================================

```

</details>

Tests run from this branch.

<details>
<Summary>No errors</Summary>

```

$ pdm run pytest ./tests/verification/test_crsd_consistency.py
======================================================================================= test session starts ========================================================================================
platform linux -- Python 3.13.12, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/vscuser/repos/sarkit-remote
configfile: pyproject.toml
collected 596 items                                                                                                                                                                                

tests/verification/test_crsd_consistency.py ................................................................................................................................................ [ 24%]
........................................ssss......................................ss........................sssssssssssssssssssssssssssss.............sssss......ss.ss.ss......ssss......... [ 55%]
.......ss...........ssss....ssssssssssssssssssssssssssssssssssssss................................................................ssss...........ss.ss.ss..ssss.....ss............s......... [ 87%]
............................................................................                                                                                                                 [100%]

================================================================================ 485 passed, 111 skipped in 16.31s =================================================================================

```

</details>