### PR TITLE
Fix/add GeoInfo/Polygon winding checks to CRSD/CPHD/SICD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `compute_dwelltimes_using_poly` to `sarkit.cphd`
 - `get_channel_image_area`, `get_extended_image_area`, and `get_scene_image_area` to `sarkit.cphd` and `sarkit.crsd`
+- GeoInfo/Polygon winding check for SICD
 
 ### Removed
 - Unused `_processing` module
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `dtype_to_pvp_element`/`dtype_to_ppp_element`failures due to dtype endianness in `sarkit.cphd` and `sarkit.crsd`
 - Erroneous transpose in sensitivity matrix outputs of `sarkit.sicd.projection.compute_gp_xy_parameters`
 - Ignore non-elements in XmlHelper, ElementWrapper, and transcoders
+- GeoInfo/Polygon winding checks for CRSD and CPHD
 
 
 ## [1.10.1] - 2026-07-31

--- a/sarkit/verification/_consistency.py
+++ b/sarkit/verification/_consistency.py
@@ -16,6 +16,9 @@ from collections.abc import Iterable
 from typing import Optional
 
 import numpy as np
+import shapely
+
+import sarkit.wgs84
 
 
 def skipif(condition_func, details=None):
@@ -695,3 +698,38 @@ def modify_conchecker_docs(obj):
 
     """
     obj.__doc__ += textwrap.dedent(con_doc_footer)
+
+
+def is_geo_polygon_cw(geo_vertices: np.ndarray) -> bool:
+    """Determine if a polygon with WGS 84 geodetic vertices is wound clockwise.
+
+    Assumes the polygon doesn't encompass a hemisphere or more.
+
+    Parameters
+    ----------
+    geo_vertices : ndarray
+        2D array of vertices with lat, lon and (optionally) hae in last dimension.
+        HAE is assumed 0 when omitted.
+
+    Returns
+    -------
+    bool
+        Is polygon clockwise?
+    """
+    if geo_vertices.shape[1] == 2:
+        geo_vertices = np.concatenate(
+            [geo_vertices, np.zeros_like(geo_vertices[:, :1])], axis=1
+        )
+    ecef_vertices = sarkit.wgs84.geodetic_to_cartesian(geo_vertices)
+
+    origin = np.mean(ecef_vertices, axis=0)
+    ux = sarkit.wgs84.east(sarkit.wgs84.cartesian_to_geodetic(origin))
+    uy = sarkit.wgs84.north(sarkit.wgs84.cartesian_to_geodetic(origin))
+
+    plane_vertices = np.vecdot(
+        ecef_vertices[:, np.newaxis, :] - origin, np.stack([ux, uy], axis=0)
+    )
+    plane_polygon = shapely.Polygon(plane_vertices)
+    if not plane_polygon.exterior.is_valid:
+        raise ValueError("Vertices in plane do not form a valid polygon")
+    return not plane_polygon.exterior.is_ccw

--- a/sarkit/verification/_cphd_consistency.py
+++ b/sarkit/verification/_cphd_consistency.py
@@ -1495,7 +1495,12 @@ class CphdConsistency(con.ConsistencyChecker):
         with self.precondition():
             assert geo_polygons
             for geo_polygon in geo_polygons:
-                self.get_polygon(geo_polygon, check=True)
+                vertices = self.xmlhelp.load_elem(geo_polygon)
+                shg_polygon = shapely.Polygon(vertices)
+                with self.need("GeoInfo polygon is simple"):
+                    assert shg_polygon.is_simple
+                with self.need("GeoInfo polygon is clockwise"):
+                    assert con.is_geo_polygon_cw(vertices)
 
     def check_segment_polygons(self):
         """SegmentPolygons are simple, valid and clockwise."""
@@ -1512,7 +1517,7 @@ class CphdConsistency(con.ConsistencyChecker):
         iacp_node = self.cphdroot.find("./{*}SceneCoordinates/{*}ImageAreaCornerPoints")
         vertex_nodes = sorted(list(iacp_node), key=lambda x: int(x.attrib["index"]))
         polygon = np.asarray(
-            [self.xmlhelp.load_elem(vertex)[::-1] for vertex in vertex_nodes]
+            [self.xmlhelp.load_elem(vertex) for vertex in vertex_nodes]
         )
         with self.need("4 corner points"):
             assert len(polygon) == 4
@@ -1524,7 +1529,7 @@ class CphdConsistency(con.ConsistencyChecker):
             with self.need("Polygon is simple"):
                 assert shg_polygon.is_simple
             with self.need("Polygon is clockwise"):
-                assert not shg_polygon.exterior.is_ccw
+                assert con.is_geo_polygon_cw(polygon)
 
     def check_extended_imagearea_polygon(self):
         """Scene extended area polygon is simple and consistent with X1Y1 and X2Y2."""

--- a/sarkit/verification/_crsd_consistency.py
+++ b/sarkit/verification/_crsd_consistency.py
@@ -1433,7 +1433,7 @@ class CrsdConsistency(con.ConsistencyChecker):
                 with self.need("GeoInfo polygon is simple"):
                     assert shg_polygon.is_simple
                 with self.need("GeoInfo polygon is clockwise"):
-                    assert not shg_polygon.exterior.is_ccw
+                    assert con.is_geo_polygon_cw(vertices)
 
     def check_scene_iarp(self):
         """IARP is consistent and near Earth's surface"""

--- a/sarkit/verification/_sicd_consistency.py
+++ b/sarkit/verification/_sicd_consistency.py
@@ -983,6 +983,10 @@ class SicdConsistency(con.ConsistencyChecker):
                 with self.need("Number of vertices >= 3"):
                     assert num_vertices >= 3
 
+                vertices = self.xmlhelp.load_elem(elem)
+                with self.need("GeoInfo polygon is clockwise"):
+                    assert con.is_geo_polygon_cw(vertices)
+
     def check_validdata_presence(self) -> None:
         """ValidData should be in both GeoData and ImageData or neither."""
         in_geodata = self.sicdroot.find("./{*}GeoData/{*}ValidData") is not None

--- a/tests/verification/test_cphd_consistency.py
+++ b/tests/verification/test_cphd_consistency.py
@@ -1867,3 +1867,15 @@ def test_check_channel_txrcvpolref(cphd_con_from_file, txrcv):
     assert cphd_con.passes() and not cphd_con.skips()
     testing.assert_failures(cphd_con, f"{txrcv} AmpH/AmpV")
     testing.assert_failures(cphd_con, f"{txrcv} PhaseV")
+
+
+def test_geoinfo_polygon_clockwise(cphd_con):
+    ew = skcphd.ElementWrapper(cphd_con.cphdroot)
+    vertices = [[1.0, 180.0], [-1.0, -179.0], [-1.0, 179.0]]
+    geo = ew.add("GeoInfo", {"@name": "unittest"})
+    geo.add("Polygon", vertices)
+    cphd_con.check("check_geoinfo_polygons")
+    assert cphd_con.passes()
+    geo.add("Polygon", vertices[::-1])
+    cphd_con.check("check_geoinfo_polygons")
+    testing.assert_failures(cphd_con, "GeoInfo polygon is clockwise")

--- a/tests/verification/test_crsd_consistency.py
+++ b/tests/verification/test_crsd_consistency.py
@@ -194,9 +194,9 @@ def crsd_con_with_geoinfo(crsd_con):
     ew.add("GeoInfo").add(
         "Polygon",
         [
-            [-0.0026191804573599776, 0.001821692610367564],
-            [0.0018339698998625154, 0.0026016466694818927],
             [0.0026191804573599776, -0.001821692610367564],
+            [0.0018339698998625154, 0.0026016466694818927],
+            [-0.0026191804573599776, 0.001821692610367564],
             [-0.0018339698998625154, -0.0026016466694818927],
         ],
     )
@@ -1341,7 +1341,7 @@ def test_geoinfo_polygon_clockwise(crsd_con_with_geoinfo):
     crsd_con_with_geoinfo.xmlhelp.set(
         "./{*}GeoInfo/{*}Polygon", geoinfo_polygon[[2, 1, 0, 3]]
     )
-    crsd_con_with_geoinfo.check("check_geoinfo_polygons", allow_prefix=True)
+    crsd_con_with_geoinfo.check("check_geoinfo_polygons")
     assert_failures(crsd_con_with_geoinfo, "GeoInfo polygon is clockwise")
 
 

--- a/tests/verification/test_sicd_consistency.py
+++ b/tests/verification/test_sicd_consistency.py
@@ -2098,3 +2098,16 @@ def test_check_errorstatistics_conditionals_mono():
 
     sicd_con.check("check_errorstatistics_conditionals")
     testing.assert_failures(sicd_con, "BistaticCompositeSCP not allowed")
+
+
+def test_geoinfo_polygon_clockwise(sicd_con):
+    ew = sksicd.ElementWrapper(sicd_con.sicdroot)
+    vertices = [[1.0, 180.0], [-1.0, -179.0], [-1.0, 179.0]]
+    geo = ew["GeoData"].add("GeoInfo", {"@name": "goodpoly"})
+    geo.add("Polygon", vertices)
+    sicd_con.check("check_geoinfo_polygon")
+    assert sicd_con.passes()
+    geo = ew["GeoData"].add("GeoInfo", {"@name": "badpoly"})
+    geo.add("Polygon", vertices[::-1])
+    sicd_con.check("check_geoinfo_polygon")
+    testing.assert_failures(sicd_con, "GeoInfo polygon is clockwise")


### PR DESCRIPTION
# Description
This PR addresses incorrect/missing winding checks for geodetic polygons in CRSD, CPHD, and SICD. Here is a survey of the polygons:

```
# CRSD
# GeoInfo/Polygon                                                                                     *

# CPHD
# SceneCoordinates/ImageAreaCornerPoints                                                              *
# GeoInfo/Polygon                                                                                     *

# SICD
# GeoData/ImageCorners        check projections
# GeoData/ValidData           check same order as ImageData/ValidData
# GeoData/GeoInfo/Polygon                                                                             *
# RadarCollection/Area/Corner/ACP                                                                     *

# SIDD
# Geodata/ImageCorners        check projections
# GeoData/ValidData           check same order as Measurement/ValidData
# GeoData/GeoInfo/Polygon     only in v2.0, v3.0; neither seem to require CW
```

The proposed method is essentially the same [`sarkit.verification.SicdConsistency.check_area_corners`](https://github.com/ValkyrieSystems/sarkit/blob/f67935a2a64f4c14875eabb696cb3bae18718160/sarkit/verification/_sicd_consistency.py#L1330)

The new tests fail in `main`:

```
============================================================================================================================================================================= short test summary info ==============================================================================================================================================================================
FAILED tests/verification/test_cphd_consistency.py::test_geoinfo_polygon_clockwise - AssertionError
FAILED tests/verification/test_crsd_consistency.py::test_geoinfo_polygon_clockwise[sar] - AssertionError
FAILED tests/verification/test_crsd_consistency.py::test_geoinfo_polygon_clockwise[tx] - AssertionError
FAILED tests/verification/test_crsd_consistency.py::test_geoinfo_polygon_clockwise[rcv] - AssertionError
FAILED tests/verification/test_sicd_consistency.py::test_geoinfo_polygon_clockwise - AssertionError
============================================================================================================================================================== 5 failed, 896 passed, 111 skipped, 1 warning in 32.86s ==============================================================================================================================================================
```