### PR TITLE
Add SICD v1.2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Support for SICD v1.0 (XML namespace: `urn:SICD:1.0.1`)
+- Support for SICD v1.0 (XML namespace: `urn:SICD:1.0.1`) and SICD v1.2
 
 
 ## [1.11.0] - 2026-09-01

--- a/data/example-sicd-1.2.xml
+++ b/data/example-sicd-1.2.xml
@@ -1,0 +1,224 @@
+<SICD xmlns="urn:SICD:1.2.0">
+    <CollectionInfo>
+        <CollectorName>Synthetic</CollectorName>
+        <CoreName>SyntheticCore</CoreName>
+        <CollectType>MONOSTATIC</CollectType>
+        <RadarMode>
+            <ModeType>SPOTLIGHT</ModeType>
+        </RadarMode>
+        <Classification>UNCLASSIFIED</Classification>
+    </CollectionInfo>
+    <ImageData>
+        <PixelType>RE32F_IM32F</PixelType>
+        <NumRows>1494</NumRows>
+        <NumCols>1723</NumCols>
+        <FirstRow>0</FirstRow>
+        <FirstCol>0</FirstCol>
+        <FullImage>
+            <NumRows>1494</NumRows>
+            <NumCols>1723</NumCols>
+        </FullImage>
+        <SCPPixel>
+            <Row>747</Row>
+            <Col>861</Col>
+        </SCPPixel>
+    </ImageData>
+    <GeoData>
+        <EarthModel>WGS_84</EarthModel>
+        <SCP>
+            <ECF>
+                <X>6378137</X>
+                <Y>0</Y>
+                <Z>0</Z>
+            </ECF>
+            <LLH>
+                <Lat>0</Lat>
+                <Lon>0</Lon>
+                <HAE>0</HAE>
+            </LLH>
+        </SCP>
+        <ImageCorners>
+            <ICP index="1:FRFC">
+                <Lat>0.0080807974971151136</Lat>
+                <Lon>-0.0061258326901634519</Lon>
+            </ICP>
+            <ICP index="2:FRLC">
+                <Lat>0.0056733384282420182</Lat>
+                <Lon>0.0074368679872295704</Lon>
+            </ICP>
+            <ICP index="3:LRLC">
+                <Lat>-0.008071597406306948</Lat>
+                <Lon>0.0061267096368526897</Lon>
+            </ICP>
+            <ICP index="4:LRFC">
+                <Lat>-0.0056641383373949505</Lat>
+                <Lon>-0.0074359910405444127</Lon>
+            </ICP>
+        </ImageCorners>
+    </GeoData>
+    <Grid>
+        <ImagePlane>SLANT</ImagePlane>
+        <Type>RGAZIM</Type>
+        <TimeCOAPoly order1="0" order2="0">
+            <Coef exponent1="0" exponent2="0">1.6800674762530383</Coef>
+        </TimeCOAPoly>
+        <Row>
+            <UVectECF>
+                <X>-0.50000122375786304</X>
+                <Y>-0.15037583977714006</Y>
+                <Z>-0.8528692064148875</Z>
+            </UVectECF>
+            <SS>0.88229809656554448</SS>
+            <ImpRespWid>0.99747529707162585</ImpRespWid>
+            <Sgn>-1</Sgn>
+            <ImpRespBW>0.88798408351600244</ImpRespBW>
+            <KCtr>66.712157247222834</KCtr>
+            <DeltaK1>-0.44399204175799412</DeltaK1>
+            <DeltaK2>0.44399204175800833</DeltaK2>
+        </Row>
+        <Col>
+            <UVectECF>
+                <X>-0.13518643844872713</X>
+                <Y>0.98628938466763816</Y>
+                <Z>-0.094646059985916131</Z>
+            </UVectECF>
+            <SS>0.8788669876603048</SS>
+            <ImpRespWid>0.99666461341322399</ImpRespWid>
+            <Sgn>-1</Sgn>
+            <ImpRespBW>0.88870636679539183</ImpRespBW>
+            <KCtr>1.3449549529642717e-08</KCtr>
+            <DeltaK1>-0.44435318339769592</DeltaK1>
+            <DeltaK2>0.44435318339769592</DeltaK2>
+        </Col>
+    </Grid>
+    <Timeline>
+        <CollectStart>2022-12-05T18:41:24.051402Z</CollectStart>
+        <CollectDuration>3.4668291025146964</CollectDuration>
+    </Timeline>
+    <Position>
+        <ARPPoly>
+            <X order1="5">
+                <Coef exponent1="0">7228127.9124448663</Coef>
+                <Coef exponent1="1">352.53242998756502</Coef>
+                <Coef exponent1="2">-3.5891719134975157</Coef>
+                <Coef exponent1="3">-5.7694198643316104e-05</Coef>
+                <Coef exponent1="4">2.7699968593303768e-07</Coef>
+                <Coef exponent1="5">2.1592636134572539e-09</Coef>
+            </X>
+            <Y order1="5">
+                <Coef exponent1="0">268129.91744542622</Coef>
+                <Coef exponent1="1">-7332.3823879634392</Coef>
+                <Coef exponent1="2">-0.13313219332893028</Coef>
+                <Coef exponent1="3">0.0012135963117010783</Coef>
+                <Coef exponent1="4">1.0196690368353028e-08</Coef>
+                <Coef exponent1="5">1.3607911396273635e-11</Coef>
+            </Y>
+            <Z order1="5">
+                <Coef exponent1="0">1451527.4824241539</Coef>
+                <Coef exponent1="1">-401.08990372640221</Coef>
+                <Coef exponent1="2">-0.72076439428225647</Coef>
+                <Coef exponent1="3">6.6511087447480695e-05</Coef>
+                <Coef exponent1="4">5.6690990559856781e-08</Coef>
+                <Coef exponent1="5">3.2123861103114586e-10</Coef>
+            </Z>
+        </ARPPoly>
+    </Position>
+    <RadarCollection>
+        <TxFrequency>
+            <Min>9933296178.0950012</Min>
+            <Max>10066703821.904999</Max>
+        </TxFrequency>
+        <TxPolarization>V</TxPolarization>
+        <RcvChannels size="1">
+            <ChanParameters index="1">
+                <TxRcvPolarization>V:V</TxRcvPolarization>
+            </ChanParameters>
+        </RcvChannels>
+    </RadarCollection>
+    <ImageFormation>
+        <RcvChanProc>
+            <NumChanProc>1</NumChanProc>
+            <ChanIndex>1</ChanIndex>
+        </RcvChanProc>
+        <TxRcvPolarizationProc>V:V</TxRcvPolarizationProc>
+        <TStartProc>0.0056816659534327432</TStartProc>
+        <TEndProc>3.4611621345438324</TEndProc>
+        <TxFrequencyProc>
+            <MinProc>9933296178.0950298</MinProc>
+            <MaxProc>10066703821.905016</MaxProc>
+        </TxFrequencyProc>
+        <ImageFormAlgo>PFA</ImageFormAlgo>
+        <STBeamComp>NO</STBeamComp>
+        <ImageBeamComp>NO</ImageBeamComp>
+        <AzAutofocus>NO</AzAutofocus>
+        <RgAutofocus>NO</RgAutofocus>
+    </ImageFormation>
+    <SCPCOA>
+        <SCPTime>1.6800674762530383</SCPTime>
+        <ARPPos>
+            <X>7228710.0595508879</X>
+            <Y>255810.65024467336</Y>
+            <Z>1450851.5901888732</Z>
+        </ARPPos>
+        <ARPVel>
+            <X>340.47184478328006</X>
+            <Y>-7332.8194533174392</Y>
+            <Z>-403.5112050640754</Z>
+        </ARPVel>
+        <ARPAcc>
+            <X>-7.1789158206813477</X>
+            <Y>-0.25403049783428427</Y>
+            <Z>-1.4408563791978921</Z>
+        </ARPAcc>
+        <SideOfTrack>L</SideOfTrack>
+        <SlantRange>1701141.9562064605</SlantRange>
+        <GroundRange>1282320.3392587577</GroundRange>
+        <DopplerConeAng>80.000333057346595</DopplerConeAng>
+        <GrazeAng>30.000080950049</GrazeAng>
+        <IncidenceAng>59.999919049951004</IncidenceAng>
+        <TwistAng>8.9805970546123763</TwistAng>
+        <SlopeAng>31.195125856239255</SlopeAng>
+        <AzimAng>9.9994779614198173</AzimAng>
+        <LayoverAng>352.45909403041333</LayoverAng>
+    </SCPCOA>
+    <PFA>
+        <FPN>
+            <X>1</X>
+            <Y>0</Y>
+            <Z>0</Z>
+        </FPN>
+        <IPN>
+            <X>0.85540832579135895</X>
+            <Y>0.067973204303252321</Y>
+            <Z>-0.51347467325894713</Z>
+        </IPN>
+        <PolarAngRefTime>1.6800674762530463</PolarAngRefTime>
+        <PolarAngPoly order1="9">
+            <Coef exponent1="0">-0.0071413060968959627</Coef>
+            <Coef exponent1="1">0.004245118151048095</Coef>
+            <Coef exponent1="2">3.303261280436797e-06</Coef>
+            <Coef exponent1="3">-2.152475729568344e-08</Coef>
+            <Coef exponent1="4">-5.5340201006749593e-11</Coef>
+            <Coef exponent1="5">1.6174039129702326e-13</Coef>
+            <Coef exponent1="6">1.2038148814517427e-15</Coef>
+            <Coef exponent1="7">-1.0008410326624715e-16</Coef>
+            <Coef exponent1="8">1.6819824323114349e-17</Coef>
+            <Coef exponent1="9">-1.1931290667377136e-18</Coef>
+        </PolarAngPoly>
+        <SpatialFreqSFPoly order1="8">
+            <Coef exponent1="0">0.99999143699142279</Coef>
+            <Coef exponent1="1">2.1389170906735031e-05</Coef>
+            <Coef exponent1="2">0.051388964320644458</Coef>
+            <Coef exponent1="3">0.0048322065140747042</Coef>
+            <Coef exponent1="4">-0.020014437732713723</Coef>
+            <Coef exponent1="5">0.0023716850734943114</Coef>
+            <Coef exponent1="6">0.14153200650672734</Coef>
+            <Coef exponent1="7">4.5834686287659396</Coef>
+            <Coef exponent1="8">-1395.0901983623608</Coef>
+        </SpatialFreqSFPoly>
+        <Krg1>66.268165205464854</Krg1>
+        <Krg2>67.156149288980856</Krg2>
+        <Kaz1>-0.44524655663963569</Kaz1>
+        <Kaz2>0.44524655663963569</Kaz2>
+    </PFA>
+</SICD>

--- a/data/syntax_only/sicd/0001-syntax-only-sicd-1.2.xml
+++ b/data/syntax_only/sicd/0001-syntax-only-sicd-1.2.xml
@@ -1,4 +1,4 @@
-<ns1:SICD xmlns:ns1="urn:SICD:1.2.1">
+<ns1:SICD xmlns:ns1="urn:SICD:1.2.0">
     <ns1:CollectionInfo>
         <ns1:CollectorName>Synthetic</ns1:CollectorName>
         <ns1:IlluminatorName>Synthetic</ns1:IlluminatorName>
@@ -355,7 +355,7 @@
         </ns1:TxSequence>
         <ns1:RcvChannels size="1">
             <ns1:ChanParameters index="1">
-                <ns1:TxRcvPolarization>V:RHC</ns1:TxRcvPolarization>
+                <ns1:TxRcvPolarization>V:V</ns1:TxRcvPolarization>
                 <ns1:RcvAPCIndex>1</ns1:RcvAPCIndex>
             </ns1:ChanParameters>
         </ns1:RcvChannels>
@@ -440,7 +440,7 @@
             <ns1:PRFScaleFactor>1.23456</ns1:PRFScaleFactor>
             <ns1:ChanIndex>1</ns1:ChanIndex>
         </ns1:RcvChanProc>
-        <ns1:TxRcvPolarizationProc>LHC:H</ns1:TxRcvPolarizationProc>
+        <ns1:TxRcvPolarizationProc>V:V</ns1:TxRcvPolarizationProc>
         <ns1:TStartProc>0.0056816659534327432</ns1:TStartProc>
         <ns1:TEndProc>3.4611621345438324</ns1:TEndProc>
         <ns1:TxFrequencyProc>

--- a/data/syntax_only/sicd/make_syntax_only_sicd_xmls.py
+++ b/data/syntax_only/sicd/make_syntax_only_sicd_xmls.py
@@ -15,6 +15,11 @@ import sarkit.sicd as sksicd
 STUB_DIR = pathlib.Path(__file__).parent / "stubs"
 
 
+def update_1_1_0_to_1_2(etree):
+    for elem in etree.iter():
+        elem.tag = f"{{urn:SICD:1.2.0}}{lxml.etree.QName(elem).localname}"
+
+
 def update_1_1_0_to_1_2_1(etree):
     new_enums = ("V:RHC", "V:LHC", "H:RHC", "H:LHC", "RHC:V", "RHC:H", "LHC:V", "LHC:H")
     for elem, new_enum in zip(
@@ -111,6 +116,7 @@ def update_1_1_0_to_1_5(etree):
 def update_version(etree, urn):
     converter = {
         "urn:SICD:1.1.0": lambda x: x,
+        "urn:SICD:1.2.0": update_1_1_0_to_1_2,
         "urn:SICD:1.2.1": update_1_1_0_to_1_2_1,
         "urn:SICD:1.3.0": update_1_1_0_to_1_3_0,
         "urn:SICD:1.4.0": update_1_1_0_to_1_4_0,
@@ -186,7 +192,7 @@ def main(args=None):
                     set_version_ifa, urn="urn:SICD:1.1.0", ifa_label="RgAzComp"
                 ),
                 functools.partial(
-                    set_version_ifa, urn="urn:SICD:1.2.1", ifa_label="PFA"
+                    set_version_ifa, urn="urn:SICD:1.2.0", ifa_label="PFA"
                 ),
                 functools.partial(
                     set_version_ifa, urn="urn:SICD:1.3.0", ifa_label="RMA-RMAT"

--- a/sarkit/sicd/__init__.py
+++ b/sarkit/sicd/__init__.py
@@ -9,7 +9,7 @@ documents that define the Sensor Independent Complex Data (SICD) format.
 Supported Versions
 ==================
 
-.. note:: As of 2026-09-02, there are no links to any version 1.0.x schema files on the NSG standards registry.
+.. note:: As of 2026-09-07, there are no links to any version 1.0.x or 1.2.0 schema files on the NSG standards registry.
 
    To get around this limitation, SARkit pulled SICD schemas from other sources.
    Consult READMEs in the `SICD schema source directory <https://github.com/ValkyrieSystems/sarkit/tree/main/sarkit/sicd/schemas>`_
@@ -18,6 +18,7 @@ Supported Versions
 
 * `SICD 1.0`_
 * `SICD 1.1`_
+* `SICD 1.2`_
 * `SICD 1.2.1`_
 * `SICD 1.3.0`_
 * `SICD 1.4.0`_
@@ -166,6 +167,18 @@ SICD 1.1
 .. [SICD_schema_V1.1.0_2014_09_30.xsd] National Center for Geospatial Intelligence Standards,
    "Sensor Independent Complex Data (SICD) XML Schema, Version 1.1.0", 2014.
    https://nsgreg.nga.mil/doc/view?i=4251
+
+SICD 1.2
+--------
+
+.. Note:: The v1.2 revision amends volume 2 only.
+   Although a revision to the 1.1 schema with only whitespace and namespace changes was distributed, it was not
+   maintained on the NSG Standards Registry.
+
+.. [NGA.STND.0024-2_1.2] National Center for Geospatial Intelligence Standards,
+   "Sensor Independent Complex Data (SICD), Vol. 2, File Format Description Document,
+   Version 1.2", 2016.
+   https://nsgreg.nga.mil/doc/view?i=4248
 
 SICD 1.2.1
 ----------

--- a/sarkit/sicd/_constants.py
+++ b/sarkit/sicd/_constants.py
@@ -29,6 +29,11 @@ VERSION_INFO: Final[dict[str, VersionInfoType]] = {
         "date": "2014-09-30T00:00:00Z",
         "schema": SCHEMA_DIR / "SICD_schema_V1.1.0_2014_09_30.xsd",
     },
+    "urn:SICD:1.2.0": {
+        "version": "1.2",
+        "date": "2016-06-30T00:00:00Z",
+        "schema": SCHEMA_DIR / "SICD_schema_V1.2.0_2016_06_30.xsd",
+    },
     "urn:SICD:1.2.1": {
         "version": "1.2.1",
         "date": "2018-12-13T00:00:00Z",

--- a/sarkit/sicd/_xml.py
+++ b/sarkit/sicd/_xml.py
@@ -243,6 +243,10 @@ class XsdHelper(skxml.XsdHelper):
             k.replace("urn:SICD:1.0.1", "urn:SICD:1.1.0"): v
             for k, v in sicd_101.items()
         }
+        sicd_120 = {
+            k.replace("urn:SICD:1.1.0", "urn:SICD:1.2.0"): v
+            for k, v in sicd_110.items()
+        }
         sicd_121 = {
             k.replace("urn:SICD:1.1.0", "urn:SICD:1.2.1"): v
             for k, v in sicd_110.items()
@@ -287,7 +291,7 @@ class XsdHelper(skxml.XsdHelper):
                 "/{urn:SICD:1.5}Polygon"
             ): skxt.NdArrayType("Vertex", LineSampType()),
         }
-        easy = sicd_101 | sicd_110 | sicd_121 | sicd_130 | sicd_140 | sicd_15
+        easy = sicd_101 | sicd_110 | sicd_120 | sicd_121 | sicd_130 | sicd_140 | sicd_15
         if tag is not None and lxml.etree.QName(tag).localname == "CalibrationDate":
             return skxt.XdtType(force_utc=False)
         if typename.startswith("{http://www.w3.org/2001/XMLSchema}"):

--- a/sarkit/sicd/schemas/README.md
+++ b/sarkit/sicd/schemas/README.md
@@ -12,6 +12,11 @@ https://nsgreg.nga.mil/doc/view?i=4251
 
 The file was renamed from `*.xml` to `*.xsd`
 
+## `SICD_schema_V1.2.0_2016_06_30.xsd`
+This file was copied from:
+https://github.com/ngageoint/six-library/blob/448e6d659bb4b650fcc19e4b909353203c3a5195/six/modules/c%2B%2B/six.sicd/conf/schema/SICD_schema_V1.2.0_2016_06_30.xsd
+
+
 ## `SICD_schema_V1.2.1_2018_12_13.xsd`
 This file was copied from:
 https://nsgreg.nga.mil/doc/view?i=5230

--- a/sarkit/sicd/schemas/SICD_schema_V1.2.0_2016_06_30.xsd
+++ b/sarkit/sicd/schemas/SICD_schema_V1.2.0_2016_06_30.xsd
@@ -1,0 +1,1111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+   elementFormDefault="qualified"
+   attributeFormDefault="unqualified"
+   targetNamespace="urn:SICD:1.2.0"
+   xmlns="urn:SICD:1.2.0">
+
+<!-- SICD TYPES -->
+
+   <xs:simpleType name="ZeroTo90Type">
+      <xs:restriction base="xs:double">
+         <xs:minInclusive value="0"/>
+         <xs:maxInclusive value="90"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <xs:simpleType name="ZeroTo360Type">
+      <xs:restriction base="xs:double">
+         <xs:minInclusive value="0"/>
+         <xs:maxInclusive value="360"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <xs:simpleType name="Neg90To90Type">
+      <xs:restriction base="xs:double">
+         <xs:minInclusive value="-90"/>
+         <xs:maxInclusive value="90"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <xs:simpleType name="Neg180To180Type">
+      <xs:restriction base="xs:double">
+         <xs:minInclusive value="-180"/>
+         <xs:maxInclusive value="180"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <xs:complexType name="XYZType">
+      <xs:sequence>
+         <xs:element name="X" type="xs:double"/>
+         <xs:element name="Y" type="xs:double"/>
+         <xs:element name="Z" type="xs:double"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="LatLonHAEType">
+      <xs:sequence>
+         <xs:element name="Lat" type="xs:double"/>
+         <xs:element name="Lon" type="xs:double"/>
+         <xs:element name="HAE" type="xs:double"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="LatLonType">
+      <xs:sequence>
+         <xs:element name="Lat" type="xs:double"/>
+         <xs:element name="Lon" type="xs:double"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="LatLonHAERestrictionType">
+      <xs:sequence>
+         <xs:element name="Lat" type="Neg90To90Type"/>
+         <xs:element name="Lon" type="Neg180To180Type"/>
+         <xs:element name="HAE" type="xs:double"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="LatLonRestrictionType">
+      <xs:sequence>
+         <xs:element name="Lat" type="Neg90To90Type"/>
+         <xs:element name="Lon" type="Neg180To180Type"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:simpleType name="CornerAttrType">
+      <xs:restriction base="xs:int">
+         <xs:minInclusive value="1"/>
+         <xs:maxInclusive value="4"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <xs:simpleType name="CornerStringType">
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="1:FRFC"/>
+         <xs:enumeration value="2:FRLC"/>
+         <xs:enumeration value="3:LRLC"/>
+         <xs:enumeration value="4:LRFC"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <xs:complexType name="LatLonCornerType">
+     <xs:complexContent>
+      <xs:extension base="LatLonType">
+         <xs:attribute name="index" type="CornerAttrType" use="required"/>
+      </xs:extension>
+     </xs:complexContent>
+   </xs:complexType>
+
+   <xs:complexType name="LatLonCornerStringType">
+     <xs:complexContent>
+      <xs:extension base="LatLonType">
+         <xs:attribute name="index" type="CornerStringType" use="required"/>
+      </xs:extension>
+     </xs:complexContent>
+   </xs:complexType>
+
+   <xs:complexType name="LatLonHAECornerRestrictType">
+     <xs:complexContent>
+      <xs:extension base="LatLonHAERestrictionType">
+         <xs:attribute name="index" type="CornerAttrType" use="required"/>
+      </xs:extension>
+     </xs:complexContent>
+   </xs:complexType>
+
+   <xs:complexType name="LatLonHAECornerStringType">
+    <xs:complexContent>
+      <xs:extension base="LatLonHAEType">
+         <xs:attribute name="index" type="CornerStringType" use="required"/>
+      </xs:extension>
+     </xs:complexContent>
+   </xs:complexType>
+
+   <xs:complexType name="RowColType">
+      <xs:sequence>
+         <xs:element name="Row" type="xs:int"/>
+         <xs:element name="Col" type="xs:int"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="ComplexType">
+      <xs:sequence>
+         <xs:element name="Real" type="xs:double"/>
+         <xs:element name="Imag" type="xs:double"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="RowColvertexType">
+    <xs:complexContent>
+      <xs:extension base="RowColType">
+         <xs:attribute name="index" type="xs:int" use="required"/>
+      </xs:extension>
+     </xs:complexContent>
+   </xs:complexType>
+
+   <xs:complexType name="PolyCoef1DType">
+      <xs:simpleContent>
+         <xs:extension base="xs:double">
+            <xs:attribute name="exponent1" type="xs:int" use="required"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <xs:complexType name="PolyCoef2DType">
+      <xs:simpleContent>
+         <xs:extension base="xs:double">
+            <xs:attribute name="exponent1" type="xs:int" use="required"/>
+            <xs:attribute name="exponent2" type="xs:int" use="required"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <xs:complexType name="Poly1DType">
+      <xs:sequence>
+         <xs:element name="Coef" type="PolyCoef1DType" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="order1" type="xs:int" use="required"/>
+   </xs:complexType>
+
+   <xs:complexType name="Poly2DType">
+      <xs:sequence>
+         <xs:element name="Coef" type="PolyCoef2DType" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="order1" type="xs:int" use="required"/>
+      <xs:attribute name="order2" type="xs:int" use="required"/>
+   </xs:complexType>
+
+   <xs:complexType name="XYZPolyType">
+      <xs:sequence>
+         <xs:element name="X" type="Poly1DType"/>
+         <xs:element name="Y" type="Poly1DType"/>
+         <xs:element name="Z" type="Poly1DType"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="XYZPolyAttributeType">
+      <xs:complexContent>
+         <xs:extension base="XYZPolyType">
+            <xs:attribute name="index" type="xs:int" use="required"/>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:complexType name="GainPhasePolyType">
+      <xs:sequence>
+         <xs:element name="GainPoly" type="Poly2DType"/>
+         <xs:element name="PhasePoly" type="Poly2DType"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="LineType">
+      <xs:sequence>
+         <xs:element name="Endpoint" minOccurs="2" maxOccurs="unbounded">
+            <xs:complexType>
+               <xs:complexContent>
+                  <xs:extension base="LatLonType">
+                     <xs:attribute name="index" type="xs:int" use="required"/>
+                  </xs:extension>
+               </xs:complexContent>
+            </xs:complexType>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="size" type="xs:int" use="required"/>
+   </xs:complexType>
+
+   <xs:complexType name="PolygonType">
+      <xs:sequence>
+         <xs:element name="Vertex" minOccurs="3" maxOccurs="unbounded">
+            <xs:complexType>
+               <xs:complexContent>
+                  <xs:extension base="LatLonRestrictionType">
+                     <xs:attribute name="index" type="xs:int" use="required"/>
+                  </xs:extension>
+               </xs:complexContent>
+            </xs:complexType>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="size" type="xs:int" use="required"/>
+   </xs:complexType>
+
+   <xs:complexType name="ArrayDouble">
+      <xs:simpleContent>
+         <xs:extension base="xs:double">
+            <xs:attribute name="index" type="xs:int" use="required"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <xs:complexType name="ErrorDecorrFuncType">
+      <xs:sequence>
+         <xs:element name="CorrCoefZero" type="xs:double"/>
+         <xs:element name="DecorrRate" type="xs:double"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="ParameterType">
+      <xs:simpleContent>
+         <xs:extension base="xs:string">
+            <xs:attribute name="name" type="xs:string" use="required"/>
+         </xs:extension>
+      </xs:simpleContent>
+   </xs:complexType>
+
+   <xs:simpleType name="OrientationType">
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="UP"/>
+         <xs:enumeration value="DOWN"/>
+         <xs:enumeration value="LEFT"/>
+         <xs:enumeration value="RIGHT"/>
+         <xs:enumeration value="ARBITRARY"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <xs:simpleType name="Polarization1Type">
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="V"/>
+         <xs:enumeration value="H"/>
+         <xs:enumeration value="RHC"/>
+         <xs:enumeration value="LHC"/>
+         <xs:enumeration value="OTHER"/>
+         <xs:enumeration value="UNKNOWN"/>
+         <xs:enumeration value="SEQUENCE"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <xs:simpleType name="Polarization2Type">
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="V"/>
+         <xs:enumeration value="H"/>
+         <xs:enumeration value="RHC"/>
+         <xs:enumeration value="LHC"/>
+         <xs:enumeration value="OTHER"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <xs:simpleType name="DualPolarizationType">
+      <xs:restriction base="xs:string">
+         <xs:enumeration value="V:V"/>
+         <xs:enumeration value="V:H"/>
+         <xs:enumeration value="H:V"/>
+         <xs:enumeration value="H:H"/>
+         <xs:enumeration value="RHC:RHC"/>
+         <xs:enumeration value="RHC:LHC"/>
+         <xs:enumeration value="LHC:RHC"/>
+         <xs:enumeration value="LHC:LHC"/>
+         <xs:enumeration value="OTHER"/>
+         <xs:enumeration value="UNKNOWN"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+
+
+
+<!-- sicd blocks -->
+
+   <xs:complexType name="CollectionInfoType">
+      <xs:sequence>
+         <xs:element name="CollectorName" type="xs:string"/>
+         <xs:element name="IlluminatorName" type="xs:string" minOccurs="0"/>
+         <xs:element name="CoreName" type="xs:string"/>
+         <xs:element name="CollectType" minOccurs="0">
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:enumeration value="MONOSTATIC"/>
+                  <xs:enumeration value="BISTATIC"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="RadarMode">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="ModeType">
+                     <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                           <xs:enumeration value="SPOTLIGHT"/>
+                           <xs:enumeration value="STRIPMAP"/>
+                           <xs:enumeration value="DYNAMIC STRIPMAP"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:element>
+                  <xs:element name="ModeID" type="xs:string" minOccurs="0"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="Classification" type="xs:string"/>
+         <xs:element name="CountryCode" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+         <xs:element name="Parameter" type="ParameterType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="ImageCreationType">
+      <xs:sequence>
+         <xs:element name="Application" type="xs:string" minOccurs="0"/>
+         <xs:element name="DateTime" type="xs:dateTime" minOccurs="0"/>
+         <xs:element name="Site" type="xs:string" minOccurs="0"/>
+         <xs:element name="Profile" type="xs:string" minOccurs="0"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="ImageDataType">
+      <xs:sequence>
+         <xs:element name="PixelType">
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:enumeration value="RE32F_IM32F"/>
+                  <xs:enumeration value="RE16I_IM16I"/>
+                  <xs:enumeration value="AMP8I_PHS8I"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="AmpTable" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="Amplitude" type="ArrayDouble" minOccurs="256" maxOccurs="256"/>
+               </xs:sequence>
+               <xs:attribute name="size" type="xs:int" use="required"/>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="NumRows" type="xs:int"/>
+         <xs:element name="NumCols" type="xs:int"/>
+         <xs:element name="FirstRow" type="xs:int"/>
+         <xs:element name="FirstCol" type="xs:int"/>
+         <xs:element name="FullImage">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="NumRows" type="xs:int"/>
+                  <xs:element name="NumCols" type="xs:int"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="SCPPixel" type="RowColType"/>
+         <xs:element name="ValidData" minOccurs="0" >
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="Vertex" type="RowColvertexType" minOccurs="3" maxOccurs="unbounded"/>
+               </xs:sequence>
+               <xs:attribute name="size" type="xs:int" use="required"/>
+            </xs:complexType>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="GeoInfoType">
+      <xs:sequence>
+         <xs:element name="Desc" type="ParameterType" minOccurs="0" maxOccurs="unbounded"/>
+         <xs:choice minOccurs="0">
+            <xs:element name="Point" type="LatLonRestrictionType"/>
+            <xs:element name="Line" type="LineType"/>
+            <xs:element name="Polygon" type="PolygonType"/>
+         </xs:choice>
+         <xs:element name="GeoInfo" type="GeoInfoType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="required"/>
+   </xs:complexType>
+
+   <xs:complexType name="GeoDataType">
+      <xs:sequence>
+         <xs:element name="EarthModel">
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:enumeration value="WGS_84"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="SCP">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="ECF" type="XYZType"/>
+                  <xs:element name="LLH" type="LatLonHAERestrictionType"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="ImageCorners">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="ICP" type="LatLonCornerStringType" minOccurs="4" maxOccurs="4"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="ValidData" type="PolygonType" minOccurs="0"/>
+         <xs:element name="GeoInfo" type="GeoInfoType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="DirParamType">
+      <xs:sequence>
+         <xs:element name="UVectECF" type="XYZType"/>
+         <xs:element name="SS" type="xs:double"/>
+         <xs:element name="ImpRespWid" type="xs:double"/>
+         <xs:element name="Sgn">
+            <xs:simpleType>
+               <xs:restriction base="xs:int">
+                  <xs:enumeration value="+1"/>
+                  <xs:enumeration value="-1"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="ImpRespBW" type="xs:double"/>
+         <xs:element name="KCtr" type="xs:double"/>
+         <xs:element name="DeltaK1" type="xs:double"/>
+         <xs:element name="DeltaK2" type="xs:double"/>
+         <xs:element name="DeltaKCOAPoly" type="Poly2DType" minOccurs="0"/>
+         <xs:element name="WgtType" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="WindowName" type="xs:string"/>
+                  <xs:element name="Parameter" type="ParameterType" minOccurs="0" maxOccurs="unbounded"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="WgtFunct" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="Wgt" type="ArrayDouble" minOccurs="2" maxOccurs="unbounded"/>
+               </xs:sequence>
+               <xs:attribute name="size" type="xs:int" use="required"/>
+            </xs:complexType>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="GridType">
+      <xs:sequence>
+         <xs:element name="ImagePlane">
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:enumeration value="SLANT"/>
+                  <xs:enumeration value="GROUND"/>
+                  <xs:enumeration value="OTHER"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="Type">
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:enumeration value="RGAZIM"/>
+                  <xs:enumeration value="RGZERO"/>
+                  <xs:enumeration value="XRGYCR"/>
+                  <xs:enumeration value="XCTYAT"/>
+                  <xs:enumeration value="PLANE"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="TimeCOAPoly" type="Poly2DType"/>
+         <xs:element name="Row" type="DirParamType"/>
+         <xs:element name="Col" type="DirParamType"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="TimelineType">
+      <xs:sequence>
+         <xs:element name="CollectStart" type="xs:dateTime"/>
+         <xs:element name="CollectDuration" type="xs:double"/>
+         <xs:element name="IPP" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="Set" maxOccurs="unbounded">
+                     <xs:complexType>
+                        <xs:sequence>
+                           <xs:element name="TStart" type="xs:double"/>
+                           <xs:element name="TEnd" type="xs:double"/>
+                           <xs:element name="IPPStart" type="xs:int"/>
+                           <xs:element name="IPPEnd" type="xs:int"/>
+                           <xs:element name="IPPPoly" type="Poly1DType"/>
+                        </xs:sequence>
+                        <xs:attribute name="index" type="xs:int" use="required"/>
+                     </xs:complexType>
+                  </xs:element>
+               </xs:sequence>
+               <xs:attribute name="size" type="xs:int" use="required"/>
+            </xs:complexType>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="PositionType">
+      <xs:sequence>
+         <xs:element name="ARPPoly" type="XYZPolyType"/>
+         <xs:element name="GRPPoly" type="XYZPolyType" minOccurs="0"/>
+         <xs:element name="TxAPCPoly" type="XYZPolyType" minOccurs="0"/>
+         <xs:element name="RcvAPC" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="RcvAPCPoly" type="XYZPolyAttributeType" maxOccurs="unbounded"/>
+               </xs:sequence>
+               <xs:attribute name="size" type="xs:int" use="required"/>
+            </xs:complexType>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="RadarCollectionType">
+      <xs:sequence>
+         <xs:element name="TxFrequency">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="Min" type="xs:double"/>
+                  <xs:element name="Max" type="xs:double"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="RefFreqIndex" type="xs:int" minOccurs="0"/>
+         <xs:element name="Waveform" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="WFParameters" maxOccurs="unbounded">
+                     <xs:complexType>
+                        <xs:sequence>
+                           <xs:element name="TxPulseLength" type="xs:double" minOccurs="0"/>
+                           <xs:element name="TxRFBandwidth" type="xs:double" minOccurs="0"/>
+                           <xs:element name="TxFreqStart" type="xs:double" minOccurs="0"/>
+                           <xs:element name="TxFMRate" type="xs:double" minOccurs="0"/>
+                           <xs:element name="RcvDemodType" minOccurs="0">
+                              <xs:simpleType>
+                                 <xs:restriction base="xs:string">
+                                    <xs:enumeration value="STRETCH"/>
+                                    <xs:enumeration value="CHIRP"/>
+                                 </xs:restriction>
+                              </xs:simpleType>
+                           </xs:element>
+                           <xs:element name="RcvWindowLength" type="xs:double" minOccurs="0"/>
+                           <xs:element name="ADCSampleRate" type="xs:double" minOccurs="0"/>
+                           <xs:element name="RcvIFBandwidth" type="xs:double" minOccurs="0"/>
+                           <xs:element name="RcvFreqStart" type="xs:double" minOccurs="0"/>
+                           <xs:element name="RcvFMRate" type="xs:double" minOccurs="0"/>
+                        </xs:sequence>
+                        <xs:attribute name="index" type="xs:int" use="required"/>
+                     </xs:complexType>
+                  </xs:element>
+               </xs:sequence>
+               <xs:attribute name="size" type="xs:int" use="required"/>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="TxPolarization" type="Polarization1Type"/>
+         <xs:element name="TxSequence" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="TxStep" maxOccurs="unbounded">
+                     <xs:complexType>
+                        <xs:sequence>
+                           <xs:element name="WFIndex" type="xs:int" minOccurs="0"/>
+                           <xs:element name="TxPolarization" type="Polarization2Type" minOccurs="0"/>
+                        </xs:sequence>
+                        <xs:attribute name="index" type="xs:int" use="required"/>
+                     </xs:complexType>
+                  </xs:element>
+               </xs:sequence>
+               <xs:attribute name="size" type="xs:int" use="required"/>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="RcvChannels">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="ChanParameters" maxOccurs="unbounded">
+                     <xs:complexType>
+                        <xs:sequence>
+                           <xs:element name="TxRcvPolarization" type="DualPolarizationType"/>
+                           <xs:element name="RcvAPCIndex" type="xs:int" minOccurs="0"/>
+                        </xs:sequence>
+                        <xs:attribute name="index" type="xs:int" use="required"/>
+                     </xs:complexType>
+                  </xs:element>
+               </xs:sequence>
+               <xs:attribute name="size" type="xs:int" use="required"/>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="Area" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="Corner">
+                     <xs:complexType>
+                        <xs:sequence>
+                           <xs:element name="ACP" type="LatLonHAECornerRestrictType" minOccurs="4" maxOccurs="4"/>
+                        </xs:sequence>
+                     </xs:complexType>
+                  </xs:element>
+                  <xs:element name="Plane" minOccurs="0">
+                     <xs:complexType>
+                        <xs:sequence>
+                           <xs:element name="RefPt">
+                              <xs:complexType>
+                                 <xs:sequence>
+                                    <xs:element name="ECF" type="XYZType"/>
+                                    <xs:element name="Line" type="xs:double"/>
+                                    <xs:element name="Sample" type="xs:double"/>
+                                 </xs:sequence>
+                                 <xs:attribute name="name" type="xs:string"/>
+                              </xs:complexType>
+                           </xs:element>
+                           <xs:element name="XDir">
+                              <xs:complexType>
+                                 <xs:sequence>
+                                    <xs:element name="UVectECF" type="XYZType"/>
+                                    <xs:element name="LineSpacing" type="xs:double"/>
+                                    <xs:element name="NumLines" type="xs:int"/>
+                                    <xs:element name="FirstLine" type="xs:int"/>
+                                 </xs:sequence>
+                              </xs:complexType>
+                           </xs:element>
+                           <xs:element name="YDir">
+                              <xs:complexType>
+                                 <xs:sequence>
+                                    <xs:element name="UVectECF" type="XYZType"/>
+                                    <xs:element name="SampleSpacing" type="xs:double"/>
+                                    <xs:element name="NumSamples" type="xs:int"/>
+                                    <xs:element name="FirstSample" type="xs:int"/>
+                                 </xs:sequence>
+                              </xs:complexType>
+                           </xs:element>
+                           <xs:element name="SegmentList" minOccurs="0">
+                              <xs:complexType>
+                                 <xs:sequence>
+                                    <xs:element name="Segment" maxOccurs="unbounded">
+                                       <xs:complexType>
+                                          <xs:sequence>
+                                             <xs:element name="StartLine" type="xs:int"/>
+                                             <xs:element name="StartSample" type="xs:int"/>
+                                             <xs:element name="EndLine" type="xs:int"/>
+                                             <xs:element name="EndSample" type="xs:int"/>
+                                             <xs:element name="Identifier" type="xs:string"/>
+                                          </xs:sequence>
+                                       <xs:attribute name="index" type="xs:int" use="required"/>
+                                       </xs:complexType>
+                                    </xs:element>
+                                 </xs:sequence>
+                                 <xs:attribute name="size" type="xs:int" use="required"/>
+                              </xs:complexType>
+                           </xs:element>
+                           <xs:element name="Orientation" type="OrientationType" minOccurs="0"/>
+                        </xs:sequence>
+                     </xs:complexType>
+                  </xs:element>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="Parameter" type="ParameterType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="ImageFormationType">
+      <xs:sequence>
+         <xs:element name="RcvChanProc">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="NumChanProc" type="xs:int"/>
+                  <xs:element name="PRFScaleFactor" type="xs:double" minOccurs="0"/>
+                  <xs:element name="ChanIndex" type="xs:int" maxOccurs="unbounded"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="TxRcvPolarizationProc" type="DualPolarizationType"/>
+         <xs:element name="TStartProc" type="xs:double"/>
+         <xs:element name="TEndProc" type="xs:double"/>
+         <xs:element name="TxFrequencyProc">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="MinProc" type="xs:double"/>
+                  <xs:element name="MaxProc" type="xs:double"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="SegmentIdentifier" type="xs:string" minOccurs="0"/>
+         <xs:element name="ImageFormAlgo">
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:enumeration value="PFA"/>
+                  <xs:enumeration value="RMA"/>
+                  <xs:enumeration value="RGAZCOMP"/>
+                  <xs:enumeration value="OTHER"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="STBeamComp">
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:enumeration value="NO"/>
+                  <xs:enumeration value="GLOBAL"/>
+                  <xs:enumeration value="SV"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="ImageBeamComp">
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:enumeration value="NO"/>
+                  <xs:enumeration value="SV"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="AzAutofocus">
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:enumeration value="NO"/>
+                  <xs:enumeration value="GLOBAL"/>
+                  <xs:enumeration value="SV"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="RgAutofocus">
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:enumeration value="NO"/>
+                  <xs:enumeration value="GLOBAL"/>
+                  <xs:enumeration value="SV"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="Processing" minOccurs="0" maxOccurs="unbounded">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="Type" type="xs:string"/>
+                  <xs:element name="Applied" type="xs:boolean"/>
+                  <xs:element name="Parameter" type="ParameterType" minOccurs="0" maxOccurs="unbounded"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="PolarizationCalibration" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="DistortCorrectionApplied" type="xs:boolean"/>
+                  <xs:element name="Distortion">
+                     <xs:complexType>
+                        <xs:sequence>
+                           <xs:element name="CalibrationDate" type="xs:dateTime" minOccurs="0"/>
+                           <xs:element name="A" type="xs:double"/>
+                           <xs:element name="F1" type="ComplexType"/>
+                           <xs:element name="Q1" type="ComplexType"/>
+                           <xs:element name="Q2" type="ComplexType"/>
+                           <xs:element name="F2" type="ComplexType"/>
+                           <xs:element name="Q3" type="ComplexType"/>
+                           <xs:element name="Q4" type="ComplexType"/>
+                           <xs:element name="GainErrorA" type="xs:double" minOccurs="0"/>
+                           <xs:element name="GainErrorF1" type="xs:double" minOccurs="0"/>
+                           <xs:element name="GainErrorF2" type="xs:double" minOccurs="0"/>
+                           <xs:element name="PhaseErrorF1" type="xs:double" minOccurs="0"/>
+                           <xs:element name="PhaseErrorF2" type="xs:double" minOccurs="0"/>
+                        </xs:sequence>
+                     </xs:complexType>
+                  </xs:element>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="SCPCOAType">
+      <xs:sequence>
+         <xs:element name="SCPTime" type="xs:double"/>
+         <xs:element name="ARPPos" type="XYZType"/>
+         <xs:element name="ARPVel" type="XYZType"/>
+         <xs:element name="ARPAcc" type="XYZType"/>
+         <xs:element name="SideOfTrack">
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:enumeration value="L"/>
+                  <xs:enumeration value="R"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="SlantRange" type="xs:double"/>
+         <xs:element name="GroundRange" type="xs:double"/>
+         <xs:element name="DopplerConeAng" type="xs:double"/>
+         <xs:element name="GrazeAng" type="ZeroTo90Type"/>
+         <xs:element name="IncidenceAng" type="ZeroTo90Type"/>
+         <xs:element name="TwistAng" type="Neg90To90Type"/>
+         <xs:element name="SlopeAng" type="ZeroTo90Type"/>
+         <xs:element name="AzimAng" type="ZeroTo360Type"/>
+         <xs:element name="LayoverAng" type="ZeroTo360Type"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="RadiometricType">
+      <xs:sequence>
+         <xs:element name="NoiseLevel" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="NoiseLevelType">
+                     <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                           <xs:enumeration value="ABSOLUTE"/>
+                           <xs:enumeration value="RELATIVE"/>
+                        </xs:restriction>
+                     </xs:simpleType>
+                  </xs:element>
+                  <xs:element name="NoisePoly" type="Poly2DType"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="RCSSFPoly" type="Poly2DType" minOccurs="0"/>
+         <xs:element name="SigmaZeroSFPoly" type="Poly2DType" minOccurs="0"/>
+         <xs:element name="BetaZeroSFPoly" type="Poly2DType" minOccurs="0"/>
+         <xs:element name="GammaZeroSFPoly" type="Poly2DType" minOccurs="0"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="AntParamType">
+      <xs:sequence>
+         <xs:element name="XAxisPoly" type="XYZPolyType"/>
+         <xs:element name="YAxisPoly" type="XYZPolyType"/>
+         <xs:element name="FreqZero" type="xs:double"/>
+         <xs:element name="EB" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="DCXPoly" type="Poly1DType"/>
+                  <xs:element name="DCYPoly" type="Poly1DType"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="Array" type="GainPhasePolyType"/>
+         <xs:element name="Elem" type="GainPhasePolyType" minOccurs="0"/>
+         <xs:element name="GainBSPoly" type="Poly1DType" minOccurs="0"/>
+         <xs:element name="EBFreqShift" type="xs:boolean" minOccurs="0"/>
+         <xs:element name="MLFreqDilation" type="xs:boolean" minOccurs="0"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="AntennaType">
+      <xs:sequence>
+         <xs:element name="Tx" type="AntParamType" minOccurs="0"/>
+         <xs:element name="Rcv" type="AntParamType" minOccurs="0"/>
+         <xs:element name="TwoWay" type="AntParamType" minOccurs="0"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="ErrorStatisticsType">
+      <xs:sequence>
+         <xs:element name="CompositeSCP" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="Rg" type="xs:double"/>
+                  <xs:element name="Az" type="xs:double"/>
+                  <xs:element name="RgAz" type="xs:double"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="Components" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="PosVelErr">
+                     <xs:complexType>
+                        <xs:sequence>
+                           <xs:element name="Frame">
+                              <xs:simpleType>
+                                 <xs:restriction base="xs:string">
+                                    <xs:enumeration value="ECF"/>
+                                    <xs:enumeration value="RIC_ECF"/>
+                                    <xs:enumeration value="RIC_ECI"/>
+                                 </xs:restriction>
+                              </xs:simpleType>
+                           </xs:element>
+                           <xs:element name="P1" type="xs:double"/>
+                           <xs:element name="P2" type="xs:double"/>
+                           <xs:element name="P3" type="xs:double"/>
+                           <xs:element name="V1" type="xs:double"/>
+                           <xs:element name="V2" type="xs:double"/>
+                           <xs:element name="V3" type="xs:double"/>
+                           <xs:element name="CorrCoefs" minOccurs="0">
+                              <xs:complexType>
+                                 <xs:sequence>
+                                    <xs:element name="P1P2" type="xs:double"/>
+                                    <xs:element name="P1P3" type="xs:double"/>
+                                    <xs:element name="P1V1" type="xs:double"/>
+                                    <xs:element name="P1V2" type="xs:double"/>
+                                    <xs:element name="P1V3" type="xs:double"/>
+                                    <xs:element name="P2P3" type="xs:double"/>
+                                    <xs:element name="P2V1" type="xs:double"/>
+                                    <xs:element name="P2V2" type="xs:double"/>
+                                    <xs:element name="P2V3" type="xs:double"/>
+                                    <xs:element name="P3V1" type="xs:double"/>
+                                    <xs:element name="P3V2" type="xs:double"/>
+                                    <xs:element name="P3V3" type="xs:double"/>
+                                    <xs:element name="V1V2" type="xs:double"/>
+                                    <xs:element name="V1V3" type="xs:double"/>
+                                    <xs:element name="V2V3" type="xs:double"/>
+                                 </xs:sequence>
+                              </xs:complexType>
+                           </xs:element>
+                           <xs:element name="PositionDecorr" type="ErrorDecorrFuncType" minOccurs="0"/>
+                        </xs:sequence>
+                     </xs:complexType>
+                  </xs:element>
+                  <xs:element name="RadarSensor">
+                     <xs:complexType>
+                        <xs:sequence>
+                           <xs:element name="RangeBias" type="xs:double"/>
+                           <xs:element name="ClockFreqSF" type="xs:double" minOccurs="0"/>
+                           <xs:element name="TransmitFreqSF" type="xs:double" minOccurs="0"/>
+                           <xs:element name="RangeBiasDecorr" type="ErrorDecorrFuncType" minOccurs="0"/>
+                        </xs:sequence>
+                     </xs:complexType>
+                  </xs:element>
+                  <xs:element name="TropoError" minOccurs="0">
+                     <xs:complexType>
+                        <xs:sequence>
+                           <xs:element name="TropoRangeVertical" type="xs:double" minOccurs="0"/>
+                           <xs:element name="TropoRangeSlant" type="xs:double" minOccurs="0"/>
+                           <xs:element name="TropoRangeDecorr" type="ErrorDecorrFuncType" minOccurs="0"/>
+                        </xs:sequence>
+                     </xs:complexType>
+                  </xs:element>
+                  <xs:element name="IonoError" minOccurs="0">
+                     <xs:complexType>
+                        <xs:sequence>
+                           <xs:element name="IonoRangeVertical" type="xs:double" minOccurs="0"/>
+                           <xs:element name="IonoRangeRateVertical" type="xs:double" minOccurs="0"/>
+                           <xs:element name="IonoRgRgRateCC" type="xs:double"/>
+                           <xs:element name="IonoRangeVertDecorr" type="ErrorDecorrFuncType" minOccurs="0"/>
+                        </xs:sequence>
+                     </xs:complexType>
+                  </xs:element>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="AdditionalParms" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="Parameter" type="ParameterType" maxOccurs="unbounded"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="MatchInfoType">
+      <xs:sequence>
+         <xs:element name="NumMatchTypes" type="xs:int"/>
+         <xs:element name="MatchType" maxOccurs="unbounded">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="TypeID" type="xs:string"/>
+                  <xs:element name="CurrentIndex" type="xs:int" minOccurs="0"/>
+                  <xs:element name="NumMatchCollections" type="xs:int"/>
+                  <xs:element name="MatchCollection" minOccurs="0" maxOccurs="unbounded">
+                     <xs:complexType>
+                        <xs:sequence>
+                           <xs:element name="CoreName" type="xs:string"/>
+                           <xs:element name="MatchIndex" type="xs:int" minOccurs="0"/>
+                           <xs:element name="Parameter" type="ParameterType" minOccurs="0" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                        <xs:attribute name="index" type="xs:int" use="required"/>
+                     </xs:complexType>
+                  </xs:element>
+               </xs:sequence>
+               <xs:attribute name="index" type="xs:int" use="required"/>
+            </xs:complexType>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="RgAzCompType">
+      <xs:sequence>
+         <xs:element name="AzSF" type="xs:double"/>
+         <xs:element name="KazPoly" type="Poly1DType"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="PFAType">
+      <xs:sequence>
+         <xs:element name="FPN" type="XYZType"/>
+         <xs:element name="IPN" type="XYZType"/>
+         <xs:element name="PolarAngRefTime" type="xs:double"/>
+         <xs:element name="PolarAngPoly" type="Poly1DType"/>
+         <xs:element name="SpatialFreqSFPoly" type="Poly1DType"/>
+         <xs:element name="Krg1" type="xs:double"/>
+         <xs:element name="Krg2" type="xs:double"/>
+         <xs:element name="Kaz1" type="xs:double"/>
+         <xs:element name="Kaz2" type="xs:double"/>
+         <xs:element name="STDeskew" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="Applied" type="xs:boolean"/>
+                  <xs:element name="STDSPhasePoly" type="Poly2DType"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="RMAType">
+      <xs:sequence>
+         <xs:element name="RMAlgoType">
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:enumeration value="OMEGA_K"/>
+                  <xs:enumeration value="CSA"/>
+                  <xs:enumeration value="RG_DOP"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:element name="ImageType">
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:enumeration value="RMAT"/>
+                  <xs:enumeration value="RMCR"/>
+                  <xs:enumeration value="INCA"/>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:element>
+         <xs:choice>
+            <xs:element name="RMAT">
+               <xs:complexType>
+                  <xs:sequence>
+                     <xs:element name="PosRef" type="XYZType"/>
+                     <xs:element name="VelRef" type="XYZType"/>
+                     <xs:element name="DopConeAngRef" type="xs:double"/>
+                  </xs:sequence>
+               </xs:complexType>
+            </xs:element>
+            <xs:element name="RMCR">
+               <xs:complexType>
+                  <xs:sequence>
+                     <xs:element name="PosRef" type="XYZType"/>
+                     <xs:element name="VelRef" type="XYZType"/>
+                     <xs:element name="DopConeAngRef" type="xs:double"/>
+                  </xs:sequence>
+               </xs:complexType>
+            </xs:element>
+            <xs:element name="INCA">
+               <xs:complexType>
+                  <xs:sequence>
+                     <xs:element name="TimeCAPoly" type="Poly1DType"/>
+                     <xs:element name="R_CA_SCP" type="xs:double"/>
+                     <xs:element name="FreqZero" type="xs:double"/>
+                     <xs:element name="DRateSFPoly" type="Poly2DType"/>
+                     <xs:element name="DopCentroidPoly" type="Poly2DType" minOccurs="0"/>
+                     <xs:element name="DopCentroidCOA" type="xs:boolean" minOccurs="0"/>
+                  </xs:sequence>
+               </xs:complexType>
+            </xs:element>
+         </xs:choice>
+      </xs:sequence>
+   </xs:complexType>
+
+
+<!-- SICD MASTER -->
+   <xs:element name="SICD">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element name="CollectionInfo" type="CollectionInfoType"/>
+            <xs:element name="ImageCreation" type="ImageCreationType" minOccurs="0"/>
+            <xs:element name="ImageData" type="ImageDataType"/>
+            <xs:element name="GeoData" type="GeoDataType"/>
+            <xs:element name="Grid" type="GridType"/>
+            <xs:element name="Timeline" type="TimelineType"/>
+            <xs:element name="Position" type="PositionType"/>
+            <xs:element name="RadarCollection" type="RadarCollectionType"/>
+            <xs:element name="ImageFormation" type="ImageFormationType"/>
+            <xs:element name="SCPCOA" type="SCPCOAType"/>
+            <xs:element name="Radiometric" type="RadiometricType" minOccurs="0"/>
+            <xs:element name="Antenna" type="AntennaType" minOccurs="0"/>
+            <xs:element name="ErrorStatistics" type="ErrorStatisticsType" minOccurs="0"/>
+            <xs:element name="MatchInfo" type="MatchInfoType" minOccurs="0"/>
+            <xs:choice minOccurs="0">
+               <xs:element name="RgAzComp" type="RgAzCompType"/>
+               <xs:element name="PFA" type="PFAType"/>
+               <xs:element name="RMA" type="RMAType"/>
+            </xs:choice>
+         </xs:sequence>
+      </xs:complexType>
+   </xs:element>
+</xs:schema>

--- a/sarkit/sicd/xsdtypes/SICD_schema_V1.2.0_2016_06_30.json
+++ b/sarkit/sicd/xsdtypes/SICD_schema_V1.2.0_2016_06_30.json
@@ -1,0 +1,2447 @@
+{
+  "/": {
+    "{urn:SICD:1.2.0}SICD": "<UNNAMED>-{urn:SICD:1.2.0}SICD"
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}AntParamType/{urn:SICD:1.2.0}EB": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}DCXPoly",
+        "typename": "{urn:SICD:1.2.0}Poly1DType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}DCYPoly",
+        "typename": "{urn:SICD:1.2.0}Poly1DType"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}CollectionInfoType/{urn:SICD:1.2.0}CollectType": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}string"
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}CollectionInfoType/{urn:SICD:1.2.0}RadarMode": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}ModeType",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}CollectionInfoType/{urn:SICD:1.2.0}RadarMode/{urn:SICD:1.2.0}ModeType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}ModeID",
+        "typename": "{http://www.w3.org/2001/XMLSchema}string"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}CollectionInfoType/{urn:SICD:1.2.0}RadarMode/{urn:SICD:1.2.0}ModeType": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}string"
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}DirParamType/{urn:SICD:1.2.0}Sgn": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}int"
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}DirParamType/{urn:SICD:1.2.0}WgtFunct": {
+    "attributes": [
+      "size"
+    ],
+    "children": [
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}Wgt",
+        "typename": "{urn:SICD:1.2.0}ArrayDouble"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}DirParamType/{urn:SICD:1.2.0}WgtType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}WindowName",
+        "typename": "{http://www.w3.org/2001/XMLSchema}string"
+      },
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}Parameter",
+        "typename": "{urn:SICD:1.2.0}ParameterType"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}ErrorStatisticsType/{urn:SICD:1.2.0}AdditionalParms": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}Parameter",
+        "typename": "{urn:SICD:1.2.0}ParameterType"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}ErrorStatisticsType/{urn:SICD:1.2.0}Components": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}PosVelErr",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}ErrorStatisticsType/{urn:SICD:1.2.0}Components/{urn:SICD:1.2.0}PosVelErr"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}RadarSensor",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}ErrorStatisticsType/{urn:SICD:1.2.0}Components/{urn:SICD:1.2.0}RadarSensor"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TropoError",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}ErrorStatisticsType/{urn:SICD:1.2.0}Components/{urn:SICD:1.2.0}TropoError"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}IonoError",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}ErrorStatisticsType/{urn:SICD:1.2.0}Components/{urn:SICD:1.2.0}IonoError"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}ErrorStatisticsType/{urn:SICD:1.2.0}Components/{urn:SICD:1.2.0}IonoError": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}IonoRangeVertical",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}IonoRangeRateVertical",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}IonoRgRgRateCC",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}IonoRangeVertDecorr",
+        "typename": "{urn:SICD:1.2.0}ErrorDecorrFuncType"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}ErrorStatisticsType/{urn:SICD:1.2.0}Components/{urn:SICD:1.2.0}PosVelErr": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Frame",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}ErrorStatisticsType/{urn:SICD:1.2.0}Components/{urn:SICD:1.2.0}PosVelErr/{urn:SICD:1.2.0}Frame"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}P1",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}P2",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}P3",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}V1",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}V2",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}V3",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}CorrCoefs",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}ErrorStatisticsType/{urn:SICD:1.2.0}Components/{urn:SICD:1.2.0}PosVelErr/{urn:SICD:1.2.0}CorrCoefs"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}PositionDecorr",
+        "typename": "{urn:SICD:1.2.0}ErrorDecorrFuncType"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}ErrorStatisticsType/{urn:SICD:1.2.0}Components/{urn:SICD:1.2.0}PosVelErr/{urn:SICD:1.2.0}CorrCoefs": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}P1P2",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}P1P3",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}P1V1",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}P1V2",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}P1V3",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}P2P3",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}P2V1",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}P2V2",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}P2V3",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}P3V1",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}P3V2",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}P3V3",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}V1V2",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}V1V3",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}V2V3",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}ErrorStatisticsType/{urn:SICD:1.2.0}Components/{urn:SICD:1.2.0}PosVelErr/{urn:SICD:1.2.0}Frame": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}string"
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}ErrorStatisticsType/{urn:SICD:1.2.0}Components/{urn:SICD:1.2.0}RadarSensor": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}RangeBias",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}ClockFreqSF",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TransmitFreqSF",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}RangeBiasDecorr",
+        "typename": "{urn:SICD:1.2.0}ErrorDecorrFuncType"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}ErrorStatisticsType/{urn:SICD:1.2.0}Components/{urn:SICD:1.2.0}TropoError": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TropoRangeVertical",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TropoRangeSlant",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TropoRangeDecorr",
+        "typename": "{urn:SICD:1.2.0}ErrorDecorrFuncType"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}ErrorStatisticsType/{urn:SICD:1.2.0}CompositeSCP": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Rg",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Az",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}RgAz",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}GeoDataType/{urn:SICD:1.2.0}EarthModel": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}string"
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}GeoDataType/{urn:SICD:1.2.0}ImageCorners": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}ICP",
+        "typename": "{urn:SICD:1.2.0}LatLonCornerStringType"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}GeoDataType/{urn:SICD:1.2.0}SCP": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}ECF",
+        "typename": "{urn:SICD:1.2.0}XYZType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}LLH",
+        "typename": "{urn:SICD:1.2.0}LatLonHAERestrictionType"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}GridType/{urn:SICD:1.2.0}ImagePlane": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}string"
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}GridType/{urn:SICD:1.2.0}Type": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}string"
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}ImageDataType/{urn:SICD:1.2.0}AmpTable": {
+    "attributes": [
+      "size"
+    ],
+    "children": [
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}Amplitude",
+        "typename": "{urn:SICD:1.2.0}ArrayDouble"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}ImageDataType/{urn:SICD:1.2.0}FullImage": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}NumRows",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}NumCols",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}ImageDataType/{urn:SICD:1.2.0}PixelType": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}string"
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}ImageDataType/{urn:SICD:1.2.0}ValidData": {
+    "attributes": [
+      "size"
+    ],
+    "children": [
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}Vertex",
+        "typename": "{urn:SICD:1.2.0}RowColvertexType"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}ImageFormationType/{urn:SICD:1.2.0}AzAutofocus": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}string"
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}ImageFormationType/{urn:SICD:1.2.0}ImageBeamComp": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}string"
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}ImageFormationType/{urn:SICD:1.2.0}ImageFormAlgo": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}string"
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}ImageFormationType/{urn:SICD:1.2.0}PolarizationCalibration": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}DistortCorrectionApplied",
+        "typename": "{http://www.w3.org/2001/XMLSchema}boolean"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Distortion",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}ImageFormationType/{urn:SICD:1.2.0}PolarizationCalibration/{urn:SICD:1.2.0}Distortion"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}ImageFormationType/{urn:SICD:1.2.0}PolarizationCalibration/{urn:SICD:1.2.0}Distortion": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}CalibrationDate",
+        "typename": "{http://www.w3.org/2001/XMLSchema}dateTime"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}A",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}F1",
+        "typename": "{urn:SICD:1.2.0}ComplexType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Q1",
+        "typename": "{urn:SICD:1.2.0}ComplexType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Q2",
+        "typename": "{urn:SICD:1.2.0}ComplexType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}F2",
+        "typename": "{urn:SICD:1.2.0}ComplexType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Q3",
+        "typename": "{urn:SICD:1.2.0}ComplexType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Q4",
+        "typename": "{urn:SICD:1.2.0}ComplexType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}GainErrorA",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}GainErrorF1",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}GainErrorF2",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}PhaseErrorF1",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}PhaseErrorF2",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}ImageFormationType/{urn:SICD:1.2.0}Processing": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Type",
+        "typename": "{http://www.w3.org/2001/XMLSchema}string"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Applied",
+        "typename": "{http://www.w3.org/2001/XMLSchema}boolean"
+      },
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}Parameter",
+        "typename": "{urn:SICD:1.2.0}ParameterType"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}ImageFormationType/{urn:SICD:1.2.0}RcvChanProc": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}NumChanProc",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}PRFScaleFactor",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}ChanIndex",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}ImageFormationType/{urn:SICD:1.2.0}RgAutofocus": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}string"
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}ImageFormationType/{urn:SICD:1.2.0}STBeamComp": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}string"
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}ImageFormationType/{urn:SICD:1.2.0}TxFrequencyProc": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}MinProc",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}MaxProc",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}LineType/{urn:SICD:1.2.0}Endpoint": {
+    "attributes": [
+      "index"
+    ],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Lat",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Lon",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}MatchInfoType/{urn:SICD:1.2.0}MatchType": {
+    "attributes": [
+      "index"
+    ],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TypeID",
+        "typename": "{http://www.w3.org/2001/XMLSchema}string"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}CurrentIndex",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}NumMatchCollections",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      },
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}MatchCollection",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}MatchInfoType/{urn:SICD:1.2.0}MatchType/{urn:SICD:1.2.0}MatchCollection"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}MatchInfoType/{urn:SICD:1.2.0}MatchType/{urn:SICD:1.2.0}MatchCollection": {
+    "attributes": [
+      "index"
+    ],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}CoreName",
+        "typename": "{http://www.w3.org/2001/XMLSchema}string"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}MatchIndex",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      },
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}Parameter",
+        "typename": "{urn:SICD:1.2.0}ParameterType"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}PFAType/{urn:SICD:1.2.0}STDeskew": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Applied",
+        "typename": "{http://www.w3.org/2001/XMLSchema}boolean"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}STDSPhasePoly",
+        "typename": "{urn:SICD:1.2.0}Poly2DType"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}PolygonType/{urn:SICD:1.2.0}Vertex": {
+    "attributes": [
+      "index"
+    ],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Lat",
+        "typename": "{urn:SICD:1.2.0}Neg90To90Type"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Lon",
+        "typename": "{urn:SICD:1.2.0}Neg180To180Type"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}PositionType/{urn:SICD:1.2.0}RcvAPC": {
+    "attributes": [
+      "size"
+    ],
+    "children": [
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}RcvAPCPoly",
+        "typename": "{urn:SICD:1.2.0}XYZPolyAttributeType"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}RMAType/{urn:SICD:1.2.0}INCA": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TimeCAPoly",
+        "typename": "{urn:SICD:1.2.0}Poly1DType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}R_CA_SCP",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}FreqZero",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}DRateSFPoly",
+        "typename": "{urn:SICD:1.2.0}Poly2DType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}DopCentroidPoly",
+        "typename": "{urn:SICD:1.2.0}Poly2DType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}DopCentroidCOA",
+        "typename": "{http://www.w3.org/2001/XMLSchema}boolean"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}RMAType/{urn:SICD:1.2.0}ImageType": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}string"
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}RMAType/{urn:SICD:1.2.0}RMAT": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}PosRef",
+        "typename": "{urn:SICD:1.2.0}XYZType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}VelRef",
+        "typename": "{urn:SICD:1.2.0}XYZType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}DopConeAngRef",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}RMAType/{urn:SICD:1.2.0}RMAlgoType": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}string"
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}RMAType/{urn:SICD:1.2.0}RMCR": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}PosRef",
+        "typename": "{urn:SICD:1.2.0}XYZType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}VelRef",
+        "typename": "{urn:SICD:1.2.0}XYZType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}DopConeAngRef",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}Area": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Corner",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}Area/{urn:SICD:1.2.0}Corner"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Plane",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}Area/{urn:SICD:1.2.0}Plane"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}Area/{urn:SICD:1.2.0}Corner": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}ACP",
+        "typename": "{urn:SICD:1.2.0}LatLonHAECornerRestrictType"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}Area/{urn:SICD:1.2.0}Plane": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}RefPt",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}Area/{urn:SICD:1.2.0}Plane/{urn:SICD:1.2.0}RefPt"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}XDir",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}Area/{urn:SICD:1.2.0}Plane/{urn:SICD:1.2.0}XDir"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}YDir",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}Area/{urn:SICD:1.2.0}Plane/{urn:SICD:1.2.0}YDir"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}SegmentList",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}Area/{urn:SICD:1.2.0}Plane/{urn:SICD:1.2.0}SegmentList"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Orientation",
+        "typename": "{urn:SICD:1.2.0}OrientationType"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}Area/{urn:SICD:1.2.0}Plane/{urn:SICD:1.2.0}RefPt": {
+    "attributes": [
+      "name"
+    ],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}ECF",
+        "typename": "{urn:SICD:1.2.0}XYZType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Line",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Sample",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}Area/{urn:SICD:1.2.0}Plane/{urn:SICD:1.2.0}SegmentList": {
+    "attributes": [
+      "size"
+    ],
+    "children": [
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}Segment",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}Area/{urn:SICD:1.2.0}Plane/{urn:SICD:1.2.0}SegmentList/{urn:SICD:1.2.0}Segment"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}Area/{urn:SICD:1.2.0}Plane/{urn:SICD:1.2.0}SegmentList/{urn:SICD:1.2.0}Segment": {
+    "attributes": [
+      "index"
+    ],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}StartLine",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}StartSample",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}EndLine",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}EndSample",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Identifier",
+        "typename": "{http://www.w3.org/2001/XMLSchema}string"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}Area/{urn:SICD:1.2.0}Plane/{urn:SICD:1.2.0}XDir": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}UVectECF",
+        "typename": "{urn:SICD:1.2.0}XYZType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}LineSpacing",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}NumLines",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}FirstLine",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}Area/{urn:SICD:1.2.0}Plane/{urn:SICD:1.2.0}YDir": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}UVectECF",
+        "typename": "{urn:SICD:1.2.0}XYZType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}SampleSpacing",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}NumSamples",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}FirstSample",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}RcvChannels": {
+    "attributes": [
+      "size"
+    ],
+    "children": [
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}ChanParameters",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}RcvChannels/{urn:SICD:1.2.0}ChanParameters"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}RcvChannels/{urn:SICD:1.2.0}ChanParameters": {
+    "attributes": [
+      "index"
+    ],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TxRcvPolarization",
+        "typename": "{urn:SICD:1.2.0}DualPolarizationType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}RcvAPCIndex",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}TxFrequency": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Min",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Max",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}TxSequence": {
+    "attributes": [
+      "size"
+    ],
+    "children": [
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}TxStep",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}TxSequence/{urn:SICD:1.2.0}TxStep"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}TxSequence/{urn:SICD:1.2.0}TxStep": {
+    "attributes": [
+      "index"
+    ],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}WFIndex",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TxPolarization",
+        "typename": "{urn:SICD:1.2.0}Polarization2Type"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}Waveform": {
+    "attributes": [
+      "size"
+    ],
+    "children": [
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}WFParameters",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}Waveform/{urn:SICD:1.2.0}WFParameters"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}Waveform/{urn:SICD:1.2.0}WFParameters": {
+    "attributes": [
+      "index"
+    ],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TxPulseLength",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TxRFBandwidth",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TxFreqStart",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TxFMRate",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}RcvDemodType",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}Waveform/{urn:SICD:1.2.0}WFParameters/{urn:SICD:1.2.0}RcvDemodType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}RcvWindowLength",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}ADCSampleRate",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}RcvIFBandwidth",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}RcvFreqStart",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}RcvFMRate",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}Waveform/{urn:SICD:1.2.0}WFParameters/{urn:SICD:1.2.0}RcvDemodType": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}string"
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}RadiometricType/{urn:SICD:1.2.0}NoiseLevel": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}NoiseLevelType",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}RadiometricType/{urn:SICD:1.2.0}NoiseLevel/{urn:SICD:1.2.0}NoiseLevelType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}NoisePoly",
+        "typename": "{urn:SICD:1.2.0}Poly2DType"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}RadiometricType/{urn:SICD:1.2.0}NoiseLevel/{urn:SICD:1.2.0}NoiseLevelType": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}string"
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}SCPCOAType/{urn:SICD:1.2.0}SideOfTrack": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}string"
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}SICD": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}CollectionInfo",
+        "typename": "{urn:SICD:1.2.0}CollectionInfoType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}ImageCreation",
+        "typename": "{urn:SICD:1.2.0}ImageCreationType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}ImageData",
+        "typename": "{urn:SICD:1.2.0}ImageDataType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}GeoData",
+        "typename": "{urn:SICD:1.2.0}GeoDataType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Grid",
+        "typename": "{urn:SICD:1.2.0}GridType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Timeline",
+        "typename": "{urn:SICD:1.2.0}TimelineType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Position",
+        "typename": "{urn:SICD:1.2.0}PositionType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}RadarCollection",
+        "typename": "{urn:SICD:1.2.0}RadarCollectionType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}ImageFormation",
+        "typename": "{urn:SICD:1.2.0}ImageFormationType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}SCPCOA",
+        "typename": "{urn:SICD:1.2.0}SCPCOAType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Radiometric",
+        "typename": "{urn:SICD:1.2.0}RadiometricType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Antenna",
+        "typename": "{urn:SICD:1.2.0}AntennaType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}ErrorStatistics",
+        "typename": "{urn:SICD:1.2.0}ErrorStatisticsType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}MatchInfo",
+        "typename": "{urn:SICD:1.2.0}MatchInfoType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}RgAzComp",
+        "typename": "{urn:SICD:1.2.0}RgAzCompType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}PFA",
+        "typename": "{urn:SICD:1.2.0}PFAType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}RMA",
+        "typename": "{urn:SICD:1.2.0}RMAType"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}TimelineType/{urn:SICD:1.2.0}IPP": {
+    "attributes": [
+      "size"
+    ],
+    "children": [
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}Set",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}TimelineType/{urn:SICD:1.2.0}IPP/{urn:SICD:1.2.0}Set"
+      }
+    ],
+    "text_typename": null
+  },
+  "<UNNAMED>-{urn:SICD:1.2.0}TimelineType/{urn:SICD:1.2.0}IPP/{urn:SICD:1.2.0}Set": {
+    "attributes": [
+      "index"
+    ],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TStart",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TEnd",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}IPPStart",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}IPPEnd",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}IPPPoly",
+        "typename": "{urn:SICD:1.2.0}Poly1DType"
+      }
+    ],
+    "text_typename": null
+  },
+  "{http://www.w3.org/2001/XMLSchema}boolean": {
+    "attributes": [],
+    "children": [],
+    "text_typename": null
+  },
+  "{http://www.w3.org/2001/XMLSchema}dateTime": {
+    "attributes": [],
+    "children": [],
+    "text_typename": null
+  },
+  "{http://www.w3.org/2001/XMLSchema}double": {
+    "attributes": [],
+    "children": [],
+    "text_typename": null
+  },
+  "{http://www.w3.org/2001/XMLSchema}int": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}long"
+  },
+  "{http://www.w3.org/2001/XMLSchema}long": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}integer"
+  },
+  "{http://www.w3.org/2001/XMLSchema}string": {
+    "attributes": [],
+    "children": [],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}AntParamType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}XAxisPoly",
+        "typename": "{urn:SICD:1.2.0}XYZPolyType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}YAxisPoly",
+        "typename": "{urn:SICD:1.2.0}XYZPolyType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}FreqZero",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}EB",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}AntParamType/{urn:SICD:1.2.0}EB"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Array",
+        "typename": "{urn:SICD:1.2.0}GainPhasePolyType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Elem",
+        "typename": "{urn:SICD:1.2.0}GainPhasePolyType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}GainBSPoly",
+        "typename": "{urn:SICD:1.2.0}Poly1DType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}EBFreqShift",
+        "typename": "{http://www.w3.org/2001/XMLSchema}boolean"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}MLFreqDilation",
+        "typename": "{http://www.w3.org/2001/XMLSchema}boolean"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}AntennaType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Tx",
+        "typename": "{urn:SICD:1.2.0}AntParamType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Rcv",
+        "typename": "{urn:SICD:1.2.0}AntParamType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TwoWay",
+        "typename": "{urn:SICD:1.2.0}AntParamType"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}ArrayDouble": {
+    "attributes": [
+      "index"
+    ],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}double"
+  },
+  "{urn:SICD:1.2.0}CollectionInfoType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}CollectorName",
+        "typename": "{http://www.w3.org/2001/XMLSchema}string"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}IlluminatorName",
+        "typename": "{http://www.w3.org/2001/XMLSchema}string"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}CoreName",
+        "typename": "{http://www.w3.org/2001/XMLSchema}string"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}CollectType",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}CollectionInfoType/{urn:SICD:1.2.0}CollectType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}RadarMode",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}CollectionInfoType/{urn:SICD:1.2.0}RadarMode"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Classification",
+        "typename": "{http://www.w3.org/2001/XMLSchema}string"
+      },
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}CountryCode",
+        "typename": "{http://www.w3.org/2001/XMLSchema}string"
+      },
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}Parameter",
+        "typename": "{urn:SICD:1.2.0}ParameterType"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}ComplexType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Real",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Imag",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}DirParamType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}UVectECF",
+        "typename": "{urn:SICD:1.2.0}XYZType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}SS",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}ImpRespWid",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Sgn",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}DirParamType/{urn:SICD:1.2.0}Sgn"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}ImpRespBW",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}KCtr",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}DeltaK1",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}DeltaK2",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}DeltaKCOAPoly",
+        "typename": "{urn:SICD:1.2.0}Poly2DType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}WgtType",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}DirParamType/{urn:SICD:1.2.0}WgtType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}WgtFunct",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}DirParamType/{urn:SICD:1.2.0}WgtFunct"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}DualPolarizationType": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}string"
+  },
+  "{urn:SICD:1.2.0}ErrorDecorrFuncType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}CorrCoefZero",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}DecorrRate",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}ErrorStatisticsType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}CompositeSCP",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}ErrorStatisticsType/{urn:SICD:1.2.0}CompositeSCP"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Components",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}ErrorStatisticsType/{urn:SICD:1.2.0}Components"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}AdditionalParms",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}ErrorStatisticsType/{urn:SICD:1.2.0}AdditionalParms"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}GainPhasePolyType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}GainPoly",
+        "typename": "{urn:SICD:1.2.0}Poly2DType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}PhasePoly",
+        "typename": "{urn:SICD:1.2.0}Poly2DType"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}GeoDataType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}EarthModel",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}GeoDataType/{urn:SICD:1.2.0}EarthModel"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}SCP",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}GeoDataType/{urn:SICD:1.2.0}SCP"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}ImageCorners",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}GeoDataType/{urn:SICD:1.2.0}ImageCorners"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}ValidData",
+        "typename": "{urn:SICD:1.2.0}PolygonType"
+      },
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}GeoInfo",
+        "typename": "{urn:SICD:1.2.0}GeoInfoType"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}GeoInfoType": {
+    "attributes": [
+      "name"
+    ],
+    "children": [
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}Desc",
+        "typename": "{urn:SICD:1.2.0}ParameterType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Point",
+        "typename": "{urn:SICD:1.2.0}LatLonRestrictionType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Line",
+        "typename": "{urn:SICD:1.2.0}LineType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Polygon",
+        "typename": "{urn:SICD:1.2.0}PolygonType"
+      },
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}GeoInfo",
+        "typename": "{urn:SICD:1.2.0}GeoInfoType"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}GridType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}ImagePlane",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}GridType/{urn:SICD:1.2.0}ImagePlane"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Type",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}GridType/{urn:SICD:1.2.0}Type"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TimeCOAPoly",
+        "typename": "{urn:SICD:1.2.0}Poly2DType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Row",
+        "typename": "{urn:SICD:1.2.0}DirParamType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Col",
+        "typename": "{urn:SICD:1.2.0}DirParamType"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}ImageCreationType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Application",
+        "typename": "{http://www.w3.org/2001/XMLSchema}string"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}DateTime",
+        "typename": "{http://www.w3.org/2001/XMLSchema}dateTime"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Site",
+        "typename": "{http://www.w3.org/2001/XMLSchema}string"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Profile",
+        "typename": "{http://www.w3.org/2001/XMLSchema}string"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}ImageDataType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}PixelType",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}ImageDataType/{urn:SICD:1.2.0}PixelType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}AmpTable",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}ImageDataType/{urn:SICD:1.2.0}AmpTable"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}NumRows",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}NumCols",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}FirstRow",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}FirstCol",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}FullImage",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}ImageDataType/{urn:SICD:1.2.0}FullImage"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}SCPPixel",
+        "typename": "{urn:SICD:1.2.0}RowColType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}ValidData",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}ImageDataType/{urn:SICD:1.2.0}ValidData"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}ImageFormationType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}RcvChanProc",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}ImageFormationType/{urn:SICD:1.2.0}RcvChanProc"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TxRcvPolarizationProc",
+        "typename": "{urn:SICD:1.2.0}DualPolarizationType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TStartProc",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TEndProc",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TxFrequencyProc",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}ImageFormationType/{urn:SICD:1.2.0}TxFrequencyProc"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}SegmentIdentifier",
+        "typename": "{http://www.w3.org/2001/XMLSchema}string"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}ImageFormAlgo",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}ImageFormationType/{urn:SICD:1.2.0}ImageFormAlgo"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}STBeamComp",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}ImageFormationType/{urn:SICD:1.2.0}STBeamComp"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}ImageBeamComp",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}ImageFormationType/{urn:SICD:1.2.0}ImageBeamComp"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}AzAutofocus",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}ImageFormationType/{urn:SICD:1.2.0}AzAutofocus"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}RgAutofocus",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}ImageFormationType/{urn:SICD:1.2.0}RgAutofocus"
+      },
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}Processing",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}ImageFormationType/{urn:SICD:1.2.0}Processing"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}PolarizationCalibration",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}ImageFormationType/{urn:SICD:1.2.0}PolarizationCalibration"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}LatLonCornerStringType": {
+    "attributes": [
+      "index"
+    ],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Lat",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Lon",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}LatLonHAECornerRestrictType": {
+    "attributes": [
+      "index"
+    ],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Lat",
+        "typename": "{urn:SICD:1.2.0}Neg90To90Type"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Lon",
+        "typename": "{urn:SICD:1.2.0}Neg180To180Type"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}HAE",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}LatLonHAERestrictionType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Lat",
+        "typename": "{urn:SICD:1.2.0}Neg90To90Type"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Lon",
+        "typename": "{urn:SICD:1.2.0}Neg180To180Type"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}HAE",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}LatLonRestrictionType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Lat",
+        "typename": "{urn:SICD:1.2.0}Neg90To90Type"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Lon",
+        "typename": "{urn:SICD:1.2.0}Neg180To180Type"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}LineType": {
+    "attributes": [
+      "size"
+    ],
+    "children": [
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}Endpoint",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}LineType/{urn:SICD:1.2.0}Endpoint"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}MatchInfoType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}NumMatchTypes",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      },
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}MatchType",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}MatchInfoType/{urn:SICD:1.2.0}MatchType"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}Neg180To180Type": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}double"
+  },
+  "{urn:SICD:1.2.0}Neg90To90Type": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}double"
+  },
+  "{urn:SICD:1.2.0}OrientationType": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}string"
+  },
+  "{urn:SICD:1.2.0}PFAType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}FPN",
+        "typename": "{urn:SICD:1.2.0}XYZType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}IPN",
+        "typename": "{urn:SICD:1.2.0}XYZType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}PolarAngRefTime",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}PolarAngPoly",
+        "typename": "{urn:SICD:1.2.0}Poly1DType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}SpatialFreqSFPoly",
+        "typename": "{urn:SICD:1.2.0}Poly1DType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Krg1",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Krg2",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Kaz1",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Kaz2",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}STDeskew",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}PFAType/{urn:SICD:1.2.0}STDeskew"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}ParameterType": {
+    "attributes": [
+      "name"
+    ],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}string"
+  },
+  "{urn:SICD:1.2.0}Polarization1Type": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}string"
+  },
+  "{urn:SICD:1.2.0}Polarization2Type": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}string"
+  },
+  "{urn:SICD:1.2.0}Poly1DType": {
+    "attributes": [
+      "order1"
+    ],
+    "children": [
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}Coef",
+        "typename": "{urn:SICD:1.2.0}PolyCoef1DType"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}Poly2DType": {
+    "attributes": [
+      "order1",
+      "order2"
+    ],
+    "children": [
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}Coef",
+        "typename": "{urn:SICD:1.2.0}PolyCoef2DType"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}PolyCoef1DType": {
+    "attributes": [
+      "exponent1"
+    ],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}double"
+  },
+  "{urn:SICD:1.2.0}PolyCoef2DType": {
+    "attributes": [
+      "exponent1",
+      "exponent2"
+    ],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}double"
+  },
+  "{urn:SICD:1.2.0}PolygonType": {
+    "attributes": [
+      "size"
+    ],
+    "children": [
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}Vertex",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}PolygonType/{urn:SICD:1.2.0}Vertex"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}PositionType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}ARPPoly",
+        "typename": "{urn:SICD:1.2.0}XYZPolyType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}GRPPoly",
+        "typename": "{urn:SICD:1.2.0}XYZPolyType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TxAPCPoly",
+        "typename": "{urn:SICD:1.2.0}XYZPolyType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}RcvAPC",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}PositionType/{urn:SICD:1.2.0}RcvAPC"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}RMAType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}RMAlgoType",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}RMAType/{urn:SICD:1.2.0}RMAlgoType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}ImageType",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}RMAType/{urn:SICD:1.2.0}ImageType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}RMAT",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}RMAType/{urn:SICD:1.2.0}RMAT"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}RMCR",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}RMAType/{urn:SICD:1.2.0}RMCR"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}INCA",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}RMAType/{urn:SICD:1.2.0}INCA"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}RadarCollectionType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TxFrequency",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}TxFrequency"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}RefFreqIndex",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Waveform",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}Waveform"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TxPolarization",
+        "typename": "{urn:SICD:1.2.0}Polarization1Type"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TxSequence",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}TxSequence"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}RcvChannels",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}RcvChannels"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Area",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}RadarCollectionType/{urn:SICD:1.2.0}Area"
+      },
+      {
+        "repeat": true,
+        "tag": "{urn:SICD:1.2.0}Parameter",
+        "typename": "{urn:SICD:1.2.0}ParameterType"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}RadiometricType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}NoiseLevel",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}RadiometricType/{urn:SICD:1.2.0}NoiseLevel"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}RCSSFPoly",
+        "typename": "{urn:SICD:1.2.0}Poly2DType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}SigmaZeroSFPoly",
+        "typename": "{urn:SICD:1.2.0}Poly2DType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}BetaZeroSFPoly",
+        "typename": "{urn:SICD:1.2.0}Poly2DType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}GammaZeroSFPoly",
+        "typename": "{urn:SICD:1.2.0}Poly2DType"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}RgAzCompType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}AzSF",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}KazPoly",
+        "typename": "{urn:SICD:1.2.0}Poly1DType"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}RowColType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Row",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Col",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}RowColvertexType": {
+    "attributes": [
+      "index"
+    ],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Row",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Col",
+        "typename": "{http://www.w3.org/2001/XMLSchema}int"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}SCPCOAType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}SCPTime",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}ARPPos",
+        "typename": "{urn:SICD:1.2.0}XYZType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}ARPVel",
+        "typename": "{urn:SICD:1.2.0}XYZType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}ARPAcc",
+        "typename": "{urn:SICD:1.2.0}XYZType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}SideOfTrack",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}SCPCOAType/{urn:SICD:1.2.0}SideOfTrack"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}SlantRange",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}GroundRange",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}DopplerConeAng",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}GrazeAng",
+        "typename": "{urn:SICD:1.2.0}ZeroTo90Type"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}IncidenceAng",
+        "typename": "{urn:SICD:1.2.0}ZeroTo90Type"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}TwistAng",
+        "typename": "{urn:SICD:1.2.0}Neg90To90Type"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}SlopeAng",
+        "typename": "{urn:SICD:1.2.0}ZeroTo90Type"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}AzimAng",
+        "typename": "{urn:SICD:1.2.0}ZeroTo360Type"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}LayoverAng",
+        "typename": "{urn:SICD:1.2.0}ZeroTo360Type"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}TimelineType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}CollectStart",
+        "typename": "{http://www.w3.org/2001/XMLSchema}dateTime"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}CollectDuration",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}IPP",
+        "typename": "<UNNAMED>-{urn:SICD:1.2.0}TimelineType/{urn:SICD:1.2.0}IPP"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}XYZPolyAttributeType": {
+    "attributes": [
+      "index"
+    ],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}X",
+        "typename": "{urn:SICD:1.2.0}Poly1DType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Y",
+        "typename": "{urn:SICD:1.2.0}Poly1DType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Z",
+        "typename": "{urn:SICD:1.2.0}Poly1DType"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}XYZPolyType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}X",
+        "typename": "{urn:SICD:1.2.0}Poly1DType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Y",
+        "typename": "{urn:SICD:1.2.0}Poly1DType"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Z",
+        "typename": "{urn:SICD:1.2.0}Poly1DType"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}XYZType": {
+    "attributes": [],
+    "children": [
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}X",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Y",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      },
+      {
+        "repeat": false,
+        "tag": "{urn:SICD:1.2.0}Z",
+        "typename": "{http://www.w3.org/2001/XMLSchema}double"
+      }
+    ],
+    "text_typename": null
+  },
+  "{urn:SICD:1.2.0}ZeroTo360Type": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}double"
+  },
+  "{urn:SICD:1.2.0}ZeroTo90Type": {
+    "attributes": [],
+    "children": [],
+    "text_typename": "{http://www.w3.org/2001/XMLSchema}double"
+  }
+}

--- a/tests/core/sicd/test_io.py
+++ b/tests/core/sicd/test_io.py
@@ -35,6 +35,7 @@ def _random_image(sicd_xmltree):
     [
         (DATAPATH / "example-sicd-1.0.1.xml", "RE32F_IM32F"),
         (DATAPATH / "example-sicd-1.1.0.xml", "RE32F_IM32F"),
+        (DATAPATH / "example-sicd-1.2.xml", "AMP8I_PHS8I"),
         (DATAPATH / "example-sicd-1.2.1.xml", "RE16I_IM16I"),
         (DATAPATH / "example-sicd-1.3.0.xml", "AMP8I_PHS8I"),
         (DATAPATH / "example-sicd-1.4.0.xml", "RE32F_IM32F"),

--- a/tests/core/sicd/test_xml.py
+++ b/tests/core/sicd/test_xml.py
@@ -87,9 +87,10 @@ def test_elementwrapper_tofromdict(xmlpath, add_comments):
 
 
 def _replace_scpcoa(sicd_xmltree):
-    sicd_xmltree.find(".//{*}SCPCOA").clear()
+    ew = sksicd.ElementWrapper(sicd_xmltree.getroot())
+    ew.pop("SCPCOA", None)  # remove SCPCOA if it exists
     scpcoa = sksicd.compute_scp_coa(sicd_xmltree)
-    sicd_xmltree.getroot().replace(sicd_xmltree.find(".//{*}SCPCOA"), scpcoa)
+    ew["SCPCOA"] = scpcoa
     basis_version = lxml.etree.QName(sicd_xmltree.getroot()).namespace
     schema = lxml.etree.XMLSchema(file=sksicd.VERSION_INFO[basis_version]["schema"])
     schema.assertValid(sicd_xmltree)


### PR DESCRIPTION
# Description
This PR closes #152 by adding support for SICD v1.2 (namespace: `urn:SICD:1.2.0`)

SICD v1.2 was a volume 2 (FFDD) only update to SICD v1.1.0 that is not fully versioned on the NSG standards registry.

Here is a snip of the rendered docs:

<img width="417" height="158" alt="image" src="https://github.com/user-attachments/assets/d00d7490-4407-4171-b039-ff19c76ffa45" />


