### PR TITLE
Fix calculation of COA times for bistatic images

### DIFF
--- a/sarkit/sicd/projection/_calc.py
+++ b/sarkit/sicd/projection/_calc.py
@@ -167,7 +167,7 @@ def compute_coa_pos_vel(
     # Compute transmit time
     assert proj_metadata.Xmt_Poly is not None
     x0 = _xyzpolyval(t_coa, proj_metadata.Xmt_Poly)
-    r_x0 = np.linalg.norm(x0 - grp_coa)
+    r_x0 = np.linalg.norm(x0 - grp_coa, axis=-1)
     tx_coa = t_coa - r_x0 / _constants.speed_of_light
 
     # Compute transmit APC position and velocity
@@ -176,7 +176,7 @@ def compute_coa_pos_vel(
 
     # Compute receive time
     r0 = _xyzpolyval(t_coa, proj_metadata.Rcv_Poly)
-    r_r0 = np.linalg.norm(r0 - grp_coa)
+    r_r0 = np.linalg.norm(r0 - grp_coa, axis=-1)
     tr_coa = t_coa + r_r0 / _constants.speed_of_light
 
     # Compute receive APC position and velocity


### PR DESCRIPTION
SARkit was returning different `scene_to_image()` results depending on the contents of the input `scene_points` array.  If it contained one point, the returned image location was correct.  If it contained a list of scene points, the returned image locations were slightly wrong.  I tracked it back to the norm calculation in `compute_coa_pos_vel()`.

With the change, this simple test now passes:
```
scene_coords = np.random.default_rng(789).uniform(low=-240.0, high=240.0, size=(7, 3)) + scp
assert(np.all(sksicd.scene_to_image(sicd_xmltree, scene_coords[0:1,:])[0][0] == sksicd.scene_to_image(sicd_xmltree, scene_coords)[0][0]))
```