### PR TITLE
Bugfix: ignore non-elements in XML classes/functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `dtype_to_pvp_element`/`dtype_to_ppp_element`failures due to dtype endianness in `sarkit.cphd` and `sarkit.crsd`
+- Ignore non-elements in XmlHelper, ElementWrapper, and transcoders
 
 
 ## [1.10.1] - 2026-07-31

--- a/sarkit/sicd/_xml.py
+++ b/sarkit/sicd/_xml.py
@@ -132,7 +132,10 @@ class ImageCornersType(skxt.NdArrayType):
         return np.asarray(
             [
                 self.sub_type.parse_elem(x)
-                for x in sorted(elem, key=lambda x: x.get("index"))
+                for x in sorted(
+                    elem.iterchildren(tag=lxml.etree.Element),
+                    key=lambda x: x.get("index"),
+                )
             ]
         )
 

--- a/sarkit/sidd/_xml.py
+++ b/sarkit/sidd/_xml.py
@@ -183,7 +183,7 @@ class FilterCoefficientType(skxt.Type):
             (int(coef.get(self.coef_x_name)), int(coef.get(self.coef_y_name))): float(
                 coef.text
             )
-            for coef in elem
+            for coef in elem.iterchildren(tag=lxml.etree.Element)
         }
         for indices, coef in coef_by_indices.items():
             coefs[*indices] = coef
@@ -299,7 +299,10 @@ class ImageCornersType(skxt.NdArrayType):
         return np.asarray(
             [
                 self.sub_type.parse_elem(x)
-                for x in sorted(elem, key=lambda x: x.get("index"))
+                for x in sorted(
+                    elem.iterchildren(tag=lxml.etree.Element),
+                    key=lambda x: x.get("index"),
+                )
             ]
         )
 
@@ -376,12 +379,13 @@ class SfaPointType(skxt.ArrayType):
 
     def parse_elem(self, elem: lxml.etree.Element) -> npt.NDArray:
         """Returns an array containing the sub-elements encoded in ``elem``."""
-        if len(elem) not in (2, 3):
+        num_child_elems = elem.xpath("count(*)")
+        if num_child_elems not in (2, 3):
             raise ValueError("Unexpected number of subelements (requires 2 or 3)")
         self.subelements = {
             k: v
             for idx, (k, v) in enumerate(self._subelem_superset.items())
-            if idx < len(elem)
+            if idx < num_child_elems
         }
         return super().parse_elem(elem)
 
@@ -408,7 +412,10 @@ class LUTInfoType(skxt.Type):
         return np.array(
             [
                 IntListType().parse_elem(x)
-                for x in sorted(elem, key=lambda x: int(x.get("lut")))
+                for x in sorted(
+                    elem.iterchildren(tag=lxml.etree.Element),
+                    key=lambda x: int(x.get("lut")),
+                )
             ]
         )
 

--- a/sarkit/xmlhelp/_core.py
+++ b/sarkit/xmlhelp/_core.py
@@ -410,7 +410,7 @@ class ElementWrapper(collections.abc.MutableMapping):
                     keys.append("@" + localname)
 
             keys.sort()
-            for subelem in self.elem:
+            for subelem in self.elem.iterchildren(tag=lxml.etree.Element):
                 localname = lxml.etree.QName(subelem).localname
                 if localname not in keys and (
                     self.typedef.get_childdef_from_localname(localname) is not None

--- a/sarkit/xmlhelp/_transcoders.py
+++ b/sarkit/xmlhelp/_transcoders.py
@@ -204,7 +204,7 @@ class PolyNdType(Type):
             tuple(
                 int(coef.get(f"exponent{x}")) for x in range(1, self.nvar + 1)
             ): float(coef.text)
-            for coef in elem
+            for coef in elem.iterchildren(tag=lxml.etree.Element)
         }
         coefs = np.zeros(np.max(list(coef_by_exponents), axis=0) + 1, np.float64)
         for exponents, coef in coef_by_exponents.items():
@@ -564,7 +564,9 @@ class SizedType(abc.ABC, Type):
 
     def iter_parse(self, elem: lxml.etree.Element) -> Iterator:
         """Yield sub-elements encoded in ``elem`` in indexed order."""
-        for x in sorted(elem, key=lambda x: int(x.get("index"))):
+        for x in sorted(
+            elem.iterchildren(tag=lxml.etree.Element), key=lambda x: int(x.get("index"))
+        ):
             yield self.sub_type.parse_elem(x)
 
     def set_elem(self, elem: lxml.etree.Element, val: Sequence[Any]) -> None:
@@ -650,7 +652,7 @@ class MtxType(Type):
         if self.shape != shape:
             raise ValueError(f"elem {shape=} does not match expected {self.shape}")
         val = np.zeros(shape)
-        for entry in elem:
+        for entry in elem.iterchildren(tag=lxml.etree.Element):
             val[*[int(entry.get(f"index{x}")) - 1 for x in (1, 2)]] = float(entry.text)
         return val
 

--- a/tests/core/cphd/test_xml.py
+++ b/tests/core/cphd/test_xml.py
@@ -86,8 +86,13 @@ def test_transcoders():
     list((DATAPATH / "syntax_only/cphd").glob("*.xml"))
     + list(DATAPATH.glob("example-cphd*.xml")),
 )
-def test_elementwrapper_tofromdict(xmlpath):
+@pytest.mark.parametrize("add_comments", (True, False))
+def test_elementwrapper_tofromdict(xmlpath, add_comments):
     xmlroot = lxml.etree.parse(xmlpath).getroot()
+    if add_comments:
+        testing.add_xml_comments(xmlroot)
+        assert len(list(xmlroot.iter(tag=lxml.etree.Comment))) > 0
+
     root_ns = lxml.etree.QName(xmlroot).namespace
     xsdhelp = skcphd.XsdHelper(root_ns)
     wrapped_cphdroot = skcphd.ElementWrapper(xmlroot)

--- a/tests/core/crsd/test_xml.py
+++ b/tests/core/crsd/test_xml.py
@@ -36,8 +36,13 @@ def test_transcoders():
     list((DATAPATH / "syntax_only/crsd").glob("*.xml"))
     + list(DATAPATH.glob("example-crsd*.xml")),
 )
-def test_elementwrapper_tofromdict(xmlpath):
+@pytest.mark.parametrize("add_comments", (True, False))
+def test_elementwrapper_tofromdict(xmlpath, add_comments):
     xmlroot = lxml.etree.parse(xmlpath).getroot()
+    if add_comments:
+        testing.add_xml_comments(xmlroot)
+        assert len(list(xmlroot.iter(tag=lxml.etree.Comment))) > 0
+
     root_ns = lxml.etree.QName(xmlroot).namespace
     xsdhelp = skcrsd.XsdHelper(root_ns)
     wrapped_crsdroot = skcrsd.ElementWrapper(xmlroot)

--- a/tests/core/sicd/test_xml.py
+++ b/tests/core/sicd/test_xml.py
@@ -64,8 +64,13 @@ def test_transcoders():
     list((DATAPATH / "syntax_only/sicd").glob("*.xml"))
     + list(DATAPATH.glob("example-sicd*.xml")),
 )
-def test_elementwrapper_tofromdict(xmlpath):
+@pytest.mark.parametrize("add_comments", (True, False))
+def test_elementwrapper_tofromdict(xmlpath, add_comments):
     xmlroot = lxml.etree.parse(xmlpath).getroot()
+    if add_comments:
+        testing.add_xml_comments(xmlroot)
+        assert len(list(xmlroot.iter(tag=lxml.etree.Comment))) > 0
+
     root_ns = lxml.etree.QName(xmlroot).namespace
     xsdhelp = sksicd.XsdHelper(root_ns)
     wrapped_sicdroot = sksicd.ElementWrapper(xmlroot)
@@ -105,7 +110,7 @@ def test_compute_scp_coa_bistatic():
 
     # Bistatic
     etree_bistatic = copy.deepcopy(etree)
-    for elem in etree_bistatic.iter():
+    for elem in etree_bistatic.iter(tag=lxml.etree.Element):
         elem.tag = f"{{urn:SICD:1.4.0}}{lxml.etree.QName(elem).localname}"
     xmlhelp_bistatic = sksicd.XmlHelper(etree_bistatic)
     xmlhelp_bistatic.set("./{*}CollectionInfo/{*}CollectType", "BISTATIC")

--- a/tests/core/sidd/test_xml.py
+++ b/tests/core/sidd/test_xml.py
@@ -120,11 +120,16 @@ def test_transcoders():
     list((DATAPATH / "syntax_only/sidd").rglob("*.xml"))
     + list(DATAPATH.glob("example-sidd*.xml")),
 )
-def test_elementwrapper_tofromdict(xmlpath):
-    siddroot = lxml.etree.parse(xmlpath).getroot()
-    root_ns = lxml.etree.QName(siddroot).namespace
+@pytest.mark.parametrize("add_comments", (True, False))
+def test_elementwrapper_tofromdict(xmlpath, add_comments):
+    xmlroot = lxml.etree.parse(xmlpath).getroot()
+    if add_comments:
+        testing.add_xml_comments(xmlroot)
+        assert len(list(xmlroot.iter(tag=lxml.etree.Comment))) > 0
+
+    root_ns = lxml.etree.QName(xmlroot).namespace
     xsdhelp = sksidd.XsdHelper(root_ns)
-    wrapped_siddroot = sksidd.ElementWrapper(siddroot)
+    wrapped_siddroot = sksidd.ElementWrapper(xmlroot)
 
     dict1 = wrapped_siddroot.to_dict()
     wrapped_root_fromdict = sksidd.ElementWrapper(
@@ -134,4 +139,4 @@ def test_elementwrapper_tofromdict(xmlpath):
     dict2 = wrapped_root_fromdict.to_dict()
 
     npt.assert_equal(dict1, dict2)
-    assert testing.elem_cmp(siddroot, wrapped_root_fromdict.elem, xsdhelp)
+    assert testing.elem_cmp(xmlroot, wrapped_root_fromdict.elem, xsdhelp)

--- a/tests/core/testing.py
+++ b/tests/core/testing.py
@@ -1,3 +1,4 @@
+import lxml.etree
 import numpy.testing as npt
 
 
@@ -20,8 +21,8 @@ def elem_cmp(a, b, xsdhelper):
             return a_text == b_text
         return True
 
-    b_children = list(b)
-    for a_child in a:
+    b_children = list(b.iterchildren(tag=lxml.etree.Element))
+    for a_child in a.iterchildren(tag=lxml.etree.Element):
         for b_child in b_children:
             if elem_cmp(a_child, b_child, xsdhelper):
                 b_children.remove(b_child)
@@ -29,3 +30,9 @@ def elem_cmp(a, b, xsdhelper):
         else:
             return False
     return all(float(x.text) == 0 for x in b_children)
+
+
+def add_xml_comments(elem: lxml.etree.Element) -> lxml.etree.Element:
+    """Add comments before each descendant Element in an XML"""
+    for elem in elem.iterdescendants(tag=lxml.etree.Element):
+        elem.addprevious(lxml.etree.Comment("comment"))


### PR DESCRIPTION
# Description
This PR addresses a bug encountered running `cphdcheck` on a CPHD XML with comments:

```console
$ cphdcheck data/cphd_with_comments.xml  -v
check_channel_dwell_polys_1: /Dwell/CODTime/CODTimePoly and /Dwell/DwellTime/DwellTimePoly are consistent with other metadata for channel 1.
    [Error] Need: Exception Raised
        line#513: ia_vertices = skcphd.get_channel_image_area( self.cphdroot.getroottree(), channel_id )
            line#358: chan_param_ew = ew["Channel"].find("Parameters", Identifier=ch_id)
                line#256: found = self.findall(localname, **kwargs)
                    line#244: if key not in child:
                        line#434: return localname in self._keys()
                            line#414: localname = lxml.etree.QName(subelem).localname
                                line#1959:
        Invalid input tag of type <class '_cython_3_2_4.cython_function_or_method'>
```

The root cause seems to be a misunderstanding of [iteration in `lxml`](https://lxml.de/tutorial.html#tree-iteration):

> By default, iteration yields all nodes in the tree, including ProcessingInstructions, Comments and Entity instances. If you want to make sure only Element objects are returned, you can pass the Element factory as tag parameter

As a rather fundamental construct/misunderstanding, there may be other instances, but hopefully the unittests catch a meaningful number.