### PR TITLE
Bugfix: dtype_to_pxp_element failures due to endianness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Unused `_processing` module
 
+### Fixed
+- `dtype_to_pvp_element`/`dtype_to_ppp_element`failures due to dtype endianness in `sarkit.cphd` and `sarkit.crsd`
+
 
 ## [1.10.1] - 2026-07-31
 

--- a/sarkit/cphd/_xml.py
+++ b/sarkit/cphd/_xml.py
@@ -229,7 +229,7 @@ class DefinedPvpType(PvpType):
         """
         local_val = copy.deepcopy(val)
         dtype = local_val.setdefault("dtype", self.dtype)
-        if dtype != self.dtype:
+        if dtype.newbyteorder("=") != self.dtype:
             raise ValueError(f"Invalid {dtype=}; expected {self.dtype}")
         size = local_val.setdefault("Size", self.dtype.itemsize // 8)
         if size != self.dtype.itemsize // 8:

--- a/tests/core/cphd/test_pvps.py
+++ b/tests/core/cphd/test_pvps.py
@@ -67,3 +67,14 @@ def test_pvp_dtype_element_roundtrip(basis_xml):
     ew["PVP"] = skcphd.dtype_to_pvp_element(basis_version, new_dtype)
     assert ew["PVP"].find("AddedPVP", Name="NewField") is not None
     schema.assertValid(basis_etree)
+
+
+def test_dtype_to_pvp_element(example_cphd):
+    with example_cphd.open("rb") as f, skcphd.Reader(f) as r:
+        pvps = r.read_pvps(r.metadata.xmltree.findtext(".//{*}RefChId"))
+    ew = skcphd.ElementWrapper(r.metadata.xmltree.getroot())
+    ew["PVP"] = skcphd.dtype_to_pvp_element(
+        lxml.etree.QName(r.metadata.xmltree.getroot()).namespace, pvps.dtype
+    )
+    new_dtype = skcphd.get_pvp_dtype(ew.elem.getroottree())
+    assert pvps.dtype.newbyteorder("=") == new_dtype.newbyteorder("=")

--- a/tests/core/crsd/test_pxps.py
+++ b/tests/core/crsd/test_pxps.py
@@ -92,3 +92,25 @@ def test_pvp_dtype_element_roundtrip():
     ew["PVP"] = skcrsd.dtype_to_pvp_element(basis_version, new_dtype)
     assert ew["PVP"].find("AddedPVP", Name="NewField") is not None
     schema.assertValid(basis_etree)
+
+
+def test_dtype_to_pvp_element(example_crsdsar):
+    with example_crsdsar.open("rb") as f, skcrsd.Reader(f) as r:
+        pvps = r.read_pvps(r.metadata.xmltree.findtext(".//{*}RefChId"))
+    ew = skcrsd.ElementWrapper(r.metadata.xmltree.getroot())
+    ew["PVP"] = skcrsd.dtype_to_pvp_element(
+        lxml.etree.QName(r.metadata.xmltree.getroot()).namespace, pvps.dtype
+    )
+    new_dtype = skcrsd.get_pvp_dtype(ew.elem.getroottree())
+    assert pvps.dtype.newbyteorder("=") == new_dtype.newbyteorder("=")
+
+
+def test_dtype_to_ppp_element(example_crsdsar):
+    with example_crsdsar.open("rb") as f, skcrsd.Reader(f) as r:
+        ppps = r.read_ppps(r.metadata.xmltree.findtext(".//{*}RefTxId"))
+    ew = skcrsd.ElementWrapper(r.metadata.xmltree.getroot())
+    ew["PPP"] = skcrsd.dtype_to_ppp_element(
+        lxml.etree.QName(r.metadata.xmltree.getroot()).namespace, ppps.dtype
+    )
+    new_dtype = skcrsd.get_ppp_dtype(ew.elem.getroottree())
+    assert ppps.dtype.newbyteorder("=") == new_dtype.newbyteorder("=")


### PR DESCRIPTION
# Description
This PR fixes a bug where `sarkit.cphd.dtype_to_pvp_element` incorrectly rejects pxp dtypes if their endianness is not native. This can be reproduced by running the new tests using main on a little-endian system:

<img width="743" height="29" alt="image" src="https://github.com/user-attachments/assets/5c1f69a5-674e-49ae-b574-afe71741f955" />
