### PR TITLE
Address TypeAlias TODOs

### DIFF
--- a/sarkit/sicd/projection/_params.py
+++ b/sarkit/sicd/projection/_params.py
@@ -2,7 +2,7 @@
 
 import dataclasses
 import functools
-from typing import Optional, Self, TypeAlias
+from typing import Optional, Self
 
 import lxml.etree
 import numpy as np
@@ -10,9 +10,8 @@ import numpy.polynomial.polynomial as npp
 
 import sarkit.sicd._xml as ss_xml
 
-# TODO: encouraged to migrate to type statements instead of TypeAlias in python 3.12
-CoaPosVelsLike: TypeAlias = "CoaPosVelsMono | CoaPosVelsBi"
-ProjectionSetsLike: TypeAlias = "ProjectionSetsMono | ProjectionSetsBi"
+type CoaPosVelsLike = CoaPosVelsMono | CoaPosVelsBi
+type ProjectionSetsLike = ProjectionSetsMono | ProjectionSetsBi
 
 
 def _get_rcv_poly(xmlhelp):

--- a/sarkit/sicd/projection/_sensitivity.py
+++ b/sarkit/sicd/projection/_sensitivity.py
@@ -1,5 +1,4 @@
 import dataclasses
-from typing import TypeAlias
 
 import numpy as np
 import numpy.polynomial.polynomial as npp
@@ -12,8 +11,7 @@ from sarkit.sicd.projection import _params as params
 
 C = sarkit._constants.c
 
-# TODO: encouraged to migrate to type statements instead of TypeAlias in python 3.12
-SensitivityMatricesLike: TypeAlias = "SensitivityMatricesMono | SensitivityMatricesBi"
+type SensitivityMatricesLike = SensitivityMatricesMono | SensitivityMatricesBi
 
 
 @dataclasses.dataclass(kw_only=True)


### PR DESCRIPTION
# Description
With Python=3.12 as the minimum version, we can address a few TODOs by replacing `typing.TypeAlias` with the `type` statement