### PR TITLE
Bugfix: apply_apos dimensionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Dimensionality mismatch in `sarkit.sicd.projection.apply_apos` for non-scalar projection sets
+- Object construction via `sarkit.sicd.projection.AdjustableParameterOffsets.from_xml` when XML contains zeroes
+
 
 ## [1.9.0] - 2026-06-10
 

--- a/sarkit/crsd/_computations.py
+++ b/sarkit/crsd/_computations.py
@@ -298,7 +298,7 @@ def compute_arp_to_rpt_geometry(
     ]
     r_arp_rpt = np.asarray((xmt_geom["R_APC_PT"] + rcv_geom["R_APC_PT"]) / 2)
     rdot_arp_rpt = np.asarray((xmt_geom["Rdot_APC_PT"] + rcv_geom["Rdot_APC_PT"]) / 2)
-    arp = pt + r_arp_rpt[..., np.newaxis] * uarp
+    arp = np.asarray(pt) + r_arp_rpt[..., np.newaxis] * uarp
     varp = rdot_arp_rpt[..., np.newaxis] * uarp + r_arp_rpt * uarpdot
     r_arp_rpt[bp_mag == 0] = 0
     rdot_arp_rpt[bp_mag == 0] = 0

--- a/sarkit/sicd/projection/_calc.py
+++ b/sarkit/sicd/projection/_calc.py
@@ -570,7 +570,8 @@ def apply_apos(
         # to form the adjusted COA projection set.
         delta_ARP_COA = (  # noqa N806
             apo_input_set.delta_ARP_SCP_COA
-            + apo_input_set.delta_VARP * (init_proj_set.t_COA - proj_metadata.t_SCP_COA)
+            + apo_input_set.delta_VARP
+            * (init_proj_set.t_COA - proj_metadata.t_SCP_COA)[..., np.newaxis]
         )
         delta_R_ARP = (  # noqa N806
             _constants.speed_of_light
@@ -612,16 +613,20 @@ def apply_apos(
     # The input APOs are used to compute the following offsets to be added to the initial COA
     # projection set to form the adjusted COA projection set
     delta_Xmt_COA = (  # noqa N806
-        init_proj_set.VXmt_COA * delta_tx_COA
+        init_proj_set.VXmt_COA * delta_tx_COA[..., np.newaxis]
         + apo_input_set.delta_Xmt_SCP_COA
         + apo_input_set.delta_VXmt
-        * (init_proj_set.tx_COA + delta_tx_COA - proj_metadata.t_SCP_COA)
+        * (init_proj_set.tx_COA + delta_tx_COA - proj_metadata.t_SCP_COA)[
+            ..., np.newaxis
+        ]
     )
     delta_Rcv_COA = (  # noqa N806
-        init_proj_set.VRcv_COA * delta_tr_COA
+        init_proj_set.VRcv_COA * delta_tr_COA[..., np.newaxis]
         + apo_input_set.delta_Rcv_SCP_COA
         + apo_input_set.delta_VRcv
-        * (init_proj_set.tr_COA + delta_tr_COA - proj_metadata.t_SCP_COA)
+        * (init_proj_set.tr_COA + delta_tr_COA - proj_metadata.t_SCP_COA)[
+            ..., np.newaxis
+        ]
     )
     delta_R_Avg_COA = (  # noqa N806
         _constants.speed_of_light / 2 * (delta_tr_COA - delta_tx_COA)

--- a/sarkit/sicd/projection/_derived.py
+++ b/sarkit/sicd/projection/_derived.py
@@ -79,7 +79,7 @@ def image_to_ground_plane(
         )
         delta_gp = np.full(gpp_tgt.shape[:-1], np.nan)
         delta_gp[np.isfinite(gpp_tgt).all(axis=-1)] = 0
-        success = np.isfinite(gpp_tgt).all()
+        success = bool(np.isfinite(gpp_tgt).all())
         return gpp_tgt, delta_gp, success
     if method == "bistatic":
         if isinstance(projection_sets, params.ProjectionSetsMono):

--- a/sarkit/sicd/projection/_errorprop.py
+++ b/sarkit/sicd/projection/_errorprop.py
@@ -24,7 +24,7 @@ def compute_ric_basis_vectors(p_ric: npt.ArrayLike, v_ric: npt.ArrayLike):
         Radial, in-track, and cross-track unit vectors that specify the RIC frame
     """
 
-    u_r = p_ric / np.linalg.norm(p_ric, keepdims=True, axis=-1)
+    u_r = np.asarray(p_ric) / np.linalg.norm(p_ric, keepdims=True, axis=-1)
     c = np.cross(u_r, np.asarray(v_ric))
     u_c = c / np.linalg.norm(c, keepdims=True, axis=-1)
     u_i = np.cross(u_c, u_r)

--- a/sarkit/sicd/projection/_params.py
+++ b/sarkit/sicd/projection/_params.py
@@ -817,46 +817,23 @@ class AdjustableParameterOffsets:
             The adjustable parameter offsets list object initialized with values from the XML.
 
         """
-        xmlhelp = ss_xml.XmlHelper(sicd_xmltree)
+        ew = ss_xml.ElementWrapper(sicd_xmltree.getroot())
+        apos = ew["ErrorStatistics"].get("AdjustableParameterOffsets", None)
+        if apos is not None:
+            return cls(
+                delta_ARP_SCP_COA=apos["ARPPosSCPCOA"],
+                delta_VARP=apos["ARPVel"],
+                delta_tx_SCP_COA=apos["TxTimeSCPCOA"],
+                delta_tr_SCP_COA=apos["RcvTimeSCPCOA"],
+            )
+        bi_apos = ew["ErrorStatistics"]["BistaticAdjustableParameterOffsets"]
         return cls(
-            **{
-                "delta_tx_SCP_COA": xmlhelp.load(
-                    "{*}ErrorStatistics/{*}AdjustableParameterOffsets/{*}TxTimeSCPCOA"
-                )
-                or xmlhelp.load(
-                    "{*}ErrorStatistics/{*}BistaticAdjustableParameterOffsets/{*}TxPlatform/{*}TimeSCPCOA"
-                ),
-                "delta_tr_SCP_COA": xmlhelp.load(
-                    "{*}ErrorStatistics/{*}AdjustableParameterOffsets/{*}RcvTimeSCPCOA"
-                )
-                or xmlhelp.load(
-                    "{*}ErrorStatistics/{*}BistaticAdjustableParameterOffsets/{*}RcvPlatform/{*}TimeSCPCOA"
-                ),
-                # Optional Monostatic Adjustable Offsets
-                "delta_ARP_SCP_COA": xmlhelp.load(
-                    "{*}ErrorStatistics/{*}AdjustableParameterOffsets/{*}ARPPosSCPCOA"
-                ),
-                "delta_VARP": xmlhelp.load(
-                    "{*}ErrorStatistics/{*}AdjustableParameterOffsets/{*}ARPVel"
-                ),
-                # Optional Bistatic Adjustable Offsets
-                "delta_Xmt_SCP_COA": xmlhelp.load(
-                    "{*}ErrorStatistics/{*}BistaticAdjustableParameterOffsets/{*}TxPlatform/{*}APCPosSCPCOA"
-                ),
-                "delta_VXmt": xmlhelp.load(
-                    "{*}ErrorStatistics/{*}BistaticAdjustableParameterOffsets/{*}TxPlatform/{*}APCVel"
-                ),
-                "f_Clk_X_SF": xmlhelp.load(
-                    "{*}ErrorStatistics/{*}BistaticAdjustableParameterOffsets/{*}TxPlatform/{*}ClockFreqSF"
-                ),
-                "delta_Rcv_SCP_COA": xmlhelp.load(
-                    "{*}ErrorStatistics/{*}BistaticAdjustableParameterOffsets/{*}RcvPlatform/{*}APCPosSCPCOA"
-                ),
-                "delta_VRcv": xmlhelp.load(
-                    "{*}ErrorStatistics/{*}BistaticAdjustableParameterOffsets/{*}RcvPlatform/{*}APCVel"
-                ),
-                "f_Clk_R_SF": xmlhelp.load(
-                    "{*}ErrorStatistics/{*}BistaticAdjustableParameterOffsets/{*}RcvPlatform/{*}ClockFreqSF"
-                ),
-            }
+            delta_Xmt_SCP_COA=bi_apos["TxPlatform"]["APCPosSCPCOA"],
+            delta_VXmt=bi_apos["TxPlatform"]["APCVel"],
+            delta_tx_SCP_COA=bi_apos["TxPlatform"]["TimeSCPCOA"],
+            f_Clk_X_SF=bi_apos["TxPlatform"]["ClockFreqSF"],
+            delta_Rcv_SCP_COA=bi_apos["RcvPlatform"]["APCPosSCPCOA"],
+            delta_VRcv=bi_apos["RcvPlatform"]["APCVel"],
+            delta_tr_SCP_COA=bi_apos["RcvPlatform"]["TimeSCPCOA"],
+            f_Clk_R_SF=bi_apos["RcvPlatform"]["ClockFreqSF"],
         )

--- a/tests/core/sicd/test_projection.py
+++ b/tests/core/sicd/test_projection.py
@@ -77,7 +77,7 @@ def test_metadata_params_is_monostatic(example_proj_metadata):
         example_proj_metadata.is_monostatic()
 
 
-@pytest.mark.parametrize("xmlfile", (DATAPATH / "syntax_only/sicd").glob("*.xml"))
+@pytest.mark.parametrize("xmlfile", list((DATAPATH / "syntax_only/sicd").glob("*.xml")))
 def test_errorstatparams(xmlfile):
     errparams = sicdproj.ErrorStatParams.from_xml(lxml.etree.parse(xmlfile))
     for field in dataclasses.fields(errparams):
@@ -91,7 +91,7 @@ def test_errorstatparams(xmlfile):
             assert val >= 0.0
 
 
-@pytest.mark.parametrize("xmlfile", (DATAPATH / "syntax_only/sicd").glob("*.xml"))
+@pytest.mark.parametrize("xmlfile", list((DATAPATH / "syntax_only/sicd").glob("*.xml")))
 def test_apoerrorparams(xmlfile):
     apoerrparams = sicdproj.ApoErrorParams.from_xml(lxml.etree.parse(xmlfile))
     for field in dataclasses.fields(apoerrparams):

--- a/tests/core/sicd/test_sicd_projections.py
+++ b/tests/core/sicd/test_sicd_projections.py
@@ -170,3 +170,132 @@ def test_image_to_dem_surface(sicd_xml):
         # assert only one intersection since DEM is an HAE surface
         assert hae_dem_coord.size == surf_coord.size
         assert np.allclose(hae_dem_coord, surf_coord, atol=0.01)
+
+
+@pytest.fixture
+def mono_1_5():
+    xmltree = lxml.etree.parse(DATAPATH / "example-sicd-1.3.0.xml")
+    old_ew = sksicd.ElementWrapper(xmltree.getroot())
+    assert old_ew["CollectionInfo"]["CollectType"] == "MONOSTATIC"
+    new_ew = sksicd.ElementWrapper(lxml.etree.Element("{urn:SICD:1.5}SICD"))
+    new_ew.from_dict(old_ew.to_dict())
+    schema = lxml.etree.XMLSchema(file=sksicd.VERSION_INFO["urn:SICD:1.5"]["schema"])
+    schema.assertValid(new_ew.elem)
+    return new_ew.elem.getroottree()
+
+
+def image_to_ground(sicdxml):
+    xmlhelp = sksicd.XmlHelper(sicdxml)
+    scp = xmlhelp.load("{*}GeoData/{*}SCP/{*}ECF")
+    image_plane_normal = np.cross(
+        xmlhelp.load("{*}Grid/{*}Row/{*}UVectECF"),
+        xmlhelp.load("{*}Grid/{*}Col/{*}UVectECF"),
+    )
+    im_coords = np.random.default_rng(12345).uniform(
+        low=-24.0, high=24.0, size=(3, 4, 5, 2)
+    )
+    gpp, _, success = sksicd.image_to_ground_plane(
+        sicdxml,
+        im_coords,
+        scp,
+        image_plane_normal,
+    )
+    assert success
+    return gpp
+
+
+def image_to_constant_hae(sicdxml):
+    xmlhelp = sksicd.XmlHelper(sicdxml)
+    scp_hae = xmlhelp.load("{*}GeoData/{*}SCP/{*}LLH/{*}HAE")
+    im_coords = np.random.default_rng(12345).uniform(
+        low=-24.0, high=24.0, size=(3, 4, 5, 2)
+    )
+    surf_coords, _, success = sksicd.image_to_constant_hae_surface(
+        sicdxml,
+        im_coords,
+        scp_hae,
+    )
+    assert success
+    return surf_coords
+
+
+def image_to_dem(sicdxml):
+    xmlhelp = sksicd.XmlHelper(sicdxml)
+    scp_hae = xmlhelp.load("{*}GeoData/{*}SCP/{*}LLH/{*}HAE")
+
+    def hae_dem_func(ecf):
+        return sarkit.wgs84.cartesian_to_geodetic(ecf)[..., -1] - scp_hae
+
+    im_coord = np.random.default_rng(12345).uniform(low=-24.0, high=24.0, size=(2,))
+    hae_dem_coord = sksicd.image_to_dem_surface(
+        sicdxml,
+        im_coord,
+        ecef2dem_func=hae_dem_func,
+        hae_min=scp_hae - 10.0,
+        hae_max=scp_hae + 10.0,
+        delta_dist_dem=1.0,
+    )
+    return hae_dem_coord
+
+
+def scene_to_image(sicdxml):
+    xmlhelp = sksicd.XmlHelper(sicdxml)
+    scp = xmlhelp.load("{*}GeoData/{*}SCP/{*}ECF")
+    scene_coords = scp + np.random.default_rng(12345).uniform(
+        low=-24.0, high=24.0, size=(3, 4, 5, 3)
+    )
+    im_coords, _, success = sksicd.scene_to_image(sicdxml, scene_coords)
+    assert success
+    return im_coords
+
+
+@pytest.mark.parametrize(
+    "projfunc", [image_to_ground, image_to_constant_hae, image_to_dem, scene_to_image]
+)
+def test_proj_with_apos_mono(mono_1_5, projfunc):
+    # project without APOs
+    assert mono_1_5.find(".//{*}AdjustableParameterOffsets") is None
+    pts_no_apo = projfunc(mono_1_5)
+
+    # project with APOs set to 0
+    ew = sksicd.ElementWrapper(mono_1_5.getroot())
+    ew["ErrorStatistics"]["AdjustableParameterOffsets"]["ARPPosSCPCOA"] = [0, 0, 0]
+    ew["ErrorStatistics"]["AdjustableParameterOffsets"]["ARPVel"] = [0, 0, 0]
+    ew["ErrorStatistics"]["AdjustableParameterOffsets"]["TxTimeSCPCOA"] = 0.0
+    ew["ErrorStatistics"]["AdjustableParameterOffsets"]["RcvTimeSCPCOA"] = 0.0
+    pts_zero_apo = projfunc(mono_1_5)
+    assert np.array_equal(pts_no_apo, pts_zero_apo)
+
+    # project with nonzero APOs
+    ew["ErrorStatistics"]["AdjustableParameterOffsets"]["ARPPosSCPCOA"] = [1, 0, 0]
+    pts_nonzero_apo = projfunc(mono_1_5)
+    assert bool(np.all(np.any(pts_no_apo != pts_nonzero_apo, axis=-1)))
+
+
+@pytest.mark.parametrize(
+    "projfunc", [image_to_ground, image_to_constant_hae, image_to_dem, scene_to_image]
+)
+def test_proj_with_apos_bi(projfunc):
+    sicdxml = lxml.etree.parse(DATAPATH / "example-sicd-1.5.xml")
+    assert sicdxml.findtext("{*}CollectionInfo/{*}CollectType") == "BISTATIC"
+
+    # project without APOs
+    assert sicdxml.find(".//{*}BistaticAdjustableParameterOffsets") is None
+    pts_no_apo = projfunc(sicdxml)
+
+    # project with APOs set to 0
+    biapos = sksicd.ElementWrapper(sicdxml.getroot())["ErrorStatistics"][
+        "BistaticAdjustableParameterOffsets"
+    ]
+    for plat in ("TxPlatform", "RcvPlatform"):
+        biapos[plat]["APCPosSCPCOA"] = [0, 0, 0]
+        biapos[plat]["APCVel"] = [0, 0, 0]
+        biapos[plat]["TimeSCPCOA"] = 0.0
+        biapos[plat]["ClockFreqSF"] = 0.0
+    pts_zero_apo = projfunc(sicdxml)
+    assert np.array_equal(pts_no_apo, pts_zero_apo)
+
+    # project with nonzero APOs
+    biapos["TxPlatform"]["APCPosSCPCOA"] = [1, 0, 0]
+    pts_nonzero_apo = projfunc(sicdxml)
+    assert bool(np.all(np.any(pts_no_apo != pts_nonzero_apo, axis=-1)))

--- a/tests/core/sicd/test_xml.py
+++ b/tests/core/sicd/test_xml.py
@@ -91,7 +91,7 @@ def _replace_scpcoa(sicd_xmltree):
     return scpcoa
 
 
-@pytest.mark.parametrize("xml_file", DATAPATH.glob("example-sicd*.xml"))
+@pytest.mark.parametrize("xml_file", list(DATAPATH.glob("example-sicd*.xml")))
 def test_compute_scp_coa(xml_file):
     _replace_scpcoa(lxml.etree.parse(xml_file))
 

--- a/tests/verification/test_cphd_consistency.py
+++ b/tests/verification/test_cphd_consistency.py
@@ -151,7 +151,9 @@ def test_main(cphd_file):
     assert not main([str(cphd_file)])
 
 
-@pytest.mark.parametrize("xml_file", (DATAPATH / "syntax_only/cphd").glob("*.xml"))
+@pytest.mark.parametrize(
+    "xml_file", list((DATAPATH / "syntax_only/cphd").glob("*.xml"))
+)
 def test_smoketest(xml_file):
     main([str(xml_file)])
 

--- a/tests/verification/test_crsd_consistency.py
+++ b/tests/verification/test_crsd_consistency.py
@@ -224,7 +224,9 @@ def test_from_file_xml():
     assert not crsdcon.failures()
 
 
-@pytest.mark.parametrize("xml_file", (DATAPATH / "syntax_only/crsd").glob("*.xml"))
+@pytest.mark.parametrize(
+    "xml_file", list((DATAPATH / "syntax_only/crsd").glob("*.xml"))
+)
 def test_smoketest(xml_file):
     main([str(xml_file)])
 

--- a/tests/verification/test_sicd_consistency.py
+++ b/tests/verification/test_sicd_consistency.py
@@ -122,7 +122,9 @@ def test_main(file):
     assert not main([str(file), "-vv"])
 
 
-@pytest.mark.parametrize("xml_file", (DATAPATH / "syntax_only/sicd").glob("*.xml"))
+@pytest.mark.parametrize(
+    "xml_file", list((DATAPATH / "syntax_only/sicd").glob("*.xml"))
+)
 def test_smoketest(xml_file):
     main([str(xml_file)])
 


### PR DESCRIPTION
# Description
Closes #146

This PR fixes a broadcasting bug in `sarkit.sicd.projection.apply_apos` as pointed out in https://github.com/ValkyrieSystems/sarkit/issues/146

While testing the fix, a separate bug in `sarkit.sicd.projection.AdjustableParameterOffsets.from_xml` was discovered where due to the order of operations and the use of falsey checking, using `AdjustableParameterOffsets.from_xml` with an XML containing zeros resulted in some fields being initialized to `None` instead of their proper values.

## Notes
This PR also contains:
- fixes for `pytest` deprecation of non-collections in `parametrize`
- fixes for updated `numpy` typing