### PR TITLE
cphdcheck: add XML-only SignalNormal check to check_channel_signalnormal 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `compute_dwelltimes_using_poly` to `sarkit.cphd`
 - `get_channel_image_area`, `get_extended_image_area`, and `get_scene_image_area` to `sarkit.cphd` and `sarkit.crsd`
+- XML-only SignalNormal check to `sarkit.verification.CphdConsistency.check_channel_signalnormal`
 
 ### Removed
 - Unused `_processing` module

--- a/sarkit/verification/_cphd_consistency.py
+++ b/sarkit/verification/_cphd_consistency.py
@@ -1133,15 +1133,19 @@ class CphdConsistency(con.ConsistencyChecker):
     @per_channel
     def check_channel_signalnormal(self, channel_id, channel_node):
         """PVP agrees with SignalNormal."""
+        has_signal_pvp = self.cphdroot.find("{*}PVP/{*}SIGNAL") is not None
+        has_channel_signalnormal = channel_node.find("{*}SignalNormal") is not None
+        with self.need(
+            f"Channel/Parameters[Identifier='{channel_id}']/SignalNormal included if and only if SIGNAL PVP is present"
+        ):
+            assert has_signal_pvp == has_channel_signalnormal
         with self.precondition():
+            assert has_signal_pvp
             pvp = self._get_channel_pvps(channel_id)
-            assert channel_node.find("./{*}SignalNormal") is not None
-            with self.need("SIGNAL PVP present"):
-                assert "SIGNAL" in pvp.dtype.names
-                with self.need("SignalNormal matches SIGNAL PVPs"):
-                    assert np.all(pvp["SIGNAL"] == 1) == self.xmlhelp.load_elem(
-                        channel_node.find("./{*}SignalNormal")
-                    )
+            with self.need("SignalNormal matches SIGNAL PVPs"):
+                assert np.all(pvp["SIGNAL"] == 1) == self.xmlhelp.load_elem(
+                    channel_node.find("./{*}SignalNormal")
+                )
 
     @per_channel
     def check_channel_fx2_gt_fx1(self, channel_id, channel_node):

--- a/tests/verification/test_cphd_consistency.py
+++ b/tests/verification/test_cphd_consistency.py
@@ -1,4 +1,5 @@
 import copy
+import itertools
 import pathlib
 import unittest.mock
 
@@ -1331,6 +1332,28 @@ def test_channel_signalnormal(cphd_con_from_file, em):
 
     new_con.check("check_channel_signalnormal", allow_prefix=True)
     assert new_con.failures()
+
+
+@pytest.mark.parametrize(
+    "remove_signalnormal,remove_signal_pvp",
+    list(itertools.product((True, False), repeat=2)),
+)
+def test_channel_signalnormal_xmlonly(
+    good_xml_root, remove_signalnormal, remove_signal_pvp
+):
+    if remove_signalnormal:
+        remove_nodes(good_xml_root.find("{*}Channel/{*}Parameters/{*}SignalNormal"))
+    if remove_signal_pvp:
+        remove_nodes(good_xml_root.find("{*}PVP/{*}SIGNAL"))
+
+    con = CphdConsistency.from_parts(good_xml_root)
+    con.check("check_channel_signalnormal", allow_prefix=True)
+    if remove_signalnormal != remove_signal_pvp:
+        testing.assert_failures(
+            con, "SignalNormal included if and only if SIGNAL PVP is present"
+        )
+    else:
+        assert con.passes()
 
 
 def test_bad_fxc(cphd_con_from_file):


### PR DESCRIPTION
# Description
This PR extends cphdcheck's `check_channel_signalnormal` (which currently only runs when PVPs with SIGNAL are present) to also check the "if and only if" relationship between `Channel/Parameters/SignalNormal` and `PVP/SIGNAL` stated in Table 11-5 of CPHD 1.0.1 and 1.1.0:

<img width="732" height="47" alt="image" src="https://github.com/user-attachments/assets/56756908-eb39-45ca-8de7-d6a21c87139f" />
