### PR TITLE
Fix calculation of COA times for bistatic images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `dtype_to_pvp_element`/`dtype_to_ppp_element`failures due to dtype endianness in `sarkit.cphd` and `sarkit.crsd`
 - Erroneous transpose in sensitivity matrix outputs of `sarkit.sicd.projection.compute_gp_xy_parameters`
 - Ignore non-elements in XmlHelper, ElementWrapper, and transcoders
+- Calculation of COA times for bistatic images in `sarkit.sicd.projection.compute_coa_pos_vel`
 
 
 ## [1.10.1] - 2026-07-31

--- a/sarkit/sicd/projection/_calc.py
+++ b/sarkit/sicd/projection/_calc.py
@@ -167,7 +167,7 @@ def compute_coa_pos_vel(
     # Compute transmit time
     assert proj_metadata.Xmt_Poly is not None
     x0 = _xyzpolyval(t_coa, proj_metadata.Xmt_Poly)
-    r_x0 = np.linalg.norm(x0 - grp_coa)
+    r_x0 = np.linalg.norm(x0 - grp_coa, axis=-1)
     tx_coa = t_coa - r_x0 / _constants.speed_of_light
 
     # Compute transmit APC position and velocity
@@ -176,7 +176,7 @@ def compute_coa_pos_vel(
 
     # Compute receive time
     r0 = _xyzpolyval(t_coa, proj_metadata.Rcv_Poly)
-    r_r0 = np.linalg.norm(r0 - grp_coa)
+    r_r0 = np.linalg.norm(r0 - grp_coa, axis=-1)
     tr_coa = t_coa + r_r0 / _constants.speed_of_light
 
     # Compute receive APC position and velocity

--- a/tests/core/sicd/test_projection.py
+++ b/tests/core/sicd/test_projection.py
@@ -160,6 +160,22 @@ def test_compute_coa_pos_vel_bi(example_proj_metadata_bi):
     )
 
 
+@pytest.mark.parametrize(
+    "mdata_name", ("example_proj_metadata", "example_proj_metadata_bi")
+)
+def test_compute_coa_pos_vel(mdata_name, request):
+    proj_metadata = request.getfixturevalue(mdata_name)
+    rng = np.random.default_rng(123456)
+    times = proj_metadata.t_SCP_COA + 0.02 * (rng.random((3, 4)) - 0.5)
+    pv_all = sicdproj.compute_coa_pos_vel(proj_metadata, times)
+    for index, t in np.ndenumerate(times):
+        pv_single = sicdproj.compute_coa_pos_vel(proj_metadata, t)
+        for f_all, f_single in zip(
+            dataclasses.astuple(pv_all), dataclasses.astuple(pv_single)
+        ):
+            assert np.array_equal(f_all[index], f_single)
+
+
 def test_scp_projection_set_mono(example_proj_metadata):
     assert example_proj_metadata.is_monostatic()
     r_scp_coa, rdot_scp_coa = sicdproj.compute_scp_coa_r_rdot(example_proj_metadata)

--- a/tests/core/sicd/test_sicd_projections.py
+++ b/tests/core/sicd/test_sicd_projections.py
@@ -299,3 +299,21 @@ def test_proj_with_apos_bi(projfunc):
     biapos["TxPlatform"]["APCPosSCPCOA"] = [1, 0, 0]
     pts_nonzero_apo = projfunc(sicdxml)
     assert bool(np.all(np.any(pts_no_apo != pts_nonzero_apo, axis=-1)))
+
+
+@pytest.mark.parametrize(
+    "xmlpath", [DATAPATH / "example-sicd-1.3.0.xml", DATAPATH / "example-sicd-1.5.xml"]
+)
+def test_scene_to_image(xmlpath):
+    sicdxml = lxml.etree.parse(xmlpath)
+    ew = sksicd.ElementWrapper(lxml.etree.parse(xmlpath).getroot())
+    scene_coords = (
+        np.random.default_rng(789).uniform(low=-240.0, high=240.0, size=(7, 3))
+        + ew["GeoData"]["SCP"]["ECF"]
+    )
+    il_all, _, success = sksicd.scene_to_image(sicdxml, scene_coords)
+    assert success
+    for sc, il in zip(scene_coords, il_all):
+        il_single, _, success = sksicd.scene_to_image(sicdxml, sc)
+        assert success
+        assert np.array_equal(il_single, il)


### PR DESCRIPTION
# Description
This PR adds a CHANGELOG entry and unittests for the bug fixed by @klamptoo in https://github.com/ValkyrieSystems/sarkit/pull/165

The simple test suggested by @klamptoo using `scene_to_image` and an additional test that checks `compute_coa_pos_vel` directly are proposed and both fail without the fix:

<details>
<summary>results of new tests in main</summary>

```console
$ pdm run pytest tests/core/sicd/test_sicd_projections.py::test_scene_to_image
============================================================================ test session starts =============================================================================
platform linux -- Python 3.13.13, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarkit
configfile: pyproject.toml
collected 2 items                                                                                                                                                            

tests/core/sicd/test_sicd_projections.py .F                                                                                                                            [100%]

================================================================================== FAILURES ==================================================================================
_______________________________________________________________________ test_scene_to_image[xmlpath1] ________________________________________________________________________

xmlpath = PosixPath('/home/vscuser/git/glweb/software/third-party/sarkit/data/example-sicd-1.5.xml')

    @pytest.mark.parametrize("xmlpath", [DATAPATH / "example-sicd-1.3.0.xml", DATAPATH / "example-sicd-1.5.xml"])
    def test_scene_to_image(xmlpath):
        sicdxml = lxml.etree.parse(xmlpath)
        ew = sksicd.ElementWrapper(lxml.etree.parse(xmlpath).getroot())
        scene_coords = np.random.default_rng(789).uniform(low=-240.0, high=240.0, size=(7, 3)) + ew["GeoData"]["SCP"]["ECF"]
        il_all, _, success = sksicd.scene_to_image(sicdxml, scene_coords)
        assert success
        for sc, il in zip(scene_coords, il_all):
            il_single, _, success = sksicd.scene_to_image(sicdxml, sc)
            assert success
>           assert np.array_equal(il_single, il)
E           assert False
E            +  where False = <function array_equal at 0x7fe685262c70>(array([206.17618449, 119.35188951]), array([206.17668617, 119.35087817]))
E            +    where <function array_equal at 0x7fe685262c70> = np.array_equal

tests/core/sicd/test_sicd_projections.py:314: AssertionError
========================================================================== short test summary info ===========================================================================
FAILED tests/core/sicd/test_sicd_projections.py::test_scene_to_image[xmlpath1] - assert False
======================================================================== 1 failed, 1 passed in 0.22s =========================================================================
                                                                                                                                                                              




$ pdm run pytest tests/core/sicd/test_projection.py::test_compute_coa_pos_vel
============================================================================ test session starts =============================================================================
platform linux -- Python 3.13.13, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarkit
configfile: pyproject.toml
collected 2 items                                                                                                                                                            

tests/core/sicd/test_projection.py .F                                                                                                                                  [100%]

================================================================================== FAILURES ==================================================================================
_____________________________________________________________ test_compute_coa_pos_vel[example_proj_metadata_bi] _____________________________________________________________

mdata_name = 'example_proj_metadata_bi', request = <FixtureRequest for <Function test_compute_coa_pos_vel[example_proj_metadata_bi]>>

    @pytest.mark.parametrize(
        "mdata_name", ("example_proj_metadata", "example_proj_metadata_bi")
    )
    def test_compute_coa_pos_vel(mdata_name, request):
        proj_metadata = request.getfixturevalue(mdata_name)
        rng = np.random.default_rng(123456)
        times = proj_metadata.t_SCP_COA + 0.02 * (rng.random((3, 4)) - 0.5)
        pv_all = sicdproj.compute_coa_pos_vel(proj_metadata, times)
        for index, t in np.ndenumerate(times):
            pv_single = sicdproj.compute_coa_pos_vel(proj_metadata, t)
            for f_all, f_single in zip(dataclasses.astuple(pv_all), dataclasses.astuple(pv_single)):
>               assert np.array_equal(f_all[index], f_single)
E               assert False
E                +  where False = <function array_equal at 0x7efc84f671b0>(np.float64(1.2036891833608192), array(1.21767646))
E                +    where <function array_equal at 0x7efc84f671b0> = np.array_equal

tests/core/sicd/test_projection.py:174: AssertionError
========================================================================== short test summary info ===========================================================================
FAILED tests/core/sicd/test_projection.py::test_compute_coa_pos_vel[example_proj_metadata_bi] - assert False
======================================================================== 1 failed, 1 passed in 0.13s =========================================================================
                                                                                                                                                                              

```


</details>