### PR TITLE
Bugfix: erroneous transpose in compute_gp_xy_parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Unused `_processing` module
 
+### Fixed
+- Erroneous transpose in sensitivity matrix outputs of `sarkit.sicd.projection.compute_gp_xy_parameters`
+
 
 ## [1.10.1] - 2026-07-31
 

--- a/sarkit/sicd/projection/_calc.py
+++ b/sarkit/sicd/projection/_calc.py
@@ -1009,17 +1009,17 @@ def compute_gp_xy_parameters(
     ugy = gy / np.linalg.norm(gy, axis=-1, keepdims=True)
 
     m_rrdot_gpxy = np.negative(
-        np.stack(
-            (
-                np.stack(
-                    ((bp_pt * ugx).sum(axis=-1), np.zeros_like(ugx[..., 0])), axis=-1
-                ),
-                np.stack(
-                    ((bpdot_pt * ugx).sum(axis=-1), (bpdot_pt * ugy).sum(axis=-1)),
-                    axis=-1,
-                ),
-            ),
-            axis=-1,
+        np.block(
+            [
+                [
+                    np.vecdot(bp_pt, ugx)[..., np.newaxis, np.newaxis],
+                    np.zeros_like(ugx[..., 0])[..., np.newaxis, np.newaxis],
+                ],
+                [
+                    np.vecdot(bpdot_pt, ugx)[..., np.newaxis, np.newaxis],
+                    np.vecdot(bpdot_pt, ugy)[..., np.newaxis, np.newaxis],
+                ],
+            ]
         )
     )
 

--- a/tests/core/sicd/test_projection.py
+++ b/tests/core/sicd/test_projection.py
@@ -222,6 +222,40 @@ def test_compute_pt_r_rdot_parameters_mono(example_proj_metadata):
     assert pt_r_rdot_params.Rdot_Avg_PT == pytest.approx(rdot_scp)
 
 
+def test_compute_gp_xy_parameters():
+    rng = np.random.default_rng(123456)
+    points = rng.random((6, 3))
+
+    def random_unit(shp):
+        out = rng.random(shp)
+        out /= np.linalg.norm(out, axis=-1, keepdims=True)
+        return out
+
+    ugpn = random_unit((4, 1, 6, 3))
+
+    # these aren't actually unit vectors but good enough for this purpose...
+    bp = random_unit((5, 1, 3))
+    bpdot = random_unit((3,)).tolist()
+
+    gpxy_params = sicdproj.compute_gp_xy_parameters(points, ugpn, bp, bpdot)
+
+    # uGX, uGY, uGPN are orthonormal
+    assert np.linalg.norm(gpxy_params.uGX, axis=-1) == pytest.approx(1.0)
+    assert np.linalg.norm(gpxy_params.uGY, axis=-1) == pytest.approx(1.0)
+    assert np.vecdot(gpxy_params.uGX, gpxy_params.uGY) == pytest.approx(0.0)
+    assert np.vecdot(gpxy_params.uGX, ugpn) == pytest.approx(0.0)
+
+    # shapes broadcast correctly
+    assert gpxy_params.uGX.shape == (4, 5, 6, 3)
+    assert gpxy_params.uGY.shape == (4, 5, 6, 3)
+    assert gpxy_params.M_RRdot_GPXY.shape == (4, 5, 6, 2, 2)
+    assert gpxy_params.M_GPXY_RRdot.shape == (4, 5, 6, 2, 2)
+
+    # matrices are constructed properly
+    assert (gpxy_params.M_RRdot_GPXY[..., 0, 1] == 0).all()
+    assert np.allclose(gpxy_params.M_RRdot_GPXY @ gpxy_params.M_GPXY_RRdot, np.eye(2))
+
+
 def test_r_rdot_to_ground_plane(example_proj_metadata):
     im_coords = np.random.default_rng(12345).uniform(
         low=-24.0, high=24.0, size=(3, 4, 5, 2)


### PR DESCRIPTION
# Description
Closes #161 

This PR fixes the erroneous transpose in `sarkit.sicd.projection.compute_gp_xy_parameters` pointed out in https://github.com/ValkyrieSystems/sarkit/issues/161

I did a quick survey of the other sensitivity matrices and did not spot any others that shared a similar flaw.

## Demo
@bombaci-vsc ran the case mentioned in `main` and this branch

### main
```python
[[[-8.39392111e-01 -9.28325248e-05]
  [-0.00000000e+00  2.66577045e-02]]]
```

### this branch
```python
[[[-8.39392111e-01 -0.00000000e+00]
  [-9.28325248e-05  2.66577045e-02]]]
```