### PR TITLE
Raise minimum python version to 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Setup PDM and Python
       uses: pdm-project/setup-pdm@v4
       with:
-        python-version: 3.11
+        python-version: 3.12
     - name: Install dependencies
       run: |
         pdm lock -G :all --strategy direct_minimal_versions

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ current_env:
     expire_in: 1 week
 
 min_env:
-  image: python:3.11
+  image: python:3.12
   stage: build
   script:
   - pdm lock -G :all --strategy direct_minimal_versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Minimum supported version of Python raised to 3.12
+
 
 ## [1.8.1] - 2026-06-03
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -89,6 +89,7 @@ numpydoc_show_inherited_class_members = {
     "sarkit.cphd.ElementWrapper": False,
     "sarkit.crsd.ElementWrapper": False,
     "sarkit.sicd.ElementWrapper": False,
+    "sarkit.sidd.calculations.CoordinateSystem": False,
     "sarkit.sidd.ElementWrapper": False,
     "sarkit.xmlhelp.ElementWrapper": False,
 }

--- a/docs/source/reference/generated/sarkit.sidd.calculations.CoordinateSystem.rst
+++ b/docs/source/reference/generated/sarkit.sidd.calculations.CoordinateSystem.rst
@@ -1,0 +1,10 @@
+﻿sarkit.sidd.calculations.CoordinateSystem
+=========================================
+
+..
+   manually created as numpydoc doesn't seem to like when StrEnum is a base class
+
+.. currentmodule:: sarkit.sidd.calculations
+
+.. autoclass:: CoordinateSystem
+   :no-members:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "Suite of SAR-related tools in Python."
 authors = [
     {name = "Valkyrie Systems Corporation", email = "info@govsco.com"},
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
@@ -14,7 +14,6 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
@@ -37,7 +36,7 @@ test = [
     "nox>=2024.3.2",
 ]
 doc = [
-    "sphinx>=7.2.6,<9",  # v9 broke some autodoc features
+    "sphinx>=9.1.0",
     "numpydoc>=1.7.0",
     "sphinx-rtd-theme>=2.0.0",
     "sphinxcontrib-autoprogram>=0.1.9",


### PR DESCRIPTION
# Description
This PR addresses the note in the `pyproject.toml` by updating sphinx to 9.1.0. This necessitates raising the minimum python version to 3.12, which is consistent with [SPEC0](https://scientific-python.org/specs/spec-0000/#support-window)