### PR TITLE
Bugfix: Accommodate Tx antenna PVPs with NaNs in cphdcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Warnings logged when not all CRSD support arrays written
+- Allow NaN in TxACX, TxACY, TxEB PVPs to indicate no transmit pulse for the vector
 
 
 ## [1.10.0] - 2026-06-25

--- a/sarkit/verification/_cphd_consistency.py
+++ b/sarkit/verification/_cphd_consistency.py
@@ -925,13 +925,17 @@ class CphdConsistency(con.ConsistencyChecker):
             pvp = self._get_channel_pvps(channel_id)
             assert {"TxACX", "TxACY"}.issubset(pvp.dtype.names)
             with self.need("TxACX is unit length"):
-                assert np.linalg.norm(pvp["TxACX"], axis=-1) == con.Approx(1.0)
+                assert np.nan_to_num(
+                    np.linalg.norm(pvp["TxACX"], axis=-1), nan=1.0
+                ) == con.Approx(1.0)
             with self.need("TxACY is unit length"):
-                assert np.linalg.norm(pvp["TxACY"], axis=-1) == con.Approx(1.0)
+                assert np.nan_to_num(
+                    np.linalg.norm(pvp["TxACY"], axis=-1), nan=1.0
+                ) == con.Approx(1.0)
             with self.need("TxACX and TxACY are orthogonal"):
-                assert np.vecdot(pvp["TxACX"], pvp["TxACY"]) == con.Approx(
-                    0.0, atol=1e-6
-                )
+                assert np.nan_to_num(
+                    np.vecdot(pvp["TxACX"], pvp["TxACY"]), nan=0.0
+                ) == con.Approx(0.0, atol=1e-6)
 
     @per_channel
     def check_txeb(self, channel_id, channel_node):
@@ -940,7 +944,9 @@ class CphdConsistency(con.ConsistencyChecker):
             pvp = self._get_channel_pvps(channel_id)
             assert "TxEB" in pvp.dtype.names
             with self.need("TxEB is less than unit length"):
-                assert np.linalg.norm(pvp["TxEB"], axis=-1) <= con.Approx(1.0)
+                assert np.nan_to_num(
+                    np.linalg.norm(pvp["TxEB"], axis=-1), nan=0.0
+                ) <= con.Approx(1.0)
 
     @per_channel
     def check_rcv_acxy(self, channel_id, channel_node):


### PR DESCRIPTION
# Description
Credit to @mtrachy

This PR contains a bugfix that addresses spurious  `cphdcheck` errors  for CPHDs that use NaNs to indicate no transmit pulse in certain transmit PVPs.